### PR TITLE
feat: Add generic crud service/repository

### DIFF
--- a/src/common/base/application/constant/base.constants.ts
+++ b/src/common/base/application/constant/base.constants.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_PAGE_NUMBER = 1;
+export const DEFAULT_PAGE_SIZE = 10;

--- a/src/common/base/application/domain/base.entity.ts
+++ b/src/common/base/application/domain/base.entity.ts
@@ -1,0 +1,24 @@
+import IEntity from '@common/base/application/domain/entity.interface';
+
+export abstract class Base implements IEntity {
+  id?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  deletedAt?: string;
+
+  constructor(
+    id?: string,
+    createdAt?: string,
+    updatedAt?: string,
+    deletedAt?: string,
+  ) {
+    this.id = id;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+    this.deletedAt = deletedAt;
+  }
+
+  static getEntityName(): string {
+    return this.name.toLowerCase();
+  }
+}

--- a/src/common/base/application/domain/entity.interface.ts
+++ b/src/common/base/application/domain/entity.interface.ts
@@ -1,0 +1,6 @@
+export default interface IEntity {
+  id?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  deletedAt?: string;
+}

--- a/src/common/base/application/dto/collection.dto.ts
+++ b/src/common/base/application/dto/collection.dto.ts
@@ -1,0 +1,28 @@
+import { ICollection } from '@common/base/application/dto/collection.interface';
+import { IDto } from '@common/base/application/dto/dto.interface';
+
+export class CollectionDto<Data extends IDto> implements ICollection<Data> {
+  readonly data: Data[];
+
+  readonly pageNumber: number;
+
+  readonly pageSize: number;
+
+  readonly pageCount: number;
+
+  readonly itemCount: number;
+
+  constructor({
+    data,
+    pageNumber,
+    pageSize,
+    pageCount,
+    itemCount,
+  }: ICollection<Data>) {
+    this.data = data;
+    this.pageNumber = pageNumber;
+    this.pageSize = pageSize;
+    this.pageCount = pageCount;
+    this.itemCount = itemCount;
+  }
+}

--- a/src/common/base/application/dto/collection.interface.ts
+++ b/src/common/base/application/dto/collection.interface.ts
@@ -1,0 +1,11 @@
+export interface IPagingCollectionData {
+  pageNumber: number;
+  pageSize: number;
+  pageCount: number;
+  itemCount: number;
+}
+
+export interface ICollection<Entity extends object>
+  extends IPagingCollectionData {
+  data: Entity[];
+}

--- a/src/common/base/application/dto/dto.interface.ts
+++ b/src/common/base/application/dto/dto.interface.ts
@@ -1,0 +1,15 @@
+import { default as IEntity } from '@common/base/application/domain/entity.interface';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface IDto {}
+
+export interface IDtoMapper<
+  Entity extends IEntity,
+  CreateDto extends IDto,
+  UpdateDto extends IDto,
+  ResponseDto extends IDto,
+> {
+  fromEntityToResponseDto(entity: Entity): ResponseDto;
+  fromCreateDtoToEntity(dto: CreateDto): Entity;
+  fromUpdateDtoToEntity(dto: UpdateDto): Entity;
+}

--- a/src/common/base/application/dto/get-all-options.interface.ts
+++ b/src/common/base/application/dto/get-all-options.interface.ts
@@ -1,0 +1,27 @@
+import { Base } from '@common/base/application/domain/base.entity';
+import IEntity from '@common/base/application/domain/entity.interface';
+import { IDto } from '@common/base/application/dto/dto.interface';
+import { SortType } from '@common/base/application/enum/sort-type.enum';
+
+export type SimpleProps<T> = {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+  [K in keyof T]: T[K] extends Base | Base[] | Function ? never : K;
+}[keyof T];
+
+export type Filter<T> = Partial<Pick<T, SimpleProps<T>>>;
+export type Sort<T> = Partial<Record<SimpleProps<T>, SortType>>;
+export type Fields<T> = SimpleProps<T>[];
+
+export type Page = {
+  number?: number;
+  size?: number;
+  offset?: number;
+};
+
+export interface IGetAllOptions<T extends IDto | IEntity, Include = []> {
+  page?: Page;
+  filter?: Filter<T>;
+  sort?: Sort<T>;
+  fields?: Fields<T>;
+  include?: Include;
+}

--- a/src/common/base/application/dto/page-query-params.ts
+++ b/src/common/base/application/dto/page-query-params.ts
@@ -1,0 +1,21 @@
+import { IsInt, Max, Min } from 'class-validator';
+
+import {
+  DEFAULT_PAGE_NUMBER,
+  DEFAULT_PAGE_SIZE,
+} from '@common/base/application/constant/base.constants';
+
+export class PageQueryParamsDto {
+  @IsInt()
+  @Min(1)
+  number?: number = DEFAULT_PAGE_NUMBER;
+
+  @IsInt()
+  @Min(1)
+  @Max(50)
+  size?: number = DEFAULT_PAGE_SIZE;
+
+  get offset(): number {
+    return (this.number - 1) * this.size;
+  }
+}

--- a/src/common/base/application/enum/sort-type.enum.ts
+++ b/src/common/base/application/enum/sort-type.enum.ts
@@ -1,0 +1,4 @@
+export enum SortType {
+  ASC = 'ASC',
+  DESC = 'DESC',
+}

--- a/src/common/base/application/mapper/base.mapper.ts
+++ b/src/common/base/application/mapper/base.mapper.ts
@@ -1,0 +1,3 @@
+export const fromCommaSeparatedToArray = (value: string): string[] => {
+  return value.replace(/\s/g, '').split(',');
+};

--- a/src/common/base/application/service/base-crud.service.ts
+++ b/src/common/base/application/service/base-crud.service.ts
@@ -1,0 +1,59 @@
+import { default as IEntity } from '@common/base/application/domain/entity.interface';
+import { IDto, IDtoMapper } from '@common/base/application/dto/dto.interface';
+import { IGetAllOptions } from '@common/base/application/dto/get-all-options.interface';
+import { ICRUDService } from '@common/base/application/service/crud-service.interface';
+import BaseRepository from '@common/base/infrastructure/database/base.repository';
+
+export class BaseCRUDService<
+  Entity extends IEntity,
+  CreateDto extends IDto,
+  UpdateDto extends IDto,
+  ResponseDto extends IDto,
+> implements ICRUDService<Entity, ResponseDto, CreateDto, UpdateDto>
+{
+  constructor(
+    protected readonly repository: BaseRepository<Entity>,
+    protected readonly mapper: IDtoMapper<
+      Entity,
+      CreateDto,
+      UpdateDto,
+      ResponseDto
+    >,
+  ) {}
+
+  async getAll(options?: IGetAllOptions<Entity>): Promise<ResponseDto[]> {
+    const entities = await this.repository.getAll(options);
+    const responseDtos = entities.data.map((entity) =>
+      this.mapper.fromEntityToResponseDto(entity),
+    );
+
+    return responseDtos;
+  }
+
+  async getOneByIdOrFail(id: string): Promise<ResponseDto> {
+    const entity = await this.repository.getOneByIdOrFail(id);
+    const responseDto = this.mapper.fromEntityToResponseDto(entity);
+
+    return responseDto;
+  }
+
+  async saveOne(createDto: CreateDto): Promise<ResponseDto> {
+    const entity = this.mapper.fromCreateDtoToEntity(createDto);
+    const savedEntity = await this.repository.saveOne(entity);
+    const responseDto = this.mapper.fromEntityToResponseDto(savedEntity);
+
+    return responseDto;
+  }
+
+  async updateOne(id: string, updateDto: UpdateDto): Promise<ResponseDto> {
+    const entity = this.mapper.fromUpdateDtoToEntity(updateDto);
+    const updatedEntity = await this.repository.updateOneByIdOrFail(id, entity);
+    const responseDto = this.mapper.fromEntityToResponseDto(updatedEntity);
+
+    return responseDto;
+  }
+
+  async deleteOneByIdOrFail(id: string): Promise<void> {
+    await this.repository.deleteOneByIdOrFail(id);
+  }
+}

--- a/src/common/base/application/service/crud-service.interface.ts
+++ b/src/common/base/application/service/crud-service.interface.ts
@@ -1,0 +1,16 @@
+import IEntity from '@common/base/application/domain/entity.interface';
+import { IDto } from '@common/base/application/dto/dto.interface';
+import { IGetAllOptions } from '@common/base/application/dto/get-all-options.interface';
+
+export interface ICRUDService<
+  Entity extends IEntity,
+  ResponseDto extends IDto,
+  CreateDto extends IDto,
+  UpdateDto extends IDto,
+> {
+  getAll(options?: IGetAllOptions<Entity>): Promise<ResponseDto[]>;
+  getOneByIdOrFail(id: string): Promise<ResponseDto>;
+  saveOne(createDto: CreateDto): Promise<ResponseDto>;
+  updateOne(id: string, updateDto: UpdateDto): Promise<ResponseDto>;
+  deleteOneByIdOrFail(id: string): Promise<void>;
+}

--- a/src/common/base/infrastructure/database/base.repository.ts
+++ b/src/common/base/infrastructure/database/base.repository.ts
@@ -1,0 +1,92 @@
+import {
+  DeepPartial,
+  FindManyOptions,
+  FindOneOptions,
+  FindOptionsOrder,
+  FindOptionsWhere,
+  Repository,
+} from 'typeorm';
+
+import Entity from '@common/base/application/domain/entity.interface';
+import { ICollection } from '@common/base/application/dto/collection.interface';
+import { IGetAllOptions } from '@common/base/application/dto/get-all-options.interface';
+import { IRepository } from '@common/base/infrastructure/database/repository.interface';
+import EntityNotFoundException from '@common/base/infrastructure/exception/not.found.exception';
+
+abstract class BaseRepository<T extends Entity> implements IRepository<T> {
+  protected readonly repository: Repository<T>;
+
+  constructor(repository: Repository<T>) {
+    this.repository = repository;
+  }
+
+  async getAll(options: IGetAllOptions<T>): Promise<ICollection<T>> {
+    const { filter, page, sort, fields } = options || {};
+
+    const [items, itemCount] = await this.repository.findAndCount({
+      where: filter as FindOptionsWhere<T>,
+      order: sort as FindOptionsOrder<T>,
+      select: fields,
+      take: page.size,
+      skip: page.offset,
+    } as FindManyOptions<T>);
+
+    return {
+      data: items,
+      pageNumber: page.number,
+      pageSize: page.size,
+      pageCount: Math.ceil(itemCount / page.size),
+      itemCount,
+    };
+  }
+
+  async getOneById(id: string): Promise<T> {
+    return this.repository.findOne({
+      where: { id },
+    } as FindOneOptions<T>);
+  }
+
+  async getOneByIdOrFail(id: string): Promise<T> {
+    const entity = await this.getOneById(id);
+
+    if (!entity) {
+      throw new EntityNotFoundException(id);
+    }
+
+    return entity;
+  }
+
+  async saveOne(entity: T): Promise<T> {
+    return this.repository.save(entity);
+  }
+
+  async deleteOneByIdOrFail(id: string): Promise<void> {
+    const entityToDelete = await this.repository.findOne({
+      where: { id },
+    } as FindOneOptions<T>);
+
+    if (!entityToDelete) {
+      throw new EntityNotFoundException(id);
+    }
+
+    await this.repository.softDelete({ id } as FindOptionsWhere<T>);
+  }
+
+  async updateOneByIdOrFail(
+    id: string,
+    updates: Partial<Omit<T, 'id'>>,
+  ): Promise<T> {
+    const entityToUpdate = await this.repository.preload({
+      ...updates,
+      id,
+    } as DeepPartial<T>);
+
+    if (!entityToUpdate) {
+      throw new EntityNotFoundException(id);
+    }
+
+    return this.repository.save(entityToUpdate);
+  }
+}
+
+export default BaseRepository;

--- a/src/common/base/infrastructure/database/base.schema.ts
+++ b/src/common/base/infrastructure/database/base.schema.ts
@@ -1,0 +1,19 @@
+import { EntitySchemaColumnOptions } from 'typeorm';
+
+type EntitySchemaColumns<Entity extends object> = {
+  [Key in keyof Entity]?: EntitySchemaColumnOptions;
+};
+
+export function withBaseSchemaColumns<Entity extends object>(
+  columns: EntitySchemaColumns<
+    Omit<Entity, 'id' | 'createdAt' | 'updatedAt' | 'deletedAt'>
+  >,
+): EntitySchemaColumns<Entity> {
+  return {
+    id: { type: 'uuid', primary: true, generated: 'uuid', unique: true },
+    ...columns,
+    createdAt: { type: Date, createDate: true },
+    updatedAt: { type: Date, updateDate: true },
+    deletedAt: { type: Date, deleteDate: true },
+  };
+}

--- a/src/common/base/infrastructure/database/repository.interface.ts
+++ b/src/common/base/infrastructure/database/repository.interface.ts
@@ -1,0 +1,12 @@
+import Entity from '@common/base/application/domain/entity.interface';
+import { ICollection } from '@common/base/application/dto/collection.interface';
+import { IGetAllOptions } from '@common/base/application/dto/get-all-options.interface';
+
+export interface IRepository<T extends Entity> {
+  getAll(options: IGetAllOptions<T>): Promise<ICollection<T>>;
+  saveOne(entity: T): Promise<T>;
+  getOneById(id: string): Promise<T>;
+  getOneByIdOrFail(id: string): Promise<T>;
+  deleteOneByIdOrFail(id: string): Promise<void>;
+  updateOneByIdOrFail(id: string, updates: Partial<Omit<T, 'id'>>): Promise<T>;
+}

--- a/src/common/base/infrastructure/exception/not.found.exception.ts
+++ b/src/common/base/infrastructure/exception/not.found.exception.ts
@@ -1,0 +1,8 @@
+import { NotFoundException } from '@nestjs/common';
+
+class EntityNotFoundException extends NotFoundException {
+  constructor(id: string) {
+    super(`Entity with id ${id} not found`);
+  }
+}
+export default EntityNotFoundException;

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -1,0 +1,23 @@
+import { ValidationPipe, VersioningType } from '@nestjs/common';
+import { NestExpressApplication } from '@nestjs/platform-express';
+
+export const setupApp = (app: NestExpressApplication): void => {
+  app.enableVersioning({
+    type: VersioningType.URI,
+    defaultVersion: '1',
+  });
+  app.setGlobalPrefix('api');
+
+  app.set('query parser', 'extended');
+
+  app.useGlobalPipes(
+    new ValidationPipe({
+      transform: true,
+      transformOptions: {
+        enableImplicitConversion: true,
+      },
+      whitelist: true,
+      forbidNonWhitelisted: true,
+    }),
+  );
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,13 @@
 import { NestFactory } from '@nestjs/core';
+import { NestExpressApplication } from '@nestjs/platform-express';
+
+import { setupApp } from '@config/app.config';
 
 import { AppModule } from '@module/app.module';
 
 async function bootstrap(): Promise<void> {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create<NestExpressApplication>(AppModule);
+  setupApp(app);
   await app.listen(process.env.PORT ?? 3000);
 }
 


### PR DESCRIPTION
# Summary

This PR introduces a generic service and repository with CRUD methods that can be reused in any other specific module by extending the classes. 

# Details

-  Added config for the nest application to enable global prefix, parsed query params and validation pipes.
- Created base domain/schema entities so that specific entities can extend them to inherit base properties.
- Implemented a base class for the collection DTOs along with a base interface for the Dto mappers.
- Added a query params DTOs in order to validate and format query params for the `getAll` method.
- Developed a base repository with CRUD methods that can be used with any specific repository.
- Created a base service with CRUD methods that can be used by any specific controller as dependency.