### PR TITLE
feat: Add exception filter to format app error responses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@types/node": "^22.15.14",
         "@types/supertest": "^6.0.2",
         "better-sqlite3": "^11.10.0",
+        "change-case-all": "^2.1.0",
         "cross-env": "^7.0.3",
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^10.0.1",
@@ -8630,6 +8631,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/change-case-all": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-2.1.0.tgz",
+      "integrity": "sha512-v6b0WWWkZUMHVuYk82l+WROgkUm4qEN2w5hKRNWtEOYwWqUGoi8C6xH0l1RLF1EoWqDFK6MFclmN3od6ws3/uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "change-case": "^5.2.0",
+        "sponge-case": "^2.0.2",
+        "swap-case": "^3.0.2",
+        "title-case": "^3.0.3"
+      }
+    },
     "node_modules/char-regex": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
@@ -15834,6 +15855,13 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/sponge-case": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/sponge-case/-/sponge-case-2.0.3.tgz",
+      "integrity": "sha512-i4h9ZGRfxV6Xw3mpZSFOfbXjf0cQcYmssGWutgNIfFZ2VM+YIWfD71N/kjjwK6X/AAHzBr+rciEcn/L34S8TGw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -16233,6 +16261,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swap-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-3.0.3.tgz",
+      "integrity": "sha512-6p4op8wE9CQv7uDFzulI6YXUw4lD9n4oQierdbFThEKVWVQcbQcUjdP27W8XE7V4QnWmnq9jueSHceyyQnqQVA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/symbol-observable": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
@@ -16563,6 +16598,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/title-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/title-case/-/title-case-3.0.3.tgz",
+      "integrity": "sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/tmp": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@types/node": "^22.15.14",
     "@types/supertest": "^6.0.2",
     "better-sqlite3": "^11.10.0",
+    "change-case-all": "^2.1.0",
     "cross-env": "^7.0.3",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",

--- a/src/common/base/application/exception/app-error-response.interface.ts
+++ b/src/common/base/application/exception/app-error-response.interface.ts
@@ -1,0 +1,17 @@
+export interface IAppErrorResponse {
+  error: IAppError;
+}
+
+export interface IBaseErrorInfo {
+  status?: number;
+  pointer?: string;
+  title?: string;
+  message?: string;
+}
+
+interface IAppError {
+  status: string;
+  source: { pointer: string };
+  title: string;
+  detail: string;
+}

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -1,6 +1,7 @@
 import { ValidationPipe, VersioningType } from '@nestjs/common';
 import { NestExpressApplication } from '@nestjs/platform-express';
 
+import { AppExceptionFilter } from '@module/app/infrastructure/nestjs/app-exception.filter';
 import { GetCurrentEndpointInterceptor } from '@module/app/interceptor/get-current-endpoint.interceptor';
 import { AppService } from '@module/app/service/app.service';
 
@@ -16,6 +17,9 @@ export const setupApp = (app: NestExpressApplication): void => {
   app.useGlobalInterceptors(
     new GetCurrentEndpointInterceptor(app.get(AppService)),
   );
+
+  app.useGlobalFilters(new AppExceptionFilter());
+
   app.useGlobalPipes(
     new ValidationPipe({
       transform: true,

--- a/src/module/app/infrastructure/nestjs/__test__/app-exception.filter.spec.ts
+++ b/src/module/app/infrastructure/nestjs/__test__/app-exception.filter.spec.ts
@@ -1,0 +1,190 @@
+import { ArgumentsHost, HttpException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Request, Response } from 'express';
+
+import { AppExceptionFilter } from '@module/app/infrastructure/nestjs/app-exception.filter';
+
+describe('AppExceptionFilter', () => {
+  let appExceptionFilter: AppExceptionFilter;
+  let mockResponse: Pick<Response, 'status' | 'json'>;
+  let mockRequest: Pick<Request, 'url'>;
+  const DEFAULT_ERROR_TITLE = 'An error occurred';
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AppExceptionFilter],
+    }).compile();
+
+    appExceptionFilter = module.get<AppExceptionFilter>(AppExceptionFilter);
+    mockResponse = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    mockRequest = {
+      url: '/test-route',
+    };
+  });
+
+  it('Should catch HttpException and send the correct error response', () => {
+    const mockHttpException = new HttpException('Error message', 400);
+    const host: ArgumentsHost = {
+      switchToHttp: () => ({
+        getResponse: () => mockResponse as Response,
+        getRequest: () => mockRequest as Request,
+      }),
+    } as ArgumentsHost;
+
+    appExceptionFilter.catch(mockHttpException, host);
+
+    expect(mockResponse.status).toHaveBeenCalledWith(400);
+    expect(mockResponse.json).toHaveBeenCalledWith({
+      error: {
+        status: '400',
+        source: { pointer: '/test-route' },
+        title: DEFAULT_ERROR_TITLE,
+        detail: 'Error message',
+      },
+    });
+  });
+
+  it('Should use default values if errorInfo is not provided', () => {
+    const mockHttpException = new HttpException(null, 400);
+
+    const host: ArgumentsHost = {
+      switchToHttp: () => ({
+        getResponse: () => mockResponse as Response,
+        getRequest: () => mockRequest as Request,
+      }),
+    } as ArgumentsHost;
+
+    jest.spyOn(mockHttpException, 'getResponse').mockReturnValue({});
+
+    appExceptionFilter.catch(mockHttpException, host);
+
+    expect(mockResponse.status).toHaveBeenCalledWith(400);
+    expect(mockResponse.json).toHaveBeenCalledWith({
+      error: {
+        status: '400',
+        source: { pointer: '/test-route' },
+        title: DEFAULT_ERROR_TITLE,
+        detail: 'An error occurred',
+      },
+    });
+  });
+
+  it('Should handle an error response that is an array', () => {
+    const mockErrorArray = [{ message: 'Array error', status: 400 }];
+    const mockHttpException = new HttpException(mockErrorArray, 400);
+
+    const host: ArgumentsHost = {
+      switchToHttp: () => ({
+        getResponse: () => mockResponse as Response,
+        getRequest: () => mockRequest as Request,
+      }),
+    } as ArgumentsHost;
+
+    appExceptionFilter.catch(mockHttpException, host);
+
+    expect(mockResponse.status).toHaveBeenCalledWith(400);
+    expect(mockResponse.json).toHaveBeenCalledWith({
+      error: {
+        status: '400',
+        source: { pointer: '/test-route' },
+        title: DEFAULT_ERROR_TITLE,
+        detail: 'Array error',
+      },
+    });
+  });
+
+  it('Should return a title when exception does not have a name', () => {
+    const mockHttpException = new HttpException('Exception without name', 400);
+    Object.defineProperty(mockHttpException, 'name', {
+      get: () => undefined,
+    });
+
+    const errorInfo = { title: '' };
+    const errorTitle = appExceptionFilter['getErrorTitle'](
+      errorInfo,
+      mockHttpException,
+    );
+
+    expect(errorTitle).toBe(DEFAULT_ERROR_TITLE);
+  });
+
+  it('Should handle an empty string message', () => {
+    const mockHttpException = new HttpException('', 400);
+
+    const host: ArgumentsHost = {
+      switchToHttp: () => ({
+        getResponse: () => mockResponse as Response,
+        getRequest: () => mockRequest as Request,
+      }),
+    } as ArgumentsHost;
+
+    appExceptionFilter.catch(mockHttpException, host);
+
+    expect(mockResponse.status).toHaveBeenCalledWith(400);
+    expect(mockResponse.json).toHaveBeenCalledWith({
+      error: {
+        status: '400',
+        source: { pointer: '/test-route' },
+        title: DEFAULT_ERROR_TITLE,
+        detail: 'An error occurred',
+      },
+    });
+  });
+
+  it('Should return the correct error title', () => {
+    const mockHttpException = new HttpException('Error title', 400);
+
+    const errorInfo = { title: 'Specific error' };
+    const errorTitle = appExceptionFilter['getErrorTitle'](
+      errorInfo,
+      mockHttpException,
+    );
+
+    expect(errorTitle).toBe('Specific error');
+  });
+
+  it('Should return the default error title if no title is provided', () => {
+    const mockHttpException = new HttpException('Http Exception', 400);
+    const errorTitle = appExceptionFilter['getErrorTitle'](
+      {},
+      mockHttpException,
+    );
+
+    expect(errorTitle).toBe(DEFAULT_ERROR_TITLE);
+  });
+
+  it('Should return the correct error detail', () => {
+    const errorDetail = appExceptionFilter['getErrorDetail']({
+      message: 'Test Detail',
+    });
+
+    expect(errorDetail).toBe('Test Detail');
+  });
+
+  it('Should return the default error detail if no message is provided', () => {
+    const errorDetail = appExceptionFilter['getErrorDetail']({});
+
+    expect(errorDetail).toBe('An error occurred');
+  });
+
+  it('Should return the correct error pointer', () => {
+    const errorPointer = appExceptionFilter['getErrorPointer'](
+      { pointer: 'Test Pointer' },
+      mockRequest as Request,
+    );
+
+    expect(errorPointer).toBe('Test Pointer');
+  });
+
+  it('Should return the request URL as error pointer if no pointer is provided', () => {
+    const errorPointer = appExceptionFilter['getErrorPointer'](
+      {},
+      mockRequest as Request,
+    );
+
+    expect(errorPointer).toBe('/test-route');
+  });
+});

--- a/src/module/app/infrastructure/nestjs/app-exception.filter.ts
+++ b/src/module/app/infrastructure/nestjs/app-exception.filter.ts
@@ -1,0 +1,90 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpException,
+} from '@nestjs/common';
+import { sentenceCase } from 'change-case-all';
+import { Request, Response } from 'express';
+
+import {
+  IAppErrorResponse,
+  IBaseErrorInfo,
+} from '@common/base/application/exception/app-error-response.interface';
+
+@Catch(HttpException)
+export class AppExceptionFilter implements ExceptionFilter {
+  catch(exception: HttpException, host: ArgumentsHost): void {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const request = ctx.getRequest<Request>();
+    const status = exception.getStatus();
+
+    const errorResponse = this.createErrorResponse(exception, request);
+
+    response.status(status).json(errorResponse);
+  }
+
+  private createErrorResponse(
+    exception: HttpException,
+    request: Request,
+  ): IAppErrorResponse {
+    const errorInfo = this.getErrorInfoFromException(exception);
+
+    const errorTitle = this.getErrorTitle(errorInfo, exception);
+    const errorDetail = this.getErrorDetail(errorInfo);
+    const errorPointer = this.getErrorPointer(errorInfo, request);
+
+    return {
+      error: {
+        status: String(errorInfo?.status || exception.getStatus()),
+        source: { pointer: errorPointer },
+        title: errorTitle,
+        detail: errorDetail,
+      },
+    };
+  }
+
+  private getErrorInfoFromException(exception: HttpException): IBaseErrorInfo {
+    const exceptionResponse = exception.getResponse();
+
+    if (typeof exceptionResponse === 'string') {
+      return { message: exceptionResponse };
+    }
+
+    if (Array.isArray(exceptionResponse)) {
+      return exceptionResponse[0] as IBaseErrorInfo;
+    }
+
+    return exceptionResponse as IBaseErrorInfo;
+  }
+
+  private getErrorTitle(
+    errorInfo: IBaseErrorInfo,
+    exception: HttpException,
+  ): string {
+    const DEFAULT_ERROR_TITLE = 'An error occurred';
+    const GENERIC_EXCEPTION = 'HttpException';
+    const exceptionName = exception?.name || '';
+    const errorTitle = errorInfo?.title || '';
+
+    if (exceptionName === GENERIC_EXCEPTION) {
+      return errorTitle || DEFAULT_ERROR_TITLE;
+    }
+
+    const formattedName = sentenceCase(exceptionName.replace('Exception', ''));
+
+    return errorTitle || formattedName || DEFAULT_ERROR_TITLE;
+  }
+
+  private getErrorDetail(errorInfo: IBaseErrorInfo): string {
+    const DEFAULT_ERROR_DETAIL = 'An error occurred';
+    const { message = '' } = errorInfo || {};
+    return message || DEFAULT_ERROR_DETAIL;
+  }
+
+  private getErrorPointer(errorInfo: IBaseErrorInfo, request: Request): string {
+    const { pointer = '' } = errorInfo || {};
+    return pointer || request.url;
+  }
+}

--- a/src/module/iam/authentication/application/exception/user-already-signed-up.exception.ts
+++ b/src/module/iam/authentication/application/exception/user-already-signed-up.exception.ts
@@ -1,7 +1,10 @@
 import { BadRequestException } from '@nestjs/common';
 
+import { IBaseErrorInfo } from '@common/base/application/exception/app-error-response.interface';
+
 export class UserAlreadySignedUp extends BadRequestException {
-  constructor(message: string, title: string) {
-    super(message, title);
+  constructor(params: IBaseErrorInfo) {
+    const title = params.title ?? 'Signup Conflict';
+    super({ ...params, title });
   }
 }

--- a/src/module/iam/authentication/application/service/authentication.service.ts
+++ b/src/module/iam/authentication/application/service/authentication.service.ts
@@ -61,10 +61,10 @@ export class AuthenticationService {
       );
     }
 
-    throw new UserAlreadySignedUp(
-      USER_ALREADY_SIGNED_UP_ERROR,
-      SIGNUP_CONFLICT_TITLE,
-    );
+    throw new UserAlreadySignedUp({
+      message: USER_ALREADY_SIGNED_UP_ERROR,
+      title: SIGNUP_CONFLICT_TITLE,
+    });
   }
 
   private async signUpAndSave(

--- a/src/module/iam/authentication/infrastructure/cognito/__test__/cognito.unit-test.spec.ts
+++ b/src/module/iam/authentication/infrastructure/cognito/__test__/cognito.unit-test.spec.ts
@@ -84,7 +84,9 @@ describe('CognitoService', () => {
       await expect(
         cognitoService.signUp('test@example.com', 'badpass'),
       ).rejects.toThrow(
-        new PasswordValidationException(PASSWORD_VALIDATION_ERROR),
+        new PasswordValidationException({
+          message: PASSWORD_VALIDATION_ERROR,
+        }),
       );
     });
 
@@ -95,7 +97,11 @@ describe('CognitoService', () => {
 
       await expect(
         cognitoService.signUp('test@example.com', 'password'),
-      ).rejects.toThrow(new CouldNotSignUpException(error.message));
+      ).rejects.toThrow(
+        new CouldNotSignUpException({
+          message: error.message,
+        }),
+      );
     });
   });
 });

--- a/src/module/iam/authentication/infrastructure/cognito/cognito.service.ts
+++ b/src/module/iam/authentication/infrastructure/cognito/cognito.service.ts
@@ -41,9 +41,13 @@ export class CognitoService implements IIdentityProviderService {
       return { externalId: result.UserSub };
     } catch (error) {
       if ((error as Error).name === 'InvalidPasswordException') {
-        throw new PasswordValidationException(PASSWORD_VALIDATION_ERROR);
+        throw new PasswordValidationException({
+          message: PASSWORD_VALIDATION_ERROR,
+        });
       }
-      throw new CouldNotSignUpException((error as Error).message);
+      throw new CouldNotSignUpException({
+        message: (error as Error).message,
+      });
     }
   }
 }

--- a/src/module/iam/authentication/infrastructure/cognito/exception/could-not-sign-up.exception.ts
+++ b/src/module/iam/authentication/infrastructure/cognito/exception/could-not-sign-up.exception.ts
@@ -1,7 +1,9 @@
 import { InternalServerErrorException } from '@nestjs/common';
 
+import { IBaseErrorInfo } from '@common/base/application/exception/app-error-response.interface';
+
 export class CouldNotSignUpException extends InternalServerErrorException {
-  constructor(message: string) {
-    super(message);
+  constructor(params: IBaseErrorInfo) {
+    super(params);
   }
 }

--- a/src/module/iam/authentication/infrastructure/cognito/exception/password-validation.exception.ts
+++ b/src/module/iam/authentication/infrastructure/cognito/exception/password-validation.exception.ts
@@ -1,7 +1,9 @@
 import { BadRequestException } from '@nestjs/common';
 
+import { IBaseErrorInfo } from '@common/base/application/exception/app-error-response.interface';
+
 export class PasswordValidationException extends BadRequestException {
-  constructor(message: string) {
-    super(message);
+  constructor(params: IBaseErrorInfo) {
+    super(params);
   }
 }


### PR DESCRIPTION
# Summary

This PR introduces an `AppExceptionFilter` to format the error responses from the app, improving error handling with consistency.

# Details

- Installed the `change-case-all` to format error names into sentences when its necessary.
- Implemented an `AppExceptionFilter` to return errors with the same format, including default values when some properties are not provided by the error received.
- Refactored the `AuthenticationService` and `CognitoService` to be synchronized with the `AppExceptionFilter` flow.

# Evidence

![image](https://github.com/user-attachments/assets/a00d17d2-9499-4d87-817b-1e5c88b03a81)
![image](https://github.com/user-attachments/assets/ab495a2f-5909-4e8d-8254-190ab67c02a0)
![image](https://github.com/user-attachments/assets/99023ab2-ab3a-4048-bf91-30bb5f691502)
