### PR TITLE
feat: Add confirm user flow to AuthenticationModule

### DIFF
--- a/data/util/fixture-loader.ts
+++ b/data/util/fixture-loader.ts
@@ -1,0 +1,51 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { resolve } from 'path';
+import {
+  DataSource,
+  DataSourceOptions,
+  EntityTarget,
+  ObjectLiteral,
+} from 'typeorm';
+import {
+  Builder,
+  Loader,
+  Parser,
+  Resolver,
+  fixturesIterator,
+} from 'typeorm-fixtures-cli/dist';
+
+export const loadFixtures = async (
+  fixturesPath: string,
+  datasourceOptions: DataSourceOptions,
+): Promise<void> => {
+  let dataSource: DataSource | undefined;
+
+  try {
+    dataSource = new DataSource(datasourceOptions);
+
+    await dataSource.initialize();
+    await dataSource.synchronize(true);
+
+    const loader = new Loader();
+    loader.load(resolve(fixturesPath));
+
+    const resolver = new Resolver();
+    const fixtures = resolver.resolve(loader.fixtureConfigs);
+    const builder = new Builder(dataSource, new Parser(), false);
+
+    for (const fixture of fixturesIterator(fixtures)) {
+      const entity = await builder.build(fixture);
+      await dataSource
+        .getRepository(fixture.entity as EntityTarget<ObjectLiteral>)
+        .save(entity);
+    }
+  } finally {
+    if (dataSource) {
+      await dataSource.destroy();
+    }
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "ts-loader": "^9.5.2",
         "ts-node": "^10.9.2",
         "tsconfig-paths": "^4.2.0",
+        "typeorm-fixtures-cli": "^4.1.0",
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.20.0"
       }
@@ -2001,6 +2002,40 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.8.0.tgz",
+      "integrity": "sha512-U9wpuSrJC93jZBxx/Qq2wPjCuYISBueyVUGK7qqdmj7r/nxaxwW8AQDCLeRO7wZnjj94sh3p246cAYjUKuqgfg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
+      }
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -4199,6 +4234,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sideway/address": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/formula": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -4886,7 +4945,7 @@
       "version": "1.11.24",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.11.24.tgz",
       "integrity": "sha512-MaQEIpfcEMzx3VWWopbofKJvaraqmL6HbLlw2bFZ7qYqYw3rkhM0cQVEgyzbHtTWwCwPMFZSC2DUbhlZgrMfLg==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4928,7 +4987,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4945,7 +5003,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4962,7 +5019,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4979,7 +5035,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4996,7 +5051,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5013,7 +5067,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5030,7 +5083,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5047,7 +5099,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5064,7 +5115,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5081,7 +5131,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5095,14 +5144,14 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@swc/types": {
       "version": "0.1.21",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.21.tgz",
       "integrity": "sha512-2YEtj5HJVbKivud9N4bpPBAyZhj4S2Ipe5LkUG94alTpr7in/GU/EARgPAd3BwU+YOmFVJC2+kjqhGRi3r0ZpQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"
@@ -7099,6 +7148,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -8615,6 +8674,35 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chai/node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -8667,6 +8755,19 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
@@ -8762,6 +8863,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cli-progress": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.12.0.tgz",
+      "integrity": "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.3"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/cli-spinners": {
@@ -9430,6 +9544,19 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-extend": {
@@ -10911,6 +11038,16 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -11125,6 +11262,52 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/graphology": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/graphology/-/graphology-0.25.4.tgz",
+      "integrity": "sha512-33g0Ol9nkWdD6ulw687viS8YJQBxqG5LWII6FI6nul0pq6iM2t5EKquOTFDbyTblRB3O9I+7KX4xI8u5ffekAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events": "^3.3.0",
+        "obliterator": "^2.0.2"
+      },
+      "peerDependencies": {
+        "graphology-types": ">=0.24.0"
+      }
+    },
+    "node_modules/graphology-dag": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/graphology-dag/-/graphology-dag-0.3.0.tgz",
+      "integrity": "sha512-dg4JPb+/LDEbDinZIj7ezWzlEXDRokshdpTL8oAuftE9Uy0uTKGOKSmYULY8p3j/vw0HB31Wog9T/kpqprUQpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graphology-utils": "^2.4.1",
+        "mnemonist": "^0.39.0"
+      },
+      "peerDependencies": {
+        "graphology-types": ">=0.19.0"
+      }
+    },
+    "node_modules/graphology-types": {
+      "version": "0.24.8",
+      "resolved": "https://registry.npmjs.org/graphology-types/-/graphology-types-0.24.8.tgz",
+      "integrity": "sha512-hDRKYXa8TsoZHjgEaysSRyPdT6uB78Ci8WnjgbStlQysz7xR52PInxNsmnB7IBOM1BhikxkNyCVEFgmPKnpx3Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/graphology-utils": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/graphology-utils/-/graphology-utils-2.5.2.tgz",
+      "integrity": "sha512-ckHg8MXrXJkOARk56ZaSCM1g1Wihe2d6iTmz1enGOz4W/l831MBCKSayeFQfowgF8wd+PQ4rlch/56Vs/VZLDQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "graphology-types": ">=0.23.0"
+      }
     },
     "node_modules/has-ansi": {
       "version": "2.0.0",
@@ -13094,6 +13277,20 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/joi": {
+      "version": "17.13.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
+      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.5",
+        "@sideway/formula": "^3.0.1",
+        "@sideway/pinpoint": "^2.0.0"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -13645,6 +13842,16 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
     "node_modules/lowercase-keys": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
@@ -13914,6 +14121,16 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/mnemonist": {
+      "version": "0.39.8",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.39.8.tgz",
+      "integrity": "sha512-vyWo2K3fjrUw8YeeZ1zF0fy6Mu59RHokURlld8ymdUPjMlD9EC9ov1/YPqTgqRvUN9nTr3Gqfz29LYAmu0PHPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "obliterator": "^2.0.1"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -14138,6 +14355,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obliterator": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.5.tgz",
+      "integrity": "sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -14173,6 +14397,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/opencollective-postinstall": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "opencollective-postinstall": "index.js"
       }
     },
     "node_modules/optionator": {
@@ -14498,6 +14732,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/peek-readable": {
@@ -17178,6 +17422,148 @@
         }
       }
     },
+    "node_modules/typeorm-fixtures-cli": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/typeorm-fixtures-cli/-/typeorm-fixtures-cli-4.1.0.tgz",
+      "integrity": "sha512-v+3bw741UNr0D1JyZKv42ygtPTZmXevN00Zyvi4p29ChBM1i67I4SltaIKhG8d+XH7KzsGnrKad+drajMX4ZMw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@faker-js/faker": ">=7.4.0",
+        "chai": "^4.2.0",
+        "chalk": "^4.0.0",
+        "class-transformer": "^0.5.0",
+        "cli-progress": "^3.10.0",
+        "ejs": "^3.1.5",
+        "glob": "^8.0.1",
+        "graphology": "^0.25.4",
+        "graphology-dag": "^0.3.0",
+        "joi": "^17.0.0",
+        "js-yaml": "^4.0.0",
+        "lodash": "^4.0.0",
+        "opencollective-postinstall": "^2.0.3",
+        "reflect-metadata": "^0.1.13",
+        "resolve-from": "^5.0.0",
+        "typescript-collections": "^1.3.3",
+        "yargs": "^17.5.1"
+      },
+      "bin": {
+        "fixtures": "dist/cli.js",
+        "fixtures-ts-node-commonjs": "dist/cli-ts-node-commonjs.js",
+        "fixtures-ts-node-esm": "dist/cli-ts-node-esm.js"
+      },
+      "peerDependencies": {
+        "typeorm": "^0.3.0"
+      }
+    },
+    "node_modules/typeorm-fixtures-cli/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/typeorm-fixtures-cli/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typeorm-fixtures-cli/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/typeorm-fixtures-cli/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/typeorm-fixtures-cli/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/typeorm-fixtures-cli/node_modules/reflect-metadata": {
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.14.tgz",
+      "integrity": "sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/typeorm-fixtures-cli/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/typeorm-fixtures-cli/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/typeorm-naming-strategies": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/typeorm-naming-strategies/-/typeorm-naming-strategies-4.1.0.tgz",
@@ -17318,6 +17704,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/typescript-collections": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/typescript-collections/-/typescript-collections-1.3.3.tgz",
+      "integrity": "sha512-7sI4e/bZijOzyURng88oOFZCISQPTHozfE2sUu5AviFYk5QV7fYGb6YiDl+vKjF/pICA354JImBImL9XJWUvdQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/typescript-eslint": {
       "version": "8.32.1",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "ts-loader": "^9.5.2",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
+    "typeorm-fixtures-cli": "^4.1.0",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.20.0"
   },

--- a/src/common/base/application/dto/successful-operation-response.interface.ts
+++ b/src/common/base/application/dto/successful-operation-response.interface.ts
@@ -1,0 +1,4 @@
+export interface ISuccessfulOperationResponse {
+  success: boolean;
+  message: string;
+}

--- a/src/module/iam/authentication/__test__/authentication.e2e.spec.ts
+++ b/src/module/iam/authentication/__test__/authentication.e2e.spec.ts
@@ -3,10 +3,13 @@ import { HttpStatus } from '@nestjs/common';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import request from 'supertest';
 
+import { loadFixtures } from '@data/util/fixture-loader';
+
 import { HttpMethod } from '@common/base/application/enum/http-method.enum';
 import { IAppErrorResponse } from '@common/base/application/exception/app-error-response.interface';
 
 import { setupApp } from '@config/app.config';
+import { datasourceOptions } from '@config/orm.config';
 
 import { SignUpDto } from '@module/iam/authentication/application/dto/sign-up.dto';
 import { PASSWORD_VALIDATION_ERROR } from '@module/iam/authentication/infrastructure/cognito/exception/cognito-exception-messages';
@@ -29,6 +32,10 @@ describe('Authentication Module', () => {
     setupApp(app);
 
     await app.init();
+  });
+
+  beforeEach(async () => {
+    await loadFixtures(`${__dirname}/fixture`, datasourceOptions);
   });
 
   afterEach(() => {

--- a/src/module/iam/authentication/__test__/authentication.e2e.spec.ts
+++ b/src/module/iam/authentication/__test__/authentication.e2e.spec.ts
@@ -11,10 +11,21 @@ import { IAppErrorResponse } from '@common/base/application/exception/app-error-
 import { setupApp } from '@config/app.config';
 import { datasourceOptions } from '@config/orm.config';
 
+import { AUTHENTICATION_NAME } from '@module/iam/authentication/application/domain/authentication.name';
+import { ConfirmUserDto } from '@module/iam/authentication/application/dto/confirm-user.dto';
 import { SignUpDto } from '@module/iam/authentication/application/dto/sign-up.dto';
-import { PASSWORD_VALIDATION_ERROR } from '@module/iam/authentication/infrastructure/cognito/exception/cognito-exception-messages';
+import { USER_ALREADY_CONFIRMED_ERROR } from '@module/iam/authentication/application/exception/authentication-exception-messages';
+import { CodeMismatchException } from '@module/iam/authentication/infrastructure/cognito/exception/code-mismatch.exception';
+import {
+  CODE_MISMATCH_ERROR,
+  EXPIRED_CODE_ERROR,
+  PASSWORD_VALIDATION_ERROR,
+  UNEXPECTED_ERROR_CODE_ERROR,
+} from '@module/iam/authentication/infrastructure/cognito/exception/cognito-exception-messages';
 import { CouldNotSignUpException } from '@module/iam/authentication/infrastructure/cognito/exception/could-not-sign-up.exception';
+import { ExpiredCodeException } from '@module/iam/authentication/infrastructure/cognito/exception/expired-code.exception';
 import { PasswordValidationException } from '@module/iam/authentication/infrastructure/cognito/exception/password-validation.exception';
+import { UnexpectedErrorCodeException } from '@module/iam/authentication/infrastructure/cognito/exception/unexpected-code.exception';
 import { AppRole } from '@module/iam/authorization/domain/app-role.enum';
 import { User } from '@module/iam/user/domain/user.entity';
 
@@ -198,7 +209,7 @@ describe('Authentication Module', () => {
             expect.objectContaining({
               error: expect.objectContaining({
                 detail: 'User already signed up',
-                status: '400',
+                status: HttpStatus.BAD_REQUEST.toString(),
                 source: { pointer: '/api/v1/auth/sign-up' },
                 title: 'Signup Conflict',
               }),
@@ -227,11 +238,226 @@ describe('Authentication Module', () => {
           expect(body as IAppErrorResponse).toMatchObject({
             error: expect.objectContaining({
               detail: expectedError.message,
-              status: '400',
+              status: HttpStatus.BAD_REQUEST.toString(),
               source: { pointer: '/api/v1/auth/sign-up' },
               title: 'Password validation',
             }),
           });
+        });
+    });
+  });
+
+  describe('POST - /auth/confirm-user', () => {
+    it('Should confirm a user when provided a correct confirmation code', async () => {
+      const successResponse = {
+        success: true,
+        message: 'User successfully confirmed',
+      };
+      identityProviderServiceMock.confirmUser.mockResolvedValueOnce(
+        successResponse,
+      );
+      const confirmUserDto: ConfirmUserDto = {
+        email: 'test_confirm@email.co',
+        code: '123456',
+      };
+
+      await request(app.getHttpServer())
+        .post('/api/v1/auth/confirm-user')
+        .send(confirmUserDto)
+        .expect(HttpStatus.OK)
+        .then(({ body }: { body }) => {
+          const expectedResponse = expect.objectContaining({
+            data: expect.objectContaining({
+              type: AUTHENTICATION_NAME,
+              attributes: expect.objectContaining({
+                ...successResponse,
+              }),
+            }),
+            links: expect.objectContaining({
+              self: expect.objectContaining({
+                href: expect.stringContaining('/auth/confirm-user'),
+                rel: 'self',
+                method: HttpMethod.GET,
+              }),
+            }),
+          });
+
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should send a UserAlreadyConfirmed error when trying to confirm a confirmed user', async () => {
+      const email = 'test_admin@email.co';
+      const confirmUserDto: ConfirmUserDto = {
+        email,
+        code: '123456',
+      };
+
+      await request(app.getHttpServer())
+        .post('/api/v1/auth/confirm-user')
+        .send(confirmUserDto)
+        .expect(HttpStatus.BAD_REQUEST)
+        .then(({ body }: { body: IAppErrorResponse }) => {
+          const expectedError: IAppErrorResponse = {
+            error: {
+              status: HttpStatus.BAD_REQUEST.toString(),
+              source: {
+                pointer: '/api/v1/auth/confirm-user',
+              },
+              title: 'User already confirmed',
+              detail: USER_ALREADY_CONFIRMED_ERROR,
+            },
+          };
+          expect(body).toEqual(expectedError);
+        });
+    });
+
+    it('Should send an UserNotFound error when provided an email that does not exist', async () => {
+      const email = 'not-existing@email.co';
+      const confirmUserDto: ConfirmUserDto = {
+        email,
+        code: '123456',
+      };
+      await request(app.getHttpServer())
+        .post('/api/v1/auth/confirm-user')
+        .send(confirmUserDto)
+        .expect(HttpStatus.NOT_FOUND)
+        .then(({ body }: { body: IAppErrorResponse }) => {
+          const expectedError: IAppErrorResponse = {
+            error: {
+              status: HttpStatus.NOT_FOUND.toString(),
+              source: {
+                pointer: '/api/v1/auth/confirm-user',
+              },
+              title: 'Email not found',
+              detail: `User with email ${email} was not found`,
+            },
+          };
+
+          expect(body).toEqual(expectedError);
+        });
+    });
+
+    it('Should send a CodeMismatch error when provided an incorrect code', async () => {
+      const codeMismatchError = new CodeMismatchException({
+        message: CODE_MISMATCH_ERROR,
+      });
+
+      identityProviderServiceMock.confirmUser.mockImplementationOnce(
+        (email: string, code: string) => {
+          if (code === '100000') {
+            throw codeMismatchError;
+          }
+          return Promise.resolve({
+            success: true,
+            message: 'User successfully confirmed',
+          });
+        },
+      );
+
+      const confirmUserDto: ConfirmUserDto = {
+        email: 'test_confirm@email.co',
+        code: '100000',
+      };
+
+      await request(app.getHttpServer())
+        .post('/api/v1/auth/confirm-user')
+        .send(confirmUserDto)
+        .expect(HttpStatus.UNAUTHORIZED)
+        .then(({ body }: { body: IAppErrorResponse }) => {
+          const expectedResponse: IAppErrorResponse = {
+            error: {
+              status: HttpStatus.UNAUTHORIZED.toString(),
+              source: {
+                pointer: '/api/v1/auth/confirm-user',
+              },
+              title: 'Code mismatch',
+              detail: CODE_MISMATCH_ERROR,
+            },
+          };
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should send an ExpiredCode error when provided an expired code', async () => {
+      const expiredCodeError = new ExpiredCodeException({
+        message: EXPIRED_CODE_ERROR,
+      });
+
+      identityProviderServiceMock.confirmUser.mockImplementationOnce(
+        (email: string, code: string) => {
+          if (code === '999999') {
+            throw expiredCodeError;
+          }
+          return Promise.resolve({
+            success: true,
+            message: 'User successfully confirmed',
+          });
+        },
+      );
+
+      const confirmUserDto: ConfirmUserDto = {
+        email: 'test_confirm@email.co',
+        code: '999999',
+      };
+
+      await request(app.getHttpServer())
+        .post('/api/v1/auth/confirm-user')
+        .send(confirmUserDto)
+        .expect(HttpStatus.BAD_REQUEST)
+        .then(({ body }: { body: IAppErrorResponse }) => {
+          const expectedResponse: IAppErrorResponse = {
+            error: {
+              status: HttpStatus.BAD_REQUEST.toString(),
+              source: {
+                pointer: '/api/v1/auth/confirm-user',
+              },
+              title: 'Expired code',
+              detail: EXPIRED_CODE_ERROR,
+            },
+          };
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should respond with an UnexpectedErrorCodeException when an unexpected error occurs', async () => {
+      const unexpectedError = new UnexpectedErrorCodeException({
+        message: UNEXPECTED_ERROR_CODE_ERROR,
+      });
+
+      identityProviderServiceMock.confirmUser.mockImplementationOnce(
+        (email: string, code: string) => {
+          if (code === '555555') {
+            throw unexpectedError;
+          }
+          return Promise.resolve({
+            success: true,
+            message: 'User successfully confirmed',
+          });
+        },
+      );
+
+      const confirmUserDto: ConfirmUserDto = {
+        email: 'test_confirm@email.co',
+        code: '555555',
+      };
+
+      await request(app.getHttpServer())
+        .post('/api/v1/auth/confirm-user')
+        .send(confirmUserDto)
+        .expect(HttpStatus.INTERNAL_SERVER_ERROR)
+        .then(({ body }: { body: IAppErrorResponse }) => {
+          const expectedResponse: IAppErrorResponse = {
+            error: {
+              status: HttpStatus.INTERNAL_SERVER_ERROR.toString(),
+              source: {
+                pointer: '/api/v1/auth/confirm-user',
+              },
+              title: 'Unexpected error code',
+              detail: UNEXPECTED_ERROR_CODE_ERROR,
+            },
+          };
+          expect(body).toEqual(expectedResponse);
         });
     });
   });

--- a/src/module/iam/authentication/__test__/fixture/User.yml
+++ b/src/module/iam/authentication/__test__/fixture/User.yml
@@ -1,0 +1,16 @@
+entity: User
+items:
+  admin-user:
+    email: 'test_admin@email.co'
+    firstName: test_admin
+    lastName: test_admin
+    externalId: '00000000-0000-0000-0000-00000000000X'
+    roles: admin
+    isVerified: true
+  confirm-user:
+    email: 'test_confirm@email.co'
+    firstName: test_confirm
+    lastName: email
+    externalId: '00000000-0000-0000-0000-00000000000Y'
+    role: admin
+    isVerified: false

--- a/src/module/iam/authentication/application/domain/authentication.name.ts
+++ b/src/module/iam/authentication/application/domain/authentication.name.ts
@@ -1,0 +1,1 @@
+export const AUTHENTICATION_NAME = 'authentication';

--- a/src/module/iam/authentication/application/dto/confirm-user.dto.ts
+++ b/src/module/iam/authentication/application/dto/confirm-user.dto.ts
@@ -1,0 +1,11 @@
+import { IsEmail, IsNotEmpty, IsNumberString } from 'class-validator';
+
+export class ConfirmUserDto {
+  @IsEmail()
+  @IsNotEmpty()
+  email: string;
+
+  @IsNumberString()
+  @IsNotEmpty()
+  code: string;
+}

--- a/src/module/iam/authentication/application/exception/authentication-exception-messages.ts
+++ b/src/module/iam/authentication/application/exception/authentication-exception-messages.ts
@@ -1,2 +1,3 @@
 export const USER_ALREADY_SIGNED_UP_ERROR = 'User already signed up';
 export const SIGNUP_CONFLICT_TITLE = 'Signup Conflict';
+export const USER_ALREADY_CONFIRMED_ERROR = 'User is already confirmed';

--- a/src/module/iam/authentication/application/exception/user-already-confirmed.exception.ts
+++ b/src/module/iam/authentication/application/exception/user-already-confirmed.exception.ts
@@ -1,0 +1,9 @@
+import { BadRequestException } from '@nestjs/common';
+
+import { IBaseErrorInfo } from '@common/base/application/exception/app-error-response.interface';
+
+export class UserAlreadyConfirmed extends BadRequestException {
+  constructor(params: IBaseErrorInfo) {
+    super(params);
+  }
+}

--- a/src/module/iam/authentication/application/service/identity-provider.service.interface.ts
+++ b/src/module/iam/authentication/application/service/identity-provider.service.interface.ts
@@ -1,7 +1,13 @@
+import { ISuccessfulOperationResponse } from '@common/base/application/dto/successful-operation-response.interface';
+
 import { ISignUpResponse } from '@module/iam/authentication/application/dto/sign-up-response.interface';
 
 export const IDENTITY_PROVIDER_SERVICE_KEY = 'identity_provider_service';
 
 export interface IIdentityProviderService {
   signUp(email: string, password: string): Promise<ISignUpResponse>;
+  confirmUser(
+    email: string,
+    code: string,
+  ): Promise<ISuccessfulOperationResponse>;
 }

--- a/src/module/iam/authentication/infrastructure/cognito/exception/code-mismatch.exception.ts
+++ b/src/module/iam/authentication/infrastructure/cognito/exception/code-mismatch.exception.ts
@@ -1,0 +1,9 @@
+import { UnauthorizedException } from '@nestjs/common';
+
+import { IBaseErrorInfo } from '@common/base/application/exception/app-error-response.interface';
+
+export class CodeMismatchException extends UnauthorizedException {
+  constructor(params: IBaseErrorInfo) {
+    super(params);
+  }
+}

--- a/src/module/iam/authentication/infrastructure/cognito/exception/cognito-exception-messages.ts
+++ b/src/module/iam/authentication/infrastructure/cognito/exception/cognito-exception-messages.ts
@@ -1,2 +1,6 @@
 export const PASSWORD_VALIDATION_ERROR =
   'Password must have at least 8 characters, one uppercase, one lowercase, one number and one symbol';
+export const UNEXPECTED_ERROR_CODE_ERROR = 'Unexpected error code';
+export const CODE_MISMATCH_ERROR = 'Incorrect confirmation code';
+export const EXPIRED_CODE_ERROR =
+  'Confirmation code already expired. Request a new one and try again';

--- a/src/module/iam/authentication/infrastructure/cognito/exception/expired-code.exception.ts
+++ b/src/module/iam/authentication/infrastructure/cognito/exception/expired-code.exception.ts
@@ -1,0 +1,9 @@
+import { BadRequestException } from '@nestjs/common';
+
+import { IBaseErrorInfo } from '@common/base/application/exception/app-error-response.interface';
+
+export class ExpiredCodeException extends BadRequestException {
+  constructor(params: IBaseErrorInfo) {
+    super(params);
+  }
+}

--- a/src/module/iam/authentication/infrastructure/cognito/exception/unexpected-code.exception.ts
+++ b/src/module/iam/authentication/infrastructure/cognito/exception/unexpected-code.exception.ts
@@ -1,0 +1,9 @@
+import { InternalServerErrorException } from '@nestjs/common';
+
+import { IBaseErrorInfo } from '@common/base/application/exception/app-error-response.interface';
+
+export class UnexpectedErrorCodeException extends InternalServerErrorException {
+  constructor(params: IBaseErrorInfo) {
+    super(params);
+  }
+}

--- a/src/module/iam/authentication/interface/authentication.controller.ts
+++ b/src/module/iam/authentication/interface/authentication.controller.ts
@@ -1,7 +1,9 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
 
 import { SerializedResponseDto } from '@common/base/application/dto/serialized-response.dto';
+import { ISuccessfulOperationResponse } from '@common/base/application/dto/successful-operation-response.interface';
 
+import { ConfirmUserDto } from '@module/iam/authentication/application/dto/confirm-user.dto';
 import { SignUpDto } from '@module/iam/authentication/application/dto/sign-up.dto';
 import { AuthenticationService } from '@module/iam/authentication/application/service/authentication.service';
 import { UserResponseDto } from '@module/iam/user/application/dto/user-response.dto';
@@ -15,5 +17,13 @@ export class AuthenticationController {
     @Body() signUpDto: SignUpDto,
   ): Promise<SerializedResponseDto<UserResponseDto>> {
     return this.authenticationService.handleSignUp(signUpDto);
+  }
+
+  @Post('confirm-user')
+  @HttpCode(HttpStatus.OK)
+  async confirmUser(
+    @Body() confirmUserDto: ConfirmUserDto,
+  ): Promise<SerializedResponseDto<ISuccessfulOperationResponse>> {
+    return this.authenticationService.handleConfirmUser(confirmUserDto);
   }
 }

--- a/src/module/iam/user/infrastructure/database/exception/email-not-found.exception.ts
+++ b/src/module/iam/user/infrastructure/database/exception/email-not-found.exception.ts
@@ -1,7 +1,9 @@
 import { NotFoundException } from '@nestjs/common';
 
+import { IBaseErrorInfo } from '@common/base/application/exception/app-error-response.interface';
+
 export class EmailNotFoundException extends NotFoundException {
-  constructor(message: string) {
-    super(message);
+  constructor(params: IBaseErrorInfo) {
+    super(params);
   }
 }

--- a/src/module/iam/user/infrastructure/database/exception/user-not-found.exception.ts
+++ b/src/module/iam/user/infrastructure/database/exception/user-not-found.exception.ts
@@ -1,7 +1,9 @@
 import { NotFoundException } from '@nestjs/common';
 
+import { IBaseErrorInfo } from '@common/base/application/exception/app-error-response.interface';
+
 export class UserNotFoundException extends NotFoundException {
-  constructor(message: string) {
-    super(message);
+  constructor(params: IBaseErrorInfo) {
+    super(params);
   }
 }

--- a/src/module/iam/user/infrastructure/database/user.postgres.repository.ts
+++ b/src/module/iam/user/infrastructure/database/user.postgres.repository.ts
@@ -56,9 +56,9 @@ export class UserPostgresRepository implements IUserRepository {
     });
 
     if (!user) {
-      throw new EmailNotFoundException(
-        `User with email ${email} was not found`,
-      );
+      throw new EmailNotFoundException({
+        message: `User with email ${email} was not found`,
+      });
     }
 
     return user;
@@ -78,7 +78,9 @@ export class UserPostgresRepository implements IUserRepository {
     });
 
     if (!userToUpdate) {
-      throw new UserNotFoundException(`User with ID ${id} was not found`);
+      throw new UserNotFoundException({
+        message: `User with ID ${id} was not found`,
+      });
     }
 
     return this.repository.save(userToUpdate);

--- a/src/test/test.module.bootstrapper.ts
+++ b/src/test/test.module.bootstrapper.ts
@@ -5,6 +5,7 @@ import { IDENTITY_PROVIDER_SERVICE_KEY } from '@module/iam/authentication/applic
 
 export const identityProviderServiceMock = {
   signUp: jest.fn(),
+  confirmUser: jest.fn(),
 };
 
 export const testModuleBootstrapper = (): Promise<TestingModule> => {


### PR DESCRIPTION
# Summary

This PR introduces the flow to confirm users on cognito and postgres database. Also, configures tests so fixtures can be loaded before tests,  making it easier to set up test scenarios.

# Details

- Installed a dependency for loading fixtures on TypeORM.
- Added config for loading fixtures before each authentication e2e test.
- Implemented a `confirmUser` method to the `CognitoService`.
-  Added a `confirm-user` route flow to the `AuthenticationModule`.
- Refactored error handling in the `UserPostgresRepository` to use the common error parameters across the application.