### PR TITLE
refactor: Improve ResponseFormatterInterceptor with paging links for collections

### DIFF
--- a/src/common/base/application/dto/serialized-response.interface.ts
+++ b/src/common/base/application/dto/serialized-response.interface.ts
@@ -10,13 +10,7 @@ export interface ILink {
 
 export type IResponseDtoLinks = ILink[];
 
-export interface ICollectionLinks {
-  self: ILink;
-  first?: ILink;
-  previous?: ILink;
-  next?: ILink;
-  last?: ILink;
-}
+export type ICollectionLinks = ILink[];
 
 export interface ISerializedCollection<Entity extends object> {
   data: Entity[];

--- a/src/module/app/application/service/link-builder.service.interface.ts
+++ b/src/module/app/application/service/link-builder.service.interface.ts
@@ -15,7 +15,8 @@ export interface ILinkBuilderService {
     id: string,
   ): ILink[];
   buildCollectionLinks(
-    entityName: string,
+    currentRequestUrl: string,
+    currentRequestMethod: HttpMethod,
     pagingData: IPagingCollectionData,
   ): ICollectionLinks;
 }


### PR DESCRIPTION
# Summary

This PR refactors the `ResponseFormatterInterceptor` for building `first`, `last`, `next` and `prev` paging links for the collection responses.

# Details

- Refactored the `LinkBuilderService` for building paging links by the current request url.
- Refactored the `ResponseFormatterInterceptor` to build paging links on collection responses.