### PR TITLE
feat: Add ResponseSerializerService for HATEOAS API responses

### DIFF
--- a/src/common/base/application/dto/serialized-response.dto.ts
+++ b/src/common/base/application/dto/serialized-response.dto.ts
@@ -1,0 +1,31 @@
+import { IPagingCollectionData } from '@common/base/application/dto/collection.interface';
+import {
+  ICollectionLinks,
+  IResponseDtoLinks,
+} from '@common/base/application/dto/serialized-response.interface';
+
+export class SerializedResponseDtoCollection<ResponseDto extends object> {
+  data: ResponseDto[];
+  links: ICollectionLinks;
+  meta: IPagingCollectionData;
+
+  constructor(
+    data: ResponseDto[],
+    links: ICollectionLinks,
+    meta: IPagingCollectionData,
+  ) {
+    this.data = data;
+    this.links = links;
+    this.meta = meta;
+  }
+}
+
+export class SerializedResponseDto<ResponseDto extends object> {
+  data: ResponseDto;
+  links: IResponseDtoLinks;
+
+  constructor(data: ResponseDto, links: IResponseDtoLinks) {
+    this.data = data;
+    this.links = links;
+  }
+}

--- a/src/common/base/application/dto/serialized-response.interface.ts
+++ b/src/common/base/application/dto/serialized-response.interface.ts
@@ -1,0 +1,28 @@
+import { IPagingCollectionData } from '@common/base/application/dto/collection.interface';
+import { HttpMethod } from '@common/base/application/enum/http-method.enum';
+
+export interface ILink {
+  href: string;
+  method: HttpMethod;
+  rel?: string;
+}
+
+export interface IResponseDtoLinks {
+  self: ILink;
+  update?: ILink;
+  delete?: ILink;
+}
+
+export interface ICollectionLinks {
+  self: ILink;
+  first?: ILink;
+  previous?: ILink;
+  next?: ILink;
+  last?: ILink;
+}
+
+export interface ISerializedCollection<Entity extends object> {
+  data: Entity[];
+  links: ICollectionLinks;
+  meta: IPagingCollectionData;
+}

--- a/src/common/base/application/enum/http-method.enum.ts
+++ b/src/common/base/application/enum/http-method.enum.ts
@@ -1,0 +1,6 @@
+export enum HttpMethod {
+  GET = 'GET',
+  POST = 'POST',
+  PUT = 'PUT',
+  DELETE = 'DELETE',
+}

--- a/src/common/base/application/service/base-crud.service.ts
+++ b/src/common/base/application/service/base-crud.service.ts
@@ -1,8 +1,15 @@
 import { default as IEntity } from '@common/base/application/domain/entity.interface';
+import { CollectionDto } from '@common/base/application/dto/collection.dto';
 import { IDto, IDtoMapper } from '@common/base/application/dto/dto.interface';
 import { IGetAllOptions } from '@common/base/application/dto/get-all-options.interface';
+import {
+  SerializedResponseDto,
+  SerializedResponseDtoCollection,
+} from '@common/base/application/dto/serialized-response.dto';
 import { ICRUDService } from '@common/base/application/service/crud-service.interface';
 import BaseRepository from '@common/base/infrastructure/database/base.repository';
+
+import { ResponseSerializerService } from '@module/app/service/response-serializer.service';
 
 export class BaseCRUDService<
   Entity extends IEntity,
@@ -19,38 +26,76 @@ export class BaseCRUDService<
       UpdateDto,
       ResponseDto
     >,
+    protected readonly responseSerializer: ResponseSerializerService,
+    protected readonly entityName: string,
   ) {}
 
-  async getAll(options?: IGetAllOptions<Entity>): Promise<ResponseDto[]> {
+  async getAll(
+    options?: IGetAllOptions<Entity>,
+  ): Promise<SerializedResponseDtoCollection<ResponseDto>> {
     const entities = await this.repository.getAll(options);
-    const responseDtos = entities.data.map((entity) =>
-      this.mapper.fromEntityToResponseDto(entity),
-    );
+    const collection = new CollectionDto<ResponseDto>({
+      data: entities.data.map((entity) =>
+        this.mapper.fromEntityToResponseDto(entity),
+      ),
+      itemCount: entities.itemCount,
+      pageCount: entities.pageCount,
+      pageNumber: entities.pageNumber,
+      pageSize: entities.pageSize,
+    });
 
-    return responseDtos;
+    return this.responseSerializer.serializeResponseDtoCollection(
+      collection.data,
+      this.entityName,
+      {
+        itemCount: collection.itemCount,
+        pageCount: collection.pageCount,
+        pageNumber: collection.pageNumber,
+        pageSize: collection.pageSize,
+      },
+    );
   }
 
-  async getOneByIdOrFail(id: string): Promise<ResponseDto> {
+  async getOneByIdOrFail(
+    id: string,
+  ): Promise<SerializedResponseDto<ResponseDto>> {
     const entity = await this.repository.getOneByIdOrFail(id);
     const responseDto = this.mapper.fromEntityToResponseDto(entity);
 
-    return responseDto;
+    return this.responseSerializer.serializeResponseDto(
+      id,
+      responseDto,
+      this.entityName,
+    );
   }
 
-  async saveOne(createDto: CreateDto): Promise<ResponseDto> {
+  async saveOne(
+    createDto: CreateDto,
+  ): Promise<SerializedResponseDto<ResponseDto>> {
     const entity = this.mapper.fromCreateDtoToEntity(createDto);
     const savedEntity = await this.repository.saveOne(entity);
     const responseDto = this.mapper.fromEntityToResponseDto(savedEntity);
 
-    return responseDto;
+    return this.responseSerializer.serializeResponseDto(
+      savedEntity.id,
+      responseDto,
+      this.entityName,
+    );
   }
 
-  async updateOne(id: string, updateDto: UpdateDto): Promise<ResponseDto> {
+  async updateOne(
+    id: string,
+    updateDto: UpdateDto,
+  ): Promise<SerializedResponseDto<ResponseDto>> {
     const entity = this.mapper.fromUpdateDtoToEntity(updateDto);
     const updatedEntity = await this.repository.updateOneByIdOrFail(id, entity);
     const responseDto = this.mapper.fromEntityToResponseDto(updatedEntity);
 
-    return responseDto;
+    return this.responseSerializer.serializeResponseDto(
+      id,
+      responseDto,
+      this.entityName,
+    );
   }
 
   async deleteOneByIdOrFail(id: string): Promise<void> {

--- a/src/common/base/application/service/crud-service.interface.ts
+++ b/src/common/base/application/service/crud-service.interface.ts
@@ -1,6 +1,10 @@
 import IEntity from '@common/base/application/domain/entity.interface';
 import { IDto } from '@common/base/application/dto/dto.interface';
 import { IGetAllOptions } from '@common/base/application/dto/get-all-options.interface';
+import {
+  SerializedResponseDto,
+  SerializedResponseDtoCollection,
+} from '@common/base/application/dto/serialized-response.dto';
 
 export interface ICRUDService<
   Entity extends IEntity,
@@ -8,9 +12,14 @@ export interface ICRUDService<
   CreateDto extends IDto,
   UpdateDto extends IDto,
 > {
-  getAll(options?: IGetAllOptions<Entity>): Promise<ResponseDto[]>;
-  getOneByIdOrFail(id: string): Promise<ResponseDto>;
-  saveOne(createDto: CreateDto): Promise<ResponseDto>;
-  updateOne(id: string, updateDto: UpdateDto): Promise<ResponseDto>;
+  getAll(
+    options?: IGetAllOptions<Entity>,
+  ): Promise<SerializedResponseDtoCollection<ResponseDto>>;
+  getOneByIdOrFail(id: string): Promise<SerializedResponseDto<ResponseDto>>;
+  saveOne(createDto: CreateDto): Promise<SerializedResponseDto<ResponseDto>>;
+  updateOne(
+    id: string,
+    updateDto: UpdateDto,
+  ): Promise<SerializedResponseDto<ResponseDto>>;
   deleteOneByIdOrFail(id: string): Promise<void>;
 }

--- a/src/module/app.module.ts
+++ b/src/module/app.module.ts
@@ -1,10 +1,13 @@
-import { Module } from '@nestjs/common';
+import { Global, Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { environmentConfig } from '@config/environment.config';
 import { datasourceOptions } from '@config/orm.config';
 
+import { ResponseSerializerService } from '@module/app/service/response-serializer.service';
+
+@Global()
 @Module({
   imports: [
     ConfigModule.forRoot({
@@ -18,5 +21,7 @@ import { datasourceOptions } from '@config/orm.config';
       }),
     }),
   ],
+  providers: [ResponseSerializerService],
+  exports: [ResponseSerializerService],
 })
 export class AppModule {}

--- a/src/module/app/service/response-serializer.service.ts
+++ b/src/module/app/service/response-serializer.service.ts
@@ -1,0 +1,112 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+import { IPagingCollectionData } from '@common/base/application/dto/collection.interface';
+import {
+  SerializedResponseDto,
+  SerializedResponseDtoCollection,
+} from '@common/base/application/dto/serialized-response.dto';
+import {
+  ICollectionLinks,
+  IResponseDtoLinks,
+} from '@common/base/application/dto/serialized-response.interface';
+import { HttpMethod } from '@common/base/application/enum/http-method.enum';
+
+@Injectable()
+export class ResponseSerializerService {
+  private appBaseUrl: string;
+
+  constructor(private readonly configService: ConfigService) {
+    this.appBaseUrl = this.configService.get('server.baseUrl');
+  }
+
+  serializeResponseDto<ResponseDto extends object>(
+    id: string,
+    responseDto: ResponseDto,
+    entityName: string,
+  ): SerializedResponseDto<ResponseDto> {
+    const links: IResponseDtoLinks = {
+      self: {
+        href: `${this.appBaseUrl}/${entityName}/${id}`,
+        rel: 'self',
+        method: HttpMethod.GET,
+      },
+      update: {
+        href: `${this.appBaseUrl}/${entityName}/${id}`,
+        rel: 'update',
+        method: HttpMethod.PUT,
+      },
+      delete: {
+        href: `${this.appBaseUrl}/${entityName}/${id}`,
+        rel: 'delete',
+        method: HttpMethod.DELETE,
+      },
+    };
+
+    return new SerializedResponseDto(responseDto, links);
+  }
+
+  serializeResponseDtoCollection<ResponseDto extends object>(
+    responseDtos: ResponseDto[],
+    entityName: string,
+    { itemCount, pageCount, pageNumber, pageSize }: IPagingCollectionData,
+  ): SerializedResponseDtoCollection<ResponseDto> {
+    const links = this.fromPagingDataToCollectionLinks(entityName, {
+      pageCount,
+      pageNumber,
+      pageSize,
+    });
+
+    return new SerializedResponseDtoCollection(responseDtos, links, {
+      itemCount,
+      pageCount,
+      pageNumber,
+      pageSize,
+    });
+  }
+
+  private fromPagingDataToCollectionLinks(
+    entityName: string,
+    {
+      pageCount,
+      pageNumber,
+      pageSize,
+    }: Omit<IPagingCollectionData, 'itemCount'>,
+  ): ICollectionLinks {
+    const links: ICollectionLinks = {
+      self: {
+        href: `${this.appBaseUrl}/${entityName}?page[number]=${pageNumber}&page[size]=${pageSize}`,
+        rel: 'self',
+        method: HttpMethod.GET,
+      },
+      first: {
+        href: `${this.appBaseUrl}/${entityName}?page[number]=1&page[size]=${pageSize}`,
+        rel: 'first',
+        method: HttpMethod.GET,
+      },
+      last: {
+        href: `${this.appBaseUrl}/${entityName}?page[number]=${pageCount}&page[size]=${pageSize}`,
+        rel: 'last',
+        method: HttpMethod.GET,
+      },
+    };
+
+    if (pageNumber > 1) {
+      links.previous = {
+        href: `${this.appBaseUrl}/${entityName}?page[number]=${pageNumber - 1}&page[size]=${pageSize}`,
+        rel: 'previous',
+        method: HttpMethod.GET,
+      };
+    }
+
+    if (pageNumber < pageCount) {
+      links.next = {
+        href: `${this.appBaseUrl}/${entityName}?page[number]=${pageNumber + 1}&page[size]=${pageSize}`,
+        rel: 'next',
+        method: HttpMethod.GET,
+      };
+    }
+
+    return links;
+  }
+}


### PR DESCRIPTION
# Summary

This PR adds a `ResponseSerializerService` to format DTO responses from the base CRUD service, implementing HATEOAS principles for a RESTful API.  

# Details

- Adds a `ResponseSerializerService` to embed hypermedia links in CRUD responses.  
- Refactors the base CRUD service to integrate the new serializer. 


# References

https://restfulapi.net/hateoas/