### PR TITLE
chore: Refactor prettier/eslint config to prioritize prettier module imports

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,17 +4,16 @@
   "tabWidth": 2,
   "printWidth": 80,
   "endOfLine": "lf",
-  "plugins": [
-    "@trivago/prettier-plugin-sort-imports"
-  ],
+  "plugins": ["@trivago/prettier-plugin-sort-imports"],
   "importOrder": [
     "<THIRD_PARTY_MODULES>",
     "^@data/(.*)$",
     "^@common/(.*)$",
     "^@config/(.*)$",
     "^@test/(.*)$",
-    "^@/(.*)$",
+    "^@module/(.*)$",
     "^@root/(.*)$",
+    "^@/(.*)$",
     "^[./]"
   ],
   "importOrderSeparation": true,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,5 @@
 // @ts-check
 import eslint from '@eslint/js';
-import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
@@ -10,7 +9,6 @@ export default tseslint.config(
   },
   eslint.configs.recommended,
   ...tseslint.configs.recommendedTypeChecked,
-  eslintPluginPrettierRecommended,
   {
     languageOptions: {
       globals: {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
-import { AppModule } from '@module/app.module';
 import { NestFactory } from '@nestjs/core';
+
+import { AppModule } from '@module/app.module';
 
 async function bootstrap(): Promise<void> {
   const app = await NestFactory.create(AppModule);

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,8 +1,9 @@
-import { AppModule } from '@module/app.module';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import request from 'supertest';
 import { App } from 'supertest/types';
+
+import { AppModule } from '@module/app.module';
 
 describe('AppController (e2e)', () => {
   let app: INestApplication<App>;


### PR DESCRIPTION
# Summary

This PR refactors the prettier/eslint config in order to prioritize prettier imports.

# Details

- Remove recommended prettier plugin for eslint in order to prioritize prettier imports without eslint errors.
