### PR TITLE
feat: Add initial UserPostgresRepository

### DIFF
--- a/data/migrations/1747091704459-initDb.ts
+++ b/data/migrations/1747091704459-initDb.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class InitDb1747091704459 implements MigrationInterface {
+    name = 'InitDb1747091704459'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "user" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "email" character varying NOT NULL, "external_id" character varying, "first_name" character varying NOT NULL, "last_name" character varying NOT NULL, "role" character varying NOT NULL DEFAULT 'regular', "is_verified" boolean NOT NULL DEFAULT false, "avatar_url" character varying, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), "deleted_at" TIMESTAMP, CONSTRAINT "UQ_cace4a159ff9f2512dd42373760" UNIQUE ("id"), CONSTRAINT "UQ_e12875dfb3b1d92d7d7c5377e22" UNIQUE ("email"), CONSTRAINT "UQ_d9479cbc9c65660b7cf9b657954" UNIQUE ("external_id"), CONSTRAINT "PK_cace4a159ff9f2512dd42373760" PRIMARY KEY ("id"))`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE "user"`);
+    }
+
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  db:
+    image: postgres:latest
+    ports:
+      - ${DB_PORT}:5432
+    environment:
+      - POSTGRES_USER=${DB_USERNAME}
+      - POSTGRES_PASSWORD=${DB_PASSWORD}
+      - POSTGRES_DB=${DB_NAME}
+    volumes:
+      - './data/docker/volumes/postgres/:/var/lib/postgresql'

--- a/src/module/app.module.ts
+++ b/src/module/app.module.ts
@@ -6,6 +6,7 @@ import { environmentConfig } from '@config/environment.config';
 import { datasourceOptions } from '@config/orm.config';
 
 import { ResponseSerializerService } from '@module/app/service/response-serializer.service';
+import { IamModule } from '@module/iam/iam.module';
 
 @Global()
 @Module({
@@ -20,6 +21,7 @@ import { ResponseSerializerService } from '@module/app/service/response-serializ
         autoLoadEntities: true,
       }),
     }),
+    IamModule,
   ],
   providers: [ResponseSerializerService],
   exports: [ResponseSerializerService],

--- a/src/module/iam/authorization/domain/app-role.enum.ts
+++ b/src/module/iam/authorization/domain/app-role.enum.ts
@@ -1,0 +1,5 @@
+export enum AppRole {
+  Admin = 'admin',
+  Regular = 'regular',
+  SuperAdmin = 'superAdmin',
+}

--- a/src/module/iam/iam.module.ts
+++ b/src/module/iam/iam.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+
+import { UserModule } from '@module/iam/user/user.module';
+
+@Module({
+  imports: [UserModule],
+})
+export class IamModule {}

--- a/src/module/iam/user/application/dto/create-user.dto.ts
+++ b/src/module/iam/user/application/dto/create-user.dto.ts
@@ -1,0 +1,21 @@
+import { Transform } from 'class-transformer';
+import { IsEmail, IsNotEmpty, IsOptional, IsUrl } from 'class-validator';
+
+import { IDto } from '@common/base/application/dto/dto.interface';
+
+export class CreateUserDto implements IDto {
+  @IsEmail()
+  @IsNotEmpty()
+  @Transform(({ value }) => (value as string).toLowerCase())
+  readonly email: string;
+
+  @IsNotEmpty()
+  readonly firstName: string;
+
+  @IsNotEmpty()
+  readonly lastName: string;
+
+  @IsOptional()
+  @IsUrl()
+  readonly avatarUrl?: string;
+}

--- a/src/module/iam/user/application/dto/update-user.dto.ts
+++ b/src/module/iam/user/application/dto/update-user.dto.ts
@@ -1,0 +1,5 @@
+import { PartialType } from '@nestjs/mapped-types';
+
+import { CreateUserDto } from '@module/iam/user/application/dto/create-user.dto';
+
+export class UpdateUserDto extends PartialType(CreateUserDto) {}

--- a/src/module/iam/user/application/dto/user-response.dto.ts
+++ b/src/module/iam/user/application/dto/user-response.dto.ts
@@ -1,0 +1,34 @@
+import { IDto } from '@common/base/application/dto/dto.interface';
+
+import { AppRole } from '@module/iam/authorization/domain/app-role.enum';
+
+export class UserResponseDto implements IDto {
+  id: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  role: AppRole;
+  isVerified: boolean;
+  externalId?: string;
+  avatarUrl?: string;
+
+  constructor(
+    id: string,
+    email: string,
+    firstName: string,
+    lastName: string,
+    role: AppRole,
+    isVerified: boolean,
+    avatarUrl?: string,
+    externalId?: string,
+  ) {
+    this.id = id;
+    this.externalId = externalId;
+    this.email = email;
+    this.firstName = firstName;
+    this.lastName = lastName;
+    this.role = role;
+    this.avatarUrl = avatarUrl;
+    this.isVerified = isVerified;
+  }
+}

--- a/src/module/iam/user/application/mapper/user.mapper.ts
+++ b/src/module/iam/user/application/mapper/user.mapper.ts
@@ -1,0 +1,44 @@
+import { IDtoMapper } from '@common/base/application/dto/dto.interface';
+
+import { AppRole } from '@module/iam/authorization/domain/app-role.enum';
+import { CreateUserDto } from '@module/iam/user/application/dto/create-user.dto';
+import { UpdateUserDto } from '@module/iam/user/application/dto/update-user.dto';
+import { UserResponseDto } from '@module/iam/user/application/dto/user-response.dto';
+import { User } from '@module/iam/user/domain/user.entity';
+
+export class UserMapper
+  implements IDtoMapper<User, CreateUserDto, UpdateUserDto, UserResponseDto>
+{
+  fromCreateDtoToEntity(dto: CreateUserDto): User {
+    return new User(
+      dto.email,
+      dto.firstName,
+      dto.lastName,
+      AppRole.Regular,
+      dto.avatarUrl,
+    );
+  }
+
+  fromUpdateDtoToEntity(dto: UpdateUserDto): User {
+    return new User(
+      dto.email,
+      dto.firstName,
+      dto.lastName,
+      AppRole.Regular,
+      dto.avatarUrl,
+    );
+  }
+
+  fromEntityToResponseDto(entity: User): UserResponseDto {
+    return new UserResponseDto(
+      entity.id,
+      entity.email,
+      entity.firstName,
+      entity.lastName,
+      entity.role,
+      entity.isVerified,
+      entity.avatarUrl,
+      entity.externalId,
+    );
+  }
+}

--- a/src/module/iam/user/application/repository/user.repository.interface.ts
+++ b/src/module/iam/user/application/repository/user.repository.interface.ts
@@ -1,0 +1,23 @@
+import { ICollection } from '@common/base/application/dto/collection.interface';
+import { IGetAllOptions } from '@common/base/application/dto/get-all-options.interface';
+
+import { User } from '@module/iam/user/domain/user.entity';
+
+export const USER_REPOSITORY_KEY = 'user_repository';
+
+export interface IUserRepository {
+  getAll(options: IGetAllOptions<User>): Promise<ICollection<User>>;
+
+  getOneByEmail(email: string): Promise<User>;
+
+  getOneByExternalId(externalId: string): Promise<User>;
+
+  getOneByEmailOrFail(email: string): Promise<User>;
+
+  saveOne(user: User): Promise<User>;
+
+  updateOneOrFail(
+    id: string,
+    updates: Partial<Omit<User, 'id'>>,
+  ): Promise<User>;
+}

--- a/src/module/iam/user/domain/user.entity.ts
+++ b/src/module/iam/user/domain/user.entity.ts
@@ -1,0 +1,36 @@
+import { Base } from '@common/base/application/domain/base.entity';
+
+import { AppRole } from '@module/iam/authorization/domain/app-role.enum';
+
+export class User extends Base {
+  externalId?: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  role: AppRole;
+  avatarUrl?: string;
+  isVerified: boolean;
+
+  constructor(
+    email: string,
+    firstName: string,
+    lastName: string,
+    role: AppRole,
+    avatarUrl?: string,
+    externalId?: string,
+    id?: string,
+    createdAt?: string,
+    updatedAt?: string,
+    deletedAt?: string,
+    isVerified?: boolean,
+  ) {
+    super(id, createdAt, updatedAt, deletedAt);
+    this.email = email;
+    this.externalId = externalId;
+    this.role = role;
+    this.avatarUrl = avatarUrl;
+    this.firstName = firstName;
+    this.lastName = lastName;
+    this.isVerified = isVerified;
+  }
+}

--- a/src/module/iam/user/infrastructure/database/exception/email-not-found.exception.ts
+++ b/src/module/iam/user/infrastructure/database/exception/email-not-found.exception.ts
@@ -1,0 +1,7 @@
+import { NotFoundException } from '@nestjs/common';
+
+export class EmailNotFoundException extends NotFoundException {
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/src/module/iam/user/infrastructure/database/exception/user-not-found.exception.ts
+++ b/src/module/iam/user/infrastructure/database/exception/user-not-found.exception.ts
@@ -1,0 +1,7 @@
+import { NotFoundException } from '@nestjs/common';
+
+export class UserNotFoundException extends NotFoundException {
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/src/module/iam/user/infrastructure/database/user.postgres.repository.ts
+++ b/src/module/iam/user/infrastructure/database/user.postgres.repository.ts
@@ -1,0 +1,86 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { ICollection } from '@common/base/application/dto/collection.interface';
+import { IGetAllOptions } from '@common/base/application/dto/get-all-options.interface';
+
+import { IUserRepository } from '@module/iam/user/application/repository/user.repository.interface';
+import { User } from '@module/iam/user/domain/user.entity';
+import { EmailNotFoundException } from '@module/iam/user/infrastructure/database/exception/email-not-found.exception';
+import { UserNotFoundException } from '@module/iam/user/infrastructure/database/exception/user-not-found.exception';
+import { UserSchema } from '@module/iam/user/infrastructure/database/user.schema';
+
+@Injectable()
+export class UserPostgresRepository implements IUserRepository {
+  constructor(
+    @InjectRepository(UserSchema)
+    private readonly repository: Repository<User>,
+  ) {}
+
+  async getAll(options: IGetAllOptions<User>): Promise<ICollection<User>> {
+    const { filter, page, sort, fields } = options || {};
+
+    const [items, itemCount] = await this.repository.findAndCount({
+      where: filter,
+      order: sort,
+      select: fields,
+      take: page.size,
+      skip: page.offset,
+    });
+
+    return {
+      data: items,
+      pageNumber: page.number,
+      pageSize: page.size,
+      pageCount: Math.ceil(itemCount / page.size),
+      itemCount,
+    };
+  }
+
+  async getOneByEmail(email: string): Promise<User> {
+    return this.repository.findOne({
+      where: { email },
+    });
+  }
+
+  async getOneByExternalId(externalId: string): Promise<User> {
+    return this.repository.findOne({
+      where: { externalId },
+    });
+  }
+
+  async getOneByEmailOrFail(email: string): Promise<User> {
+    const user = await this.repository.findOne({
+      where: { email },
+    });
+
+    if (!user) {
+      throw new EmailNotFoundException(
+        `User with email ${email} was not found`,
+      );
+    }
+
+    return user;
+  }
+
+  async saveOne(user: User): Promise<User> {
+    return this.repository.save(user);
+  }
+
+  async updateOneOrFail(
+    id: string,
+    updates: Partial<Omit<User, 'id'>>,
+  ): Promise<User> {
+    const userToUpdate = await this.repository.preload({
+      id,
+      ...updates,
+    });
+
+    if (!userToUpdate) {
+      throw new UserNotFoundException(`User with ID ${id} was not found`);
+    }
+
+    return this.repository.save(userToUpdate);
+  }
+}

--- a/src/module/iam/user/infrastructure/database/user.schema.ts
+++ b/src/module/iam/user/infrastructure/database/user.schema.ts
@@ -1,0 +1,41 @@
+import { EntitySchema } from 'typeorm';
+
+import { withBaseSchemaColumns } from '@common/base/infrastructure/database/base.schema';
+
+import { AppRole } from '@module/iam/authorization/domain/app-role.enum';
+import { User } from '@module/iam/user/domain/user.entity';
+
+export const UserSchema = new EntitySchema<User>({
+  name: 'User',
+  target: User,
+  tableName: 'user',
+  columns: withBaseSchemaColumns({
+    email: {
+      type: String,
+      unique: true,
+    },
+    externalId: {
+      type: String,
+      unique: true,
+      nullable: true,
+    },
+    firstName: {
+      type: String,
+    },
+    lastName: {
+      type: String,
+    },
+    role: {
+      type: String,
+      default: AppRole.Regular,
+    },
+    isVerified: {
+      type: Boolean,
+      default: false,
+    },
+    avatarUrl: {
+      type: String,
+      nullable: true,
+    },
+  }),
+});

--- a/src/module/iam/user/user.module.ts
+++ b/src/module/iam/user/user.module.ts
@@ -1,0 +1,19 @@
+import { Module, Provider } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { UserMapper } from '@module/iam/user/application/mapper/user.mapper';
+import { USER_REPOSITORY_KEY } from '@module/iam/user/application/repository/user.repository.interface';
+import { UserPostgresRepository } from '@module/iam/user/infrastructure/database/user.postgres.repository';
+import { UserSchema } from '@module/iam/user/infrastructure/database/user.schema';
+
+const userRepositoryProvider: Provider = {
+  provide: USER_REPOSITORY_KEY,
+  useClass: UserPostgresRepository,
+};
+
+@Module({
+  imports: [TypeOrmModule.forFeature([UserSchema])],
+  providers: [userRepositoryProvider, UserMapper],
+  exports: [userRepositoryProvider, UserMapper],
+})
+export class UserModule {}


### PR DESCRIPTION
# Summary

This PR adds an initial `UserRepository` in order to consume it during authentication flow.

# Details

- Added User domain and schema entities.
- Created DTOs and Mapper for the User entity.
- Implemented a `UserRepository` with getAll, getOneByEmail, getOneByExternalId, getOneByEmailOrFail, saveOne updateOneOrFail methods.
- Configured PostgreSQL via docker-compose.yml for local development.
- Created an initial migration file with the new user table.