### PR TITLE
feat: Add resend confirmation code mechanism to AuthenticationModule

### DIFF
--- a/src/module/iam/authentication/application/dto/resend-confirmation-code.dto.ts
+++ b/src/module/iam/authentication/application/dto/resend-confirmation-code.dto.ts
@@ -1,0 +1,3 @@
+import { ForgotPasswordDto } from '@module/iam/authentication/application/dto/forgot-password.dto';
+
+export class ResendConfirmationCodeDto extends ForgotPasswordDto {}

--- a/src/module/iam/authentication/application/service/authentication.service.ts
+++ b/src/module/iam/authentication/application/service/authentication.service.ts
@@ -5,6 +5,7 @@ import { ISuccessfulOperationResponse } from '@common/base/application/dto/succe
 import { ConfirmPasswordDto } from '@module/iam/authentication/application/dto/confirm-password.dto';
 import { ConfirmUserDto } from '@module/iam/authentication/application/dto/confirm-user.dto';
 import { ForgotPasswordDto } from '@module/iam/authentication/application/dto/forgot-password.dto';
+import { ResendConfirmationCodeDto } from '@module/iam/authentication/application/dto/resend-confirmation-code.dto';
 import { SignInResponseDto } from '@module/iam/authentication/application/dto/sign-in-response.dto';
 import { SignInDto } from '@module/iam/authentication/application/dto/sign-in.dto';
 import { SignUpDto } from '@module/iam/authentication/application/dto/sign-up.dto';
@@ -139,6 +140,22 @@ export class AuthenticationService {
       existingUser.email,
       newPassword,
       code,
+    );
+
+    return {
+      ...response,
+      type: AUTHENTICATION_NAME,
+    };
+  }
+
+  async handleResendConfirmationCode(
+    resendConfirmationCodeDto: ResendConfirmationCodeDto,
+  ): Promise<ISuccessfulOperationResponse> {
+    const { email } = resendConfirmationCodeDto;
+    const existingUser = await this.userRepository.getOneByEmailOrFail(email);
+
+    const response = await this.identityProviderService.resendConfirmationCode(
+      existingUser.email,
     );
 
     return {

--- a/src/module/iam/authentication/application/service/identity-provider.service.interface.ts
+++ b/src/module/iam/authentication/application/service/identity-provider.service.interface.ts
@@ -18,4 +18,5 @@ export interface IIdentityProviderService {
     newPassword: string,
     code: string,
   ): Promise<ISuccessfulOperationResponse>;
+  resendConfirmationCode(email: string): Promise<ISuccessfulOperationResponse>;
 }

--- a/src/module/iam/authentication/infrastructure/cognito/cognito.service.ts
+++ b/src/module/iam/authentication/infrastructure/cognito/cognito.service.ts
@@ -6,6 +6,7 @@ import {
   ForgotPasswordCommand,
   InitiateAuthCommand,
   InitiateAuthCommandInput,
+  ResendConfirmationCodeCommand,
   SignUpCommand,
 } from '@aws-sdk/client-cognito-identity-provider';
 import { Injectable } from '@nestjs/common';
@@ -209,6 +210,27 @@ export class CognitoService implements IIdentityProviderService {
             message: `${UNEXPECTED_ERROR_CODE_ERROR} - ${(error as Error).name}`,
           });
       }
+    }
+  }
+
+  async resendConfirmationCode(
+    email: string,
+  ): Promise<ISuccessfulOperationResponse> {
+    try {
+      const command = new ResendConfirmationCodeCommand({
+        ClientId: this.clientId,
+        Username: email,
+      });
+
+      await this.client.send(command);
+      return {
+        success: true,
+        message: 'A new confirmation code has been sent',
+      };
+    } catch (error) {
+      throw new UnexpectedErrorCodeException({
+        message: `${UNEXPECTED_ERROR_CODE_ERROR} - ${(error as Error).name}`,
+      });
     }
   }
 }

--- a/src/module/iam/authentication/interface/authentication.controller.ts
+++ b/src/module/iam/authentication/interface/authentication.controller.ts
@@ -7,6 +7,7 @@ import { Hypermedia } from '@common/base/infrastructure/decorator/hypermedia.dec
 import { ConfirmPasswordDto } from '@module/iam/authentication/application/dto/confirm-password.dto';
 import { ConfirmUserDto } from '@module/iam/authentication/application/dto/confirm-user.dto';
 import { ForgotPasswordDto } from '@module/iam/authentication/application/dto/forgot-password.dto';
+import { ResendConfirmationCodeDto } from '@module/iam/authentication/application/dto/resend-confirmation-code.dto';
 import { SignInResponseDto } from '@module/iam/authentication/application/dto/sign-in-response.dto';
 import { SignInDto } from '@module/iam/authentication/application/dto/sign-in.dto';
 import { SignUpDto } from '@module/iam/authentication/application/dto/sign-up.dto';
@@ -88,5 +89,22 @@ export class AuthenticationController {
     @Body() confirmPasswordDto: ConfirmPasswordDto,
   ): Promise<ISuccessfulOperationResponse> {
     return this.authenticationService.handleConfirmPassword(confirmPasswordDto);
+  }
+
+  @Post('resend-confirmation-code')
+  @Hypermedia([
+    {
+      rel: 'confirm-password',
+      endpoint: '/auth/confirm-password',
+      method: HttpMethod.POST,
+    },
+  ])
+  @HttpCode(HttpStatus.OK)
+  async handleResendConfirmationCode(
+    @Body() resendConfirmationCode: ResendConfirmationCodeDto,
+  ): Promise<ISuccessfulOperationResponse> {
+    return this.authenticationService.handleResendConfirmationCode(
+      resendConfirmationCode,
+    );
   }
 }

--- a/src/test/test.module.bootstrapper.ts
+++ b/src/test/test.module.bootstrapper.ts
@@ -9,6 +9,7 @@ export const identityProviderServiceMock = {
   signIn: jest.fn(),
   forgotPassword: jest.fn(),
   confirmPassword: jest.fn(),
+  resendConfirmationCode: jest.fn(),
 };
 
 export const testModuleBootstrapper = (): Promise<TestingModule> => {


### PR DESCRIPTION
# Summary

This PR introduces the mechanism to resend confirmation code for changing password on `AuthenticationModule`.

# Details

- Updated the `IIdentityProviderService` with `resendConfirmationCode` method.
- Added the `resendConfirmationCode` method to the `CognitoService` with both success and failure paths.
- Implemented a route handler for the resend confirmation code request.
- Created a method for handling the resend confirmation code flow on the `AuthenticationService`.