### PR TITLE
feat: Add getMe method to UserModule

### DIFF
--- a/src/module/iam/authentication/infrastructure/decorator/__test__/current-user.decorator.spec.ts
+++ b/src/module/iam/authentication/infrastructure/decorator/__test__/current-user.decorator.spec.ts
@@ -1,0 +1,85 @@
+import { ExecutionContext } from '@nestjs/common';
+import { ROUTE_ARGS_METADATA } from '@nestjs/common/constants';
+import { Request } from 'express';
+
+import {
+  CurrentUser,
+  REQUEST_USER_KEY,
+} from '@module/iam/authentication/infrastructure/decorator/current-user.decorator';
+import { User } from '@module/iam/user/domain/user.entity';
+
+describe('@CurrentUser', () => {
+  const user = {
+    id: '00000000-0000-0000-0000-000000000000',
+    email: 'test_john@email.co',
+  } as User;
+
+  const request = {
+    [REQUEST_USER_KEY]: user,
+  } as Request & { user?: User };
+
+  const executionContext = {
+    switchToHttp: () => ({
+      getRequest: (): Request => request,
+    }),
+  } as ExecutionContext;
+
+  it('Should get the current user of the request', () => {
+    class Test {
+      test(
+        @CurrentUser()
+        user: User,
+      ): User {
+        return user;
+      }
+    }
+
+    const metadata = Reflect.getMetadata(
+      ROUTE_ARGS_METADATA,
+      Test,
+      'test',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ) as Record<string, any>;
+    const key = Object.keys(metadata)[0];
+    const currentUserFactory = (
+      metadata[key] as {
+        factory: (
+          fields: keyof User | undefined,
+          ctx: ExecutionContext,
+        ) => User;
+      }
+    ).factory;
+    const result = currentUserFactory(undefined, executionContext);
+    expect(result).toEqual(request.user);
+  });
+
+  it('Should get the field requested of the current user', () => {
+    class Test {
+      test(
+        @CurrentUser('id')
+        id: string,
+      ): string {
+        return id;
+      }
+    }
+
+    const metadata = Reflect.getMetadata(
+      ROUTE_ARGS_METADATA,
+      Test,
+      'test',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ) as Record<string, any>;
+    const key = Object.keys(metadata)[0];
+    const currentUserFactory = (
+      metadata[key] as {
+        factory: (
+          fields: keyof User | undefined,
+          ctx: ExecutionContext,
+        ) => User;
+      }
+    ).factory;
+    const result = currentUserFactory('id', executionContext);
+
+    expect(result).toEqual(request.user.id);
+  });
+});

--- a/src/module/iam/authentication/infrastructure/decorator/current-user.decorator.ts
+++ b/src/module/iam/authentication/infrastructure/decorator/current-user.decorator.ts
@@ -1,0 +1,15 @@
+import { ExecutionContext, createParamDecorator } from '@nestjs/common';
+import { Request } from 'express';
+
+import { User } from '@module/iam/user/domain/user.entity';
+
+export const REQUEST_USER_KEY = 'user';
+
+export const CurrentUser = createParamDecorator(
+  (field: keyof User, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest<Request>();
+    const user = request[REQUEST_USER_KEY];
+
+    return field ? (user as User)?.[field] : user;
+  },
+);

--- a/src/module/iam/user/__test__/user.e2e.spec.ts
+++ b/src/module/iam/user/__test__/user.e2e.spec.ts
@@ -186,4 +186,44 @@ describe('User Module', () => {
         );
     });
   });
+
+  describe('GET - /user/me', () => {
+    it('Should return current user', async () => {
+      await request(app.getHttpServer())
+        .get('/api/v1/user/me')
+        .auth(adminToken, { type: 'bearer' })
+        .expect(HttpStatus.OK)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            data: expect.objectContaining({
+              attributes: expect.objectContaining({
+                firstName: expect.any(String),
+                lastName: expect.any(String),
+                email: expect.any(String),
+                avatarUrl: expect.any(String),
+                externalId: expect.any(String),
+                isVerified: expect.any(Boolean),
+                role: expect.any(String),
+              }),
+              id: expect.any(String),
+              type: 'user',
+            }),
+            links: expect.arrayContaining([
+              expect.objectContaining({
+                rel: 'self',
+                href: expect.any(String),
+                method: HttpMethod.GET,
+              }),
+            ]),
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should throw an error if user is not authenticated', async () => {
+      await request(app.getHttpServer())
+        .get('/api/v1/user/me')
+        .expect(HttpStatus.UNAUTHORIZED);
+    });
+  });
 });

--- a/src/module/iam/user/application/service/user.service.ts
+++ b/src/module/iam/user/application/service/user.service.ts
@@ -10,6 +10,7 @@ import {
   IUserRepository,
   USER_REPOSITORY_KEY,
 } from '@module/iam/user/application/repository/user.repository.interface';
+import { User } from '@module/iam/user/domain/user.entity';
 
 @Injectable()
 export class UserService {
@@ -31,5 +32,9 @@ export class UserService {
     });
 
     return collectionDto;
+  }
+
+  getMe(user: User): UserResponseDto {
+    return this.mapper.fromEntityToResponseDto(user);
   }
 }

--- a/src/module/iam/user/interface/user.controller.ts
+++ b/src/module/iam/user/interface/user.controller.ts
@@ -3,11 +3,13 @@ import { Controller, Get, Query } from '@nestjs/common';
 import { CollectionDto } from '@common/base/application/dto/collection.dto';
 import { PageQueryParamsDto } from '@common/base/application/dto/page-query-params';
 
+import { CurrentUser } from '@module/iam/authentication/infrastructure/decorator/current-user.decorator';
 import { UserFieldsQueryParamsDto } from '@module/iam/user/application/dto/user-fields-query-params.dto';
 import { UserFilterQueryParamsDto } from '@module/iam/user/application/dto/user-filter-query-params.dto';
 import { UserResponseDto } from '@module/iam/user/application/dto/user-response.dto';
 import { UserSortQueryParamsDto } from '@module/iam/user/application/dto/user-sort-query-params.dto';
 import { UserService } from '@module/iam/user/application/service/user.service';
+import { User } from '@module/iam/user/domain/user.entity';
 
 @Controller('user')
 export class UserController {
@@ -26,5 +28,10 @@ export class UserController {
       sort,
       fields: fields.target,
     });
+  }
+
+  @Get('me')
+  getMe(@CurrentUser() user: User): UserResponseDto {
+    return this.userService.getMe(user);
   }
 }


### PR DESCRIPTION
# Summary

This PR introduces a method and decorator for obtaining the current user of the request on the `UserModule`.

# Details

- Created a decorator to retrieve the user asigned to the request.
- Implemented a `getMe` route handler to the `UserController`.
- Added a `getMe` method to the `UserService` to retrieve a `UserResponseDto` from the `User` received.


# Evidence

![image](https://github.com/user-attachments/assets/30130214-b150-4345-ad3b-115b84c1fe5c)
![image](https://github.com/user-attachments/assets/10c693c5-7f3a-473a-8aa4-039c5e974076)
  