### PR TITLE
feat: Add forgot password mechanism to AuthenticationModule

### DIFF
--- a/src/module/iam/authentication/application/dto/forgot-password.dto.ts
+++ b/src/module/iam/authentication/application/dto/forgot-password.dto.ts
@@ -1,0 +1,6 @@
+import { IsNotEmpty } from 'class-validator';
+
+export class ForgotPasswordDto {
+  @IsNotEmpty()
+  email: string;
+}

--- a/src/module/iam/authentication/application/service/authentication.service.ts
+++ b/src/module/iam/authentication/application/service/authentication.service.ts
@@ -3,6 +3,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { ISuccessfulOperationResponse } from '@common/base/application/dto/successful-operation-response.interface';
 
 import { ConfirmUserDto } from '@module/iam/authentication/application/dto/confirm-user.dto';
+import { ForgotPasswordDto } from '@module/iam/authentication/application/dto/forgot-password.dto';
 import { SignInResponseDto } from '@module/iam/authentication/application/dto/sign-in-response.dto';
 import { SignInDto } from '@module/iam/authentication/application/dto/sign-in.dto';
 import { SignUpDto } from '@module/iam/authentication/application/dto/sign-up.dto';
@@ -107,6 +108,22 @@ export class AuthenticationService {
 
     return {
       ...confirmUserResponse,
+      type: AUTHENTICATION_NAME,
+    };
+  }
+
+  async handleForgotPassword(
+    forgotPasswordDto: ForgotPasswordDto,
+  ): Promise<ISuccessfulOperationResponse> {
+    const { email } = forgotPasswordDto;
+    const existingUser = await this.userRepository.getOneByEmailOrFail(email);
+
+    const response = await this.identityProviderService.forgotPassword(
+      existingUser.email,
+    );
+
+    return {
+      ...response,
       type: AUTHENTICATION_NAME,
     };
   }

--- a/src/module/iam/authentication/application/service/identity-provider.service.interface.ts
+++ b/src/module/iam/authentication/application/service/identity-provider.service.interface.ts
@@ -12,4 +12,5 @@ export interface IIdentityProviderService {
     code: string,
   ): Promise<ISuccessfulOperationResponse>;
   signIn(email: string, password: string): Promise<ISignInResponse>;
+  forgotPassword(email: string): Promise<ISuccessfulOperationResponse>;
 }

--- a/src/module/iam/authentication/infrastructure/cognito/cognito.service.ts
+++ b/src/module/iam/authentication/infrastructure/cognito/cognito.service.ts
@@ -2,6 +2,7 @@ import {
   AuthFlowType,
   CognitoIdentityProviderClient,
   ConfirmSignUpCommand,
+  ForgotPasswordCommand,
   InitiateAuthCommand,
   InitiateAuthCommandInput,
   SignUpCommand,
@@ -147,6 +148,26 @@ export class CognitoService implements IIdentityProviderService {
             message: `${UNEXPECTED_ERROR_CODE_ERROR} - ${(error as Error).name}`,
           });
       }
+    }
+  }
+
+  async forgotPassword(email: string): Promise<ISuccessfulOperationResponse> {
+    try {
+      const command = new ForgotPasswordCommand({
+        ClientId: this.clientId,
+        Username: email,
+      });
+
+      await this.client.send(command);
+
+      return {
+        success: true,
+        message: 'Password reset instructions have been sent',
+      };
+    } catch (error) {
+      throw new UnexpectedErrorCodeException({
+        message: `${UNEXPECTED_ERROR_CODE_ERROR} - ${(error as Error).name}`,
+      });
     }
   }
 }

--- a/src/module/iam/authentication/interface/authentication.controller.ts
+++ b/src/module/iam/authentication/interface/authentication.controller.ts
@@ -5,6 +5,7 @@ import { HttpMethod } from '@common/base/application/enum/http-method.enum';
 import { Hypermedia } from '@common/base/infrastructure/decorator/hypermedia.decorator';
 
 import { ConfirmUserDto } from '@module/iam/authentication/application/dto/confirm-user.dto';
+import { ForgotPasswordDto } from '@module/iam/authentication/application/dto/forgot-password.dto';
 import { SignInResponseDto } from '@module/iam/authentication/application/dto/sign-in-response.dto';
 import { SignInDto } from '@module/iam/authentication/application/dto/sign-in.dto';
 import { SignUpDto } from '@module/iam/authentication/application/dto/sign-up.dto';
@@ -51,5 +52,20 @@ export class AuthenticationController {
     @Body() confirmUserDto: ConfirmUserDto,
   ): Promise<ISuccessfulOperationResponse> {
     return this.authenticationService.handleConfirmUser(confirmUserDto);
+  }
+
+  @Post('forgot-password')
+  @Hypermedia([
+    {
+      rel: 'confirm-password',
+      endpoint: '/auth/confirm-password',
+      method: HttpMethod.POST,
+    },
+  ])
+  @HttpCode(HttpStatus.OK)
+  async handleForgotPassword(
+    @Body() forgotPasswordDto: ForgotPasswordDto,
+  ): Promise<ISuccessfulOperationResponse> {
+    return this.authenticationService.handleForgotPassword(forgotPasswordDto);
   }
 }

--- a/src/test/test.module.bootstrapper.ts
+++ b/src/test/test.module.bootstrapper.ts
@@ -7,6 +7,7 @@ export const identityProviderServiceMock = {
   signUp: jest.fn(),
   confirmUser: jest.fn(),
   signIn: jest.fn(),
+  forgotPassword: jest.fn(),
 };
 
 export const testModuleBootstrapper = (): Promise<TestingModule> => {


### PR DESCRIPTION
# Summary

This PR introduces the forgot password mechanism to `AuthenticationModule`.

# Details

- Updated the `IIdentityProviderService` interface with `forgotPassword` method.
- Created the `forgotPassword` method on the `CognitoService`.
- Implemented a route handler for the forgot password mechanism.
- Included a method on the `AuthenticationService` for handling forgo password mechanism.