### PR TITLE
refactor: Add custom response serializer option

### DIFF
--- a/src/module/app/service/link-builder.service.interface.ts
+++ b/src/module/app/service/link-builder.service.interface.ts
@@ -1,0 +1,21 @@
+import { IPagingCollectionData } from '@common/base/application/dto/collection.interface';
+import { IDto } from '@common/base/application/dto/dto.interface';
+import {
+  ICollectionLinks,
+  IResponseDtoLinks,
+} from '@common/base/application/dto/serialized-response.interface';
+
+export interface ILinkBuilderService {
+  buildSingleEntityLinks(entityName: string, dto: IDto): IResponseDtoLinks;
+  buildCollectionLinks(
+    entityName: string,
+    pagingData: IPagingCollectionData,
+  ): ICollectionLinks;
+}
+
+export interface ISingleEntityLinkBuilder {
+  buildSingleEntityLinks(
+    baseUrl: string,
+    entityName: string,
+  ): IResponseDtoLinks;
+}

--- a/src/module/app/service/link-builder.service.ts
+++ b/src/module/app/service/link-builder.service.ts
@@ -1,0 +1,87 @@
+import { IPagingCollectionData } from '@common/base/application/dto/collection.interface';
+import {
+  ICollectionLinks,
+  IResponseDtoLinks,
+} from '@common/base/application/dto/serialized-response.interface';
+import { HttpMethod } from '@common/base/application/enum/http-method.enum';
+
+import { ILinkBuilderService } from '@module/app/service/link-builder.service.interface';
+
+export class LinkBuilderService implements ILinkBuilderService {
+  protected appBaseUrl: string;
+  constructor(appBaseUrl: string) {
+    this.appBaseUrl = appBaseUrl;
+  }
+
+  buildSingleEntityLinks(entityName: string, id: string): IResponseDtoLinks {
+    return {
+      self: {
+        href: `${this.appBaseUrl}/${entityName}/${id}`,
+        rel: 'self',
+        method: HttpMethod.GET,
+      },
+      update: {
+        href: `${this.appBaseUrl}/${entityName}/${id}`,
+        rel: 'update',
+        method: HttpMethod.PUT,
+      },
+      delete: {
+        href: `${this.appBaseUrl}/${entityName}/${id}`,
+        rel: 'delete',
+        method: HttpMethod.DELETE,
+      },
+    };
+  }
+
+  buildCollectionLinks(
+    entityName: string,
+    pagingData: IPagingCollectionData,
+  ): ICollectionLinks {
+    return this.fromPagingDataToCollectionLinks(entityName, pagingData);
+  }
+
+  private fromPagingDataToCollectionLinks(
+    entityName: string,
+    {
+      pageCount,
+      pageNumber,
+      pageSize,
+    }: Omit<IPagingCollectionData, 'itemCount'>,
+  ): ICollectionLinks {
+    const links: ICollectionLinks = {
+      self: {
+        href: `${this.appBaseUrl}/${entityName}?page[number]=${pageNumber}&page[size]=${pageSize}`,
+        rel: 'self',
+        method: HttpMethod.GET,
+      },
+      first: {
+        href: `${this.appBaseUrl}/${entityName}?page[number]=1&page[size]=${pageSize}`,
+        rel: 'first',
+        method: HttpMethod.GET,
+      },
+      last: {
+        href: `${this.appBaseUrl}/${entityName}?page[number]=${pageCount}&page[size]=${pageSize}`,
+        rel: 'last',
+        method: HttpMethod.GET,
+      },
+    };
+
+    if (pageNumber > 1) {
+      links.previous = {
+        href: `${this.appBaseUrl}/${entityName}?page[number]=${pageNumber - 1}&page[size]=${pageSize}`,
+        rel: 'previous',
+        method: HttpMethod.GET,
+      };
+    }
+
+    if (pageNumber < pageCount) {
+      links.next = {
+        href: `${this.appBaseUrl}/${entityName}?page[number]=${pageNumber + 1}&page[size]=${pageSize}`,
+        rel: 'next',
+        method: HttpMethod.GET,
+      };
+    }
+
+    return links;
+  }
+}

--- a/src/module/iam/authentication/__test__/authentication.e2e.spec.ts
+++ b/src/module/iam/authentication/__test__/authentication.e2e.spec.ts
@@ -1,6 +1,9 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { HttpStatus } from '@nestjs/common';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import request from 'supertest';
+
+import { HttpMethod } from '@common/base/application/enum/http-method.enum';
 
 import { setupApp } from '@config/app.config';
 
@@ -8,6 +11,7 @@ import { SignUpDto } from '@module/iam/authentication/application/service/dto/si
 import { PASSWORD_VALIDATION_ERROR } from '@module/iam/authentication/infrastructure/cognito/exception/cognito-exception-messages';
 import { CouldNotSignUpException } from '@module/iam/authentication/infrastructure/cognito/exception/could-not-sign-up.exception';
 import { PasswordValidationException } from '@module/iam/authentication/infrastructure/cognito/exception/password-validation.exception';
+import { AppRole } from '@module/iam/authorization/domain/app-role.enum';
 
 import {
   identityProviderServiceMock,
@@ -51,8 +55,27 @@ describe('Authentication Module', () => {
         .then(({ body }) => {
           expect(body).toEqual(
             expect.objectContaining({
-              email: signUpDto.email,
-              externalId,
+              data: expect.objectContaining({
+                email: signUpDto.email,
+                externalId,
+                firstName: signUpDto.firstName,
+                lastName: signUpDto.lastName,
+                avatarUrl: signUpDto.avatarUrl,
+                role: AppRole.Regular,
+                isVerified: false,
+              }),
+              links: expect.objectContaining({
+                self: expect.objectContaining({
+                  href: expect.stringContaining('/user/me'),
+                  rel: 'self',
+                  method: HttpMethod.GET,
+                }),
+                update: expect.objectContaining({
+                  href: expect.stringContaining('/user/me'),
+                  rel: 'update',
+                  method: HttpMethod.PUT,
+                }),
+              }),
             }),
           );
         });
@@ -88,8 +111,27 @@ describe('Authentication Module', () => {
         .then(({ body }) => {
           expect(body).toEqual(
             expect.objectContaining({
-              email: signUpDto.email,
-              externalId,
+              data: expect.objectContaining({
+                email: signUpDto.email,
+                externalId,
+                firstName: signUpDto.firstName,
+                lastName: signUpDto.lastName,
+                avatarUrl: signUpDto.avatarUrl,
+                role: AppRole.Regular,
+                isVerified: false,
+              }),
+              links: expect.objectContaining({
+                self: expect.objectContaining({
+                  href: expect.stringContaining('/user/me'),
+                  rel: 'self',
+                  method: HttpMethod.GET,
+                }),
+                update: expect.objectContaining({
+                  href: expect.stringContaining('/user/me'),
+                  rel: 'update',
+                  method: HttpMethod.PUT,
+                }),
+              }),
             }),
           );
         });
@@ -115,8 +157,27 @@ describe('Authentication Module', () => {
         .then(({ body }) => {
           expect(body).toEqual(
             expect.objectContaining({
-              email: signUpDto.email,
-              externalId,
+              data: expect.objectContaining({
+                email: signUpDto.email,
+                externalId,
+                firstName: signUpDto.firstName,
+                lastName: signUpDto.lastName,
+                avatarUrl: null,
+                role: AppRole.Regular,
+                isVerified: false,
+              }),
+              links: expect.objectContaining({
+                self: expect.objectContaining({
+                  href: expect.stringContaining('/user/me'),
+                  rel: 'self',
+                  method: HttpMethod.GET,
+                }),
+                update: expect.objectContaining({
+                  href: expect.stringContaining('/user/me'),
+                  rel: 'update',
+                  method: HttpMethod.PUT,
+                }),
+              }),
             }),
           );
         });

--- a/src/module/iam/authentication/interface/authentication.controller.ts
+++ b/src/module/iam/authentication/interface/authentication.controller.ts
@@ -1,5 +1,7 @@
 import { Body, Controller, Post } from '@nestjs/common';
 
+import { SerializedResponseDto } from '@common/base/application/dto/serialized-response.dto';
+
 import { AuthenticationService } from '@module/iam/authentication/application/service/authentication.service';
 import { SignUpDto } from '@module/iam/authentication/application/service/dto/sign-up.dto';
 import { UserResponseDto } from '@module/iam/user/application/dto/user-response.dto';
@@ -9,7 +11,9 @@ export class AuthenticationController {
   constructor(private readonly authenticationService: AuthenticationService) {}
 
   @Post('sign-up')
-  async handleSignUp(@Body() signUpDto: SignUpDto): Promise<UserResponseDto> {
+  async handleSignUp(
+    @Body() signUpDto: SignUpDto,
+  ): Promise<SerializedResponseDto<UserResponseDto>> {
     return this.authenticationService.handleSignUp(signUpDto);
   }
 }

--- a/src/module/iam/user/application/service/link-builder/user-link-builder.service.ts
+++ b/src/module/iam/user/application/service/link-builder/user-link-builder.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+
+import { IResponseDtoLinks } from '@common/base/application/dto/serialized-response.interface';
+import { HttpMethod } from '@common/base/application/enum/http-method.enum';
+
+import { ISingleEntityLinkBuilder } from '@module/app/service/link-builder.service.interface';
+
+@Injectable()
+export class UserLinkBuilderService implements ISingleEntityLinkBuilder {
+  buildSingleEntityLinks(
+    baseUrl: string,
+    entityName: string,
+  ): IResponseDtoLinks {
+    return {
+      self: {
+        href: `${baseUrl}/${entityName}/me`,
+        rel: 'self',
+        method: HttpMethod.GET,
+      },
+      update: {
+        href: `${baseUrl}/${entityName}/me`,
+        rel: 'update',
+        method: HttpMethod.PUT,
+      },
+    };
+  }
+}

--- a/src/module/iam/user/user.module.ts
+++ b/src/module/iam/user/user.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { UserMapper } from '@module/iam/user/application/mapper/user.mapper';
 import { USER_REPOSITORY_KEY } from '@module/iam/user/application/repository/user.repository.interface';
+import { UserLinkBuilderService } from '@module/iam/user/application/service/link-builder/user-link-builder.service';
 import { UserPostgresRepository } from '@module/iam/user/infrastructure/database/user.postgres.repository';
 import { UserSchema } from '@module/iam/user/infrastructure/database/user.schema';
 
@@ -13,7 +14,7 @@ const userRepositoryProvider: Provider = {
 
 @Module({
   imports: [TypeOrmModule.forFeature([UserSchema])],
-  providers: [userRepositoryProvider, UserMapper],
-  exports: [userRepositoryProvider, UserMapper],
+  providers: [userRepositoryProvider, UserMapper, UserLinkBuilderService],
+  exports: [userRepositoryProvider, UserMapper, UserLinkBuilderService],
 })
 export class UserModule {}


### PR DESCRIPTION
# Summary

This PR introduces the possibility to implement custom responses to the `serializeResponseDto` metdho from the `ResponseSerializerService`.

# Details

- Implement a default `LinkBuilderService` method with `self`, `update` and `delete` hypermedia links.
- Refactor `ResponseSerializerService` for using the new `LinkBuilderService` or a custom link builder received by params.
- Add hypermedia links to `sign-up` methods, using a custom `UserLinkBuilderService`.