### PR TITLE
feat: Add confirm password mechanism to AuthenticationModule

### DIFF
--- a/src/module/iam/authentication/application/dto/confirm-password.dto.ts
+++ b/src/module/iam/authentication/application/dto/confirm-password.dto.ts
@@ -1,0 +1,13 @@
+import { IsEmail, IsNotEmpty } from 'class-validator';
+
+export class ConfirmPasswordDto {
+  @IsNotEmpty()
+  code: string;
+
+  @IsEmail()
+  @IsNotEmpty()
+  email: string;
+
+  @IsNotEmpty()
+  newPassword: string;
+}

--- a/src/module/iam/authentication/application/dto/forgot-password.dto.ts
+++ b/src/module/iam/authentication/application/dto/forgot-password.dto.ts
@@ -1,6 +1,7 @@
-import { IsNotEmpty } from 'class-validator';
+import { IsEmail, IsNotEmpty } from 'class-validator';
 
 export class ForgotPasswordDto {
   @IsNotEmpty()
+  @IsEmail()
   email: string;
 }

--- a/src/module/iam/authentication/application/service/authentication.service.ts
+++ b/src/module/iam/authentication/application/service/authentication.service.ts
@@ -2,6 +2,7 @@ import { Inject, Injectable } from '@nestjs/common';
 
 import { ISuccessfulOperationResponse } from '@common/base/application/dto/successful-operation-response.interface';
 
+import { ConfirmPasswordDto } from '@module/iam/authentication/application/dto/confirm-password.dto';
 import { ConfirmUserDto } from '@module/iam/authentication/application/dto/confirm-user.dto';
 import { ForgotPasswordDto } from '@module/iam/authentication/application/dto/forgot-password.dto';
 import { SignInResponseDto } from '@module/iam/authentication/application/dto/sign-in-response.dto';
@@ -120,6 +121,24 @@ export class AuthenticationService {
 
     const response = await this.identityProviderService.forgotPassword(
       existingUser.email,
+    );
+
+    return {
+      ...response,
+      type: AUTHENTICATION_NAME,
+    };
+  }
+
+  async handleConfirmPassword(
+    confirmPasswordDto: ConfirmPasswordDto,
+  ): Promise<ISuccessfulOperationResponse> {
+    const { email, newPassword, code } = confirmPasswordDto;
+    const existingUser = await this.userRepository.getOneByEmailOrFail(email);
+
+    const response = await this.identityProviderService.confirmPassword(
+      existingUser.email,
+      newPassword,
+      code,
     );
 
     return {

--- a/src/module/iam/authentication/application/service/identity-provider.service.interface.ts
+++ b/src/module/iam/authentication/application/service/identity-provider.service.interface.ts
@@ -13,4 +13,9 @@ export interface IIdentityProviderService {
   ): Promise<ISuccessfulOperationResponse>;
   signIn(email: string, password: string): Promise<ISignInResponse>;
   forgotPassword(email: string): Promise<ISuccessfulOperationResponse>;
+  confirmPassword(
+    email: string,
+    newPassword: string,
+    code: string,
+  ): Promise<ISuccessfulOperationResponse>;
 }

--- a/src/module/iam/authentication/infrastructure/cognito/cognito.service.ts
+++ b/src/module/iam/authentication/infrastructure/cognito/cognito.service.ts
@@ -1,6 +1,7 @@
 import {
   AuthFlowType,
   CognitoIdentityProviderClient,
+  ConfirmForgotPasswordCommand,
   ConfirmSignUpCommand,
   ForgotPasswordCommand,
   InitiateAuthCommand,
@@ -168,6 +169,46 @@ export class CognitoService implements IIdentityProviderService {
       throw new UnexpectedErrorCodeException({
         message: `${UNEXPECTED_ERROR_CODE_ERROR} - ${(error as Error).name}`,
       });
+    }
+  }
+
+  async confirmPassword(
+    email: string,
+    newPassword: string,
+    code: string,
+  ): Promise<ISuccessfulOperationResponse> {
+    try {
+      const command = new ConfirmForgotPasswordCommand({
+        ClientId: this.clientId,
+        Username: email,
+        Password: newPassword,
+        ConfirmationCode: code,
+      });
+
+      await this.client.send(command);
+      return {
+        success: true,
+        message: 'Your password has been correctly updated',
+      };
+    } catch (error) {
+      switch ((error as Error).name) {
+        case 'CodeMismatchException':
+          throw new CodeMismatchException({
+            message: CODE_MISMATCH_ERROR,
+          });
+        case 'ExpiredCodeException':
+          throw new ExpiredCodeException({
+            message: EXPIRED_CODE_ERROR,
+          });
+        case 'InvalidPasswordException':
+          throw new PasswordValidationException({
+            message: PASSWORD_VALIDATION_ERROR,
+          });
+        default:
+          throw new UnexpectedErrorCodeException({
+            message: `${UNEXPECTED_ERROR_CODE_ERROR} - ${(error as Error).name}`,
+          });
+      }
     }
   }
 }

--- a/src/module/iam/authentication/interface/authentication.controller.ts
+++ b/src/module/iam/authentication/interface/authentication.controller.ts
@@ -4,6 +4,7 @@ import { ISuccessfulOperationResponse } from '@common/base/application/dto/succe
 import { HttpMethod } from '@common/base/application/enum/http-method.enum';
 import { Hypermedia } from '@common/base/infrastructure/decorator/hypermedia.decorator';
 
+import { ConfirmPasswordDto } from '@module/iam/authentication/application/dto/confirm-password.dto';
 import { ConfirmUserDto } from '@module/iam/authentication/application/dto/confirm-user.dto';
 import { ForgotPasswordDto } from '@module/iam/authentication/application/dto/forgot-password.dto';
 import { SignInResponseDto } from '@module/iam/authentication/application/dto/sign-in-response.dto';
@@ -67,5 +68,25 @@ export class AuthenticationController {
     @Body() forgotPasswordDto: ForgotPasswordDto,
   ): Promise<ISuccessfulOperationResponse> {
     return this.authenticationService.handleForgotPassword(forgotPasswordDto);
+  }
+
+  @Post('confirm-password')
+  @Hypermedia([
+    {
+      rel: 'resend-confirmation-code',
+      endpoint: '/auth/resend-confirmation-code',
+      method: HttpMethod.POST,
+    },
+    {
+      rel: 'sign-in',
+      endpoint: '/auth/sign-in',
+      method: HttpMethod.POST,
+    },
+  ])
+  @HttpCode(HttpStatus.OK)
+  async handleConfirmPassword(
+    @Body() confirmPasswordDto: ConfirmPasswordDto,
+  ): Promise<ISuccessfulOperationResponse> {
+    return this.authenticationService.handleConfirmPassword(confirmPasswordDto);
   }
 }

--- a/src/test/test.module.bootstrapper.ts
+++ b/src/test/test.module.bootstrapper.ts
@@ -8,6 +8,7 @@ export const identityProviderServiceMock = {
   confirmUser: jest.fn(),
   signIn: jest.fn(),
   forgotPassword: jest.fn(),
+  confirmPassword: jest.fn(),
 };
 
 export const testModuleBootstrapper = (): Promise<TestingModule> => {


### PR DESCRIPTION
# Summary

This PR introduces a mechanism for confirming new password on `AuthenticationModule`.

# Details

- Updated the `IIdentityProviderService` interface with `confirmPassword` method.
- Added the `confirmPassword` method to the `CognitoService`.
- Implemented a route handler for confirming new password.
- Created a method for handling the confirm new password flow.

# Evidence

![image](https://github.com/user-attachments/assets/22ea966e-2398-49db-84b7-2b06fb41476c)
