### PR TITLE
feat: Add refresh session mechanism to AuthenticationModule

### DIFF
--- a/src/module/iam/authentication/application/dto/refresh-session-response.dto.ts
+++ b/src/module/iam/authentication/application/dto/refresh-session-response.dto.ts
@@ -1,0 +1,21 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+import { BaseResponseDto } from '@common/base/application/dto/base.response.dto';
+
+export interface IRefreshSessionResponse {
+  accessToken: string;
+}
+
+export class RefreshSessionResponseDto
+  extends BaseResponseDto
+  implements IRefreshSessionResponse
+{
+  @IsString()
+  @IsNotEmpty()
+  accessToken: string;
+
+  constructor(accessToken: string, type: string) {
+    super(type);
+    this.accessToken = accessToken;
+  }
+}

--- a/src/module/iam/authentication/application/dto/refresh-session.dto.ts
+++ b/src/module/iam/authentication/application/dto/refresh-session.dto.ts
@@ -1,0 +1,10 @@
+import { IsEmail, IsNotEmpty } from 'class-validator';
+
+export class RefreshSessionDto {
+  @IsNotEmpty()
+  @IsEmail()
+  email: string;
+
+  @IsNotEmpty()
+  refreshToken: string;
+}

--- a/src/module/iam/authentication/application/service/authentication.service.ts
+++ b/src/module/iam/authentication/application/service/authentication.service.ts
@@ -5,6 +5,8 @@ import { ISuccessfulOperationResponse } from '@common/base/application/dto/succe
 import { ConfirmPasswordDto } from '@module/iam/authentication/application/dto/confirm-password.dto';
 import { ConfirmUserDto } from '@module/iam/authentication/application/dto/confirm-user.dto';
 import { ForgotPasswordDto } from '@module/iam/authentication/application/dto/forgot-password.dto';
+import { RefreshSessionResponseDto } from '@module/iam/authentication/application/dto/refresh-session-response.dto';
+import { RefreshSessionDto } from '@module/iam/authentication/application/dto/refresh-session.dto';
 import { ResendConfirmationCodeDto } from '@module/iam/authentication/application/dto/resend-confirmation-code.dto';
 import { SignInResponseDto } from '@module/iam/authentication/application/dto/sign-in-response.dto';
 import { SignInDto } from '@module/iam/authentication/application/dto/sign-in.dto';
@@ -162,6 +164,22 @@ export class AuthenticationService {
       ...response,
       type: AUTHENTICATION_NAME,
     };
+  }
+
+  async handleRefreshSession(
+    refreshSessionDto: RefreshSessionDto,
+  ): Promise<RefreshSessionResponseDto> {
+    const { email, refreshToken } = refreshSessionDto;
+
+    await this.userRepository.getOneByEmailOrFail(email);
+
+    const response =
+      await this.identityProviderService.refreshSession(refreshToken);
+
+    return new RefreshSessionResponseDto(
+      response.accessToken,
+      AUTHENTICATION_NAME,
+    );
   }
 
   private async signUpAndSave(

--- a/src/module/iam/authentication/application/service/identity-provider.service.interface.ts
+++ b/src/module/iam/authentication/application/service/identity-provider.service.interface.ts
@@ -1,5 +1,6 @@
 import { ISuccessfulOperationResponse } from '@common/base/application/dto/successful-operation-response.interface';
 
+import { IRefreshSessionResponse } from '@module/iam/authentication/application/dto/refresh-session-response.dto';
 import { ISignInResponse } from '@module/iam/authentication/application/dto/sign-in-response.dto';
 import { ISignUpResponse } from '@module/iam/authentication/application/dto/sign-up-response.interface';
 
@@ -19,4 +20,5 @@ export interface IIdentityProviderService {
     code: string,
   ): Promise<ISuccessfulOperationResponse>;
   resendConfirmationCode(email: string): Promise<ISuccessfulOperationResponse>;
+  refreshSession(refreshToken: string): Promise<IRefreshSessionResponse>;
 }

--- a/src/module/iam/authentication/infrastructure/cognito/exception/cognito-exception-messages.ts
+++ b/src/module/iam/authentication/infrastructure/cognito/exception/cognito-exception-messages.ts
@@ -9,3 +9,4 @@ export const USER_NOT_CONFIRMED_ERROR =
   'User account not confirmed. Please confirm your account then try again';
 export const NEW_PASSWORD_REQUIRED_ERROR =
   'User must provide new password in order to complete authentication';
+export const INVALID_REFRESH_TOKEN_ERROR = 'Invalid or malformed refresh token';

--- a/src/module/iam/authentication/infrastructure/cognito/exception/invalid-refresh-token.exception.ts
+++ b/src/module/iam/authentication/infrastructure/cognito/exception/invalid-refresh-token.exception.ts
@@ -1,0 +1,9 @@
+import { UnauthorizedException } from '@nestjs/common';
+
+import { IBaseErrorInfo } from '@common/base/application/exception/app-error-response.interface';
+
+export class InvalidRefreshTokenException extends UnauthorizedException {
+  constructor(params: IBaseErrorInfo) {
+    super(params);
+  }
+}

--- a/src/module/iam/authentication/interface/authentication.controller.ts
+++ b/src/module/iam/authentication/interface/authentication.controller.ts
@@ -7,6 +7,8 @@ import { Hypermedia } from '@common/base/infrastructure/decorator/hypermedia.dec
 import { ConfirmPasswordDto } from '@module/iam/authentication/application/dto/confirm-password.dto';
 import { ConfirmUserDto } from '@module/iam/authentication/application/dto/confirm-user.dto';
 import { ForgotPasswordDto } from '@module/iam/authentication/application/dto/forgot-password.dto';
+import { RefreshSessionResponseDto } from '@module/iam/authentication/application/dto/refresh-session-response.dto';
+import { RefreshSessionDto } from '@module/iam/authentication/application/dto/refresh-session.dto';
 import { ResendConfirmationCodeDto } from '@module/iam/authentication/application/dto/resend-confirmation-code.dto';
 import { SignInResponseDto } from '@module/iam/authentication/application/dto/sign-in-response.dto';
 import { SignInDto } from '@module/iam/authentication/application/dto/sign-in.dto';
@@ -106,5 +108,20 @@ export class AuthenticationController {
     return this.authenticationService.handleResendConfirmationCode(
       resendConfirmationCode,
     );
+  }
+
+  @Post('refresh')
+  @Hypermedia([
+    {
+      rel: 'sign-in',
+      endpoint: '/auth/sign-in',
+      method: HttpMethod.POST,
+    },
+  ])
+  @HttpCode(HttpStatus.OK)
+  async handleRefreshSession(
+    @Body() refreshSessionDto: RefreshSessionDto,
+  ): Promise<RefreshSessionResponseDto> {
+    return this.authenticationService.handleRefreshSession(refreshSessionDto);
   }
 }

--- a/src/test/test.module.bootstrapper.ts
+++ b/src/test/test.module.bootstrapper.ts
@@ -10,6 +10,7 @@ export const identityProviderServiceMock = {
   forgotPassword: jest.fn(),
   confirmPassword: jest.fn(),
   resendConfirmationCode: jest.fn(),
+  refreshSession: jest.fn(),
 };
 
 export const testModuleBootstrapper = (): Promise<TestingModule> => {


### PR DESCRIPTION
# Summary

This PR introduces the mechanism for refreshing sessions on the `AuthenticationModule`.

# Details

- Updated the `IIdentityProviderService` interface with the `refreshSession` method.
- Created the `refreshSession` method on the `CognitoService` with both success and failure paths.
- Implemented a route handle for refreshing sessions.
- Added a method for handling refresh session flow to `AuthenticationService`.

# Evidence

![image](https://github.com/user-attachments/assets/21ece24b-ced8-4ca9-b27d-20a778e680fd)
