### PR TITLE
feat: Add sign in mechanism to AuthenticationModule

### DIFF
--- a/src/module/app/application/interceptor/response-formatter.interceptor.ts
+++ b/src/module/app/application/interceptor/response-formatter.interceptor.ts
@@ -52,7 +52,7 @@ export class ResponseFormatterInterceptor implements NestInterceptor {
             currentRequestUrl,
             currentRequestMethod as HttpMethod,
             baseAppUrl,
-            linksMetadata,
+            linksMetadata ?? [],
           );
         }
       }),

--- a/src/module/iam/authentication/__test__/authentication.e2e.spec.ts
+++ b/src/module/iam/authentication/__test__/authentication.e2e.spec.ts
@@ -12,6 +12,8 @@ import { setupApp } from '@config/app.config';
 import { datasourceOptions } from '@config/orm.config';
 
 import { ConfirmUserDto } from '@module/iam/authentication/application/dto/confirm-user.dto';
+import { ISignInResponse } from '@module/iam/authentication/application/dto/sign-in-response.dto';
+import { SignInDto } from '@module/iam/authentication/application/dto/sign-in.dto';
 import { SignUpDto } from '@module/iam/authentication/application/dto/sign-up.dto';
 import { USER_ALREADY_CONFIRMED_ERROR } from '@module/iam/authentication/application/exception/authentication-exception-messages';
 import { AUTHENTICATION_NAME } from '@module/iam/authentication/domain/authentication.name';
@@ -19,13 +21,19 @@ import { CodeMismatchException } from '@module/iam/authentication/infrastructure
 import {
   CODE_MISMATCH_ERROR,
   EXPIRED_CODE_ERROR,
+  INVALID_PASSWORD_ERROR,
+  NEW_PASSWORD_REQUIRED_ERROR,
   PASSWORD_VALIDATION_ERROR,
   UNEXPECTED_ERROR_CODE_ERROR,
+  USER_NOT_CONFIRMED_ERROR,
 } from '@module/iam/authentication/infrastructure/cognito/exception/cognito-exception-messages';
 import { CouldNotSignUpException } from '@module/iam/authentication/infrastructure/cognito/exception/could-not-sign-up.exception';
 import { ExpiredCodeException } from '@module/iam/authentication/infrastructure/cognito/exception/expired-code.exception';
+import { InvalidPasswordException } from '@module/iam/authentication/infrastructure/cognito/exception/invalid-password.exception';
+import { NewPasswordRequiredException } from '@module/iam/authentication/infrastructure/cognito/exception/new-password-required.exception';
 import { PasswordValidationException } from '@module/iam/authentication/infrastructure/cognito/exception/password-validation.exception';
 import { UnexpectedErrorCodeException } from '@module/iam/authentication/infrastructure/cognito/exception/unexpected-code.exception';
+import { UserNotConfirmedException } from '@module/iam/authentication/infrastructure/cognito/exception/user-not-confirmed.exception';
 import { AppRole } from '@module/iam/authorization/domain/app-role.enum';
 import { User } from '@module/iam/user/domain/user.entity';
 
@@ -493,6 +501,181 @@ describe('Authentication Module', () => {
             },
           };
           expect(body).toEqual(expectedResponse);
+        });
+    });
+  });
+
+  describe('POST - /auth/sign-in', () => {
+    it('Should allow users to sign in when provided a correct email and password', async () => {
+      const serviceResponse: ISignInResponse = {
+        accessToken: 'accessToken',
+        refreshToken: 'refreshToken',
+      };
+      identityProviderServiceMock.signIn.mockResolvedValueOnce(serviceResponse);
+
+      const signInDto: SignInDto = {
+        email: 'test_admin@email.co',
+        password: 'password',
+      };
+
+      await request(app.getHttpServer())
+        .post('/api/v1/auth/sign-in')
+        .send(signInDto)
+        .expect(HttpStatus.OK)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            data: expect.objectContaining({
+              type: AUTHENTICATION_NAME,
+              attributes: expect.objectContaining({
+                ...serviceResponse,
+              }),
+            }),
+            links: expect.arrayContaining([
+              expect.objectContaining({
+                href: expect.stringContaining('/auth/sign-in'),
+                rel: 'self',
+                method: HttpMethod.POST,
+              }),
+            ]),
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should send an UserNotFound error when provided an invalid email', async () => {
+      const signInDto: SignInDto = {
+        email: 'not-existing@email.co',
+        password: 'fakePassword',
+      };
+
+      await request(app.getHttpServer())
+        .post('/api/v1/auth/sign-in')
+        .send(signInDto)
+        .expect(HttpStatus.NOT_FOUND)
+        .then(({ body }: { body: IAppErrorResponse }) => {
+          expect(body).toEqual({
+            error: expect.objectContaining({
+              status: HttpStatus.NOT_FOUND.toString(),
+              source: expect.objectContaining({
+                pointer: '/api/v1/auth/sign-in',
+              }),
+              title: 'Email not found',
+              detail: `User with email ${signInDto.email} was not found`,
+            }),
+          });
+        });
+    });
+
+    it('Should send an InvalidPassword error provided a valid user but invalid password', async () => {
+      const error = new InvalidPasswordException({
+        message: INVALID_PASSWORD_ERROR,
+      });
+      const signInDto: SignInDto = {
+        email: 'test_admin@email.co',
+        password: 'fakePassword',
+      };
+
+      identityProviderServiceMock.signIn.mockRejectedValueOnce(error);
+
+      await request(app.getHttpServer())
+        .post('/api/v1/auth/sign-in')
+        .send(signInDto)
+        .expect(HttpStatus.UNAUTHORIZED)
+        .then(({ body }: { body: IAppErrorResponse }) => {
+          expect(body).toEqual({
+            error: expect.objectContaining({
+              status: HttpStatus.UNAUTHORIZED.toString(),
+              source: expect.objectContaining({
+                pointer: '/api/v1/auth/sign-in',
+              }),
+              title: 'Invalid password',
+              detail: error.message,
+            }),
+          });
+        });
+    });
+
+    it('Should send an UnconfirmedUser error when user is not confirmed', async () => {
+      const error = new UserNotConfirmedException({
+        message: USER_NOT_CONFIRMED_ERROR,
+      });
+      identityProviderServiceMock.signIn.mockRejectedValueOnce(error);
+      const signInDto: SignInDto = {
+        email: 'test_admin@email.co',
+        password: 'password',
+      };
+
+      await request(app.getHttpServer())
+        .post('/api/v1/auth/sign-in')
+        .send(signInDto)
+        .expect(HttpStatus.FORBIDDEN)
+        .then(({ body }: { body: IAppErrorResponse }) => {
+          expect(body).toEqual({
+            error: expect.objectContaining({
+              status: HttpStatus.FORBIDDEN.toString(),
+              source: expect.objectContaining({
+                pointer: '/api/v1/auth/sign-in',
+              }),
+              title: 'User not confirmed',
+              detail: error.message,
+            }),
+          });
+        });
+    });
+
+    it('Should send an UnexpectedErrorCode error when receiving uncovered error codes', async () => {
+      const error = new UnexpectedErrorCodeException({
+        message: UNEXPECTED_ERROR_CODE_ERROR,
+      });
+      identityProviderServiceMock.signIn.mockRejectedValueOnce(error);
+      const signInDto: SignInDto = {
+        email: 'test_admin@email.co',
+        password: 'password',
+      };
+
+      await request(app.getHttpServer())
+        .post('/api/v1/auth/sign-in')
+        .send(signInDto)
+        .expect(HttpStatus.INTERNAL_SERVER_ERROR)
+        .then(({ body }: { body: IAppErrorResponse }) => {
+          expect(body).toEqual({
+            error: expect.objectContaining({
+              status: HttpStatus.INTERNAL_SERVER_ERROR.toString(),
+              source: expect.objectContaining({
+                pointer: '/api/v1/auth/sign-in',
+              }),
+              title: 'Unexpected error code',
+              detail: error.message,
+            }),
+          });
+        });
+    });
+
+    it('Should send a NewPasswordRequired error when user needs to update their password', async () => {
+      const error = new NewPasswordRequiredException({
+        message: NEW_PASSWORD_REQUIRED_ERROR,
+      });
+      identityProviderServiceMock.signIn.mockRejectedValueOnce(error);
+      const signInDto: SignInDto = {
+        email: 'test_admin@email.co',
+        password: 'password',
+      };
+
+      await request(app.getHttpServer())
+        .post('/api/v1/auth/sign-in')
+        .send(signInDto)
+        .expect(HttpStatus.UNAUTHORIZED)
+        .then(({ body }: { body: IAppErrorResponse }) => {
+          expect(body).toEqual({
+            error: expect.objectContaining({
+              status: HttpStatus.UNAUTHORIZED.toString(),
+              source: expect.objectContaining({
+                pointer: '/api/v1/auth/sign-in',
+              }),
+              title: 'New password required',
+              detail: error.message,
+            }),
+          });
         });
     });
   });

--- a/src/module/iam/authentication/application/dto/sign-in-response.dto.ts
+++ b/src/module/iam/authentication/application/dto/sign-in-response.dto.ts
@@ -1,0 +1,13 @@
+import { BaseResponseDto } from '@common/base/application/dto/base.response.dto';
+
+export interface ISignInResponse {
+  accessToken: string;
+  refreshToken: string;
+}
+export class SignInResponseDto
+  extends BaseResponseDto
+  implements ISignInResponse
+{
+  accessToken: string;
+  refreshToken: string;
+}

--- a/src/module/iam/authentication/application/dto/sign-in.dto.ts
+++ b/src/module/iam/authentication/application/dto/sign-in.dto.ts
@@ -1,0 +1,13 @@
+import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
+
+import { IDto } from '@common/base/application/dto/dto.interface';
+
+export class SignInDto implements IDto {
+  @IsEmail()
+  @IsNotEmpty()
+  email: string;
+
+  @IsString()
+  @IsNotEmpty()
+  password: string;
+}

--- a/src/module/iam/authentication/application/service/authentication.service.ts
+++ b/src/module/iam/authentication/application/service/authentication.service.ts
@@ -3,6 +3,8 @@ import { Inject, Injectable } from '@nestjs/common';
 import { ISuccessfulOperationResponse } from '@common/base/application/dto/successful-operation-response.interface';
 
 import { ConfirmUserDto } from '@module/iam/authentication/application/dto/confirm-user.dto';
+import { SignInResponseDto } from '@module/iam/authentication/application/dto/sign-in-response.dto';
+import { SignInDto } from '@module/iam/authentication/application/dto/sign-in.dto';
 import { SignUpDto } from '@module/iam/authentication/application/dto/sign-up.dto';
 import {
   SIGNUP_CONFLICT_TITLE,
@@ -65,6 +67,21 @@ export class AuthenticationService {
       message: USER_ALREADY_SIGNED_UP_ERROR,
       title: SIGNUP_CONFLICT_TITLE,
     });
+  }
+
+  async handleSignIn(signInDto: SignInDto): Promise<SignInResponseDto> {
+    const { email, password } = signInDto;
+    const existingUser = await this.userRepository.getOneByEmailOrFail(email);
+
+    const response = await this.identityProviderService.signIn(
+      existingUser.email,
+      password,
+    );
+
+    return {
+      ...response,
+      type: AUTHENTICATION_NAME,
+    };
   }
 
   async handleConfirmUser(

--- a/src/module/iam/authentication/application/service/identity-provider.service.interface.ts
+++ b/src/module/iam/authentication/application/service/identity-provider.service.interface.ts
@@ -1,5 +1,6 @@
 import { ISuccessfulOperationResponse } from '@common/base/application/dto/successful-operation-response.interface';
 
+import { ISignInResponse } from '@module/iam/authentication/application/dto/sign-in-response.dto';
 import { ISignUpResponse } from '@module/iam/authentication/application/dto/sign-up-response.interface';
 
 export const IDENTITY_PROVIDER_SERVICE_KEY = 'identity_provider_service';
@@ -10,4 +11,5 @@ export interface IIdentityProviderService {
     email: string,
     code: string,
   ): Promise<ISuccessfulOperationResponse>;
+  signIn(email: string, password: string): Promise<ISignInResponse>;
 }

--- a/src/module/iam/authentication/infrastructure/cognito/exception/cognito-exception-messages.ts
+++ b/src/module/iam/authentication/infrastructure/cognito/exception/cognito-exception-messages.ts
@@ -4,3 +4,8 @@ export const UNEXPECTED_ERROR_CODE_ERROR = 'Unexpected error code';
 export const CODE_MISMATCH_ERROR = 'Incorrect confirmation code';
 export const EXPIRED_CODE_ERROR =
   'Confirmation code already expired. Request a new one and try again';
+export const INVALID_PASSWORD_ERROR = 'Invalid username or password';
+export const USER_NOT_CONFIRMED_ERROR =
+  'User account not confirmed. Please confirm your account then try again';
+export const NEW_PASSWORD_REQUIRED_ERROR =
+  'User must provide new password in order to complete authentication';

--- a/src/module/iam/authentication/infrastructure/cognito/exception/invalid-password.exception.ts
+++ b/src/module/iam/authentication/infrastructure/cognito/exception/invalid-password.exception.ts
@@ -1,0 +1,9 @@
+import { UnauthorizedException } from '@nestjs/common';
+
+import { IBaseErrorInfo } from '@common/base/application/exception/app-error-response.interface';
+
+export class InvalidPasswordException extends UnauthorizedException {
+  constructor(params: IBaseErrorInfo) {
+    super(params);
+  }
+}

--- a/src/module/iam/authentication/infrastructure/cognito/exception/new-password-required.exception.ts
+++ b/src/module/iam/authentication/infrastructure/cognito/exception/new-password-required.exception.ts
@@ -1,0 +1,9 @@
+import { UnauthorizedException } from '@nestjs/common';
+
+import { IBaseErrorInfo } from '@common/base/application/exception/app-error-response.interface';
+
+export class NewPasswordRequiredException extends UnauthorizedException {
+  constructor(params: IBaseErrorInfo) {
+    super(params);
+  }
+}

--- a/src/module/iam/authentication/infrastructure/cognito/exception/user-not-confirmed.exception.ts
+++ b/src/module/iam/authentication/infrastructure/cognito/exception/user-not-confirmed.exception.ts
@@ -1,0 +1,9 @@
+import { ForbiddenException } from '@nestjs/common';
+
+import { IBaseErrorInfo } from '@common/base/application/exception/app-error-response.interface';
+
+export class UserNotConfirmedException extends ForbiddenException {
+  constructor(params: IBaseErrorInfo) {
+    super(params);
+  }
+}

--- a/src/module/iam/authentication/interface/authentication.controller.ts
+++ b/src/module/iam/authentication/interface/authentication.controller.ts
@@ -5,6 +5,8 @@ import { HttpMethod } from '@common/base/application/enum/http-method.enum';
 import { Hypermedia } from '@common/base/infrastructure/decorator/hypermedia.decorator';
 
 import { ConfirmUserDto } from '@module/iam/authentication/application/dto/confirm-user.dto';
+import { SignInResponseDto } from '@module/iam/authentication/application/dto/sign-in-response.dto';
+import { SignInDto } from '@module/iam/authentication/application/dto/sign-in.dto';
 import { SignUpDto } from '@module/iam/authentication/application/dto/sign-up.dto';
 import { AuthenticationService } from '@module/iam/authentication/application/service/authentication.service';
 import { UserResponseDto } from '@module/iam/user/application/dto/user-response.dto';
@@ -28,6 +30,12 @@ export class AuthenticationController {
   ])
   async handleSignUp(@Body() signUpDto: SignUpDto): Promise<UserResponseDto> {
     return this.authenticationService.handleSignUp(signUpDto);
+  }
+
+  @Post('sign-in')
+  @HttpCode(HttpStatus.OK)
+  async handleSignIn(@Body() signInDto: SignInDto): Promise<SignInResponseDto> {
+    return this.authenticationService.handleSignIn(signInDto);
   }
 
   @Post('confirm-user')

--- a/src/test/test.module.bootstrapper.ts
+++ b/src/test/test.module.bootstrapper.ts
@@ -6,6 +6,7 @@ import { IDENTITY_PROVIDER_SERVICE_KEY } from '@module/iam/authentication/applic
 export const identityProviderServiceMock = {
   signUp: jest.fn(),
   confirmUser: jest.fn(),
+  signIn: jest.fn(),
 };
 
 export const testModuleBootstrapper = (): Promise<TestingModule> => {


### PR DESCRIPTION
# Summary

This PR introduces a mechanism for the sign in flow on the `AuthenticationModule`.

# Details
- Updated the generic `IIdentityProviderService` interface with `signIn` method.
- Created Dtos for validating signIn request and responses.
- Updated the `CognitoService` with a `signIn` method that handles success and failure paths.
- Implemented a `signIn` mechanims to the `AuthenticationModule` using the new method from the `CognitoService`.
- Fixed a bug that caused errors when trying to format a route handler response with empty `Hypermedia` decorator.