### PR TITLE
feat: Add IsCommaSeparatedEnum class validator

### DIFF
--- a/src/common/base/application/validator/__test__/validator.spec.ts
+++ b/src/common/base/application/validator/__test__/validator.spec.ts
@@ -1,0 +1,46 @@
+import { validate } from 'class-validator';
+
+import { IsCommaSeparatedEnum } from '@common/base/application/validator/comma-separated-enum.validator';
+
+describe('IsCommaSeparatedEnum', () => {
+  enum TestEnum {
+    first = 'first',
+    second = 'second',
+    third = 'third',
+  }
+
+  class TestDto {
+    @IsCommaSeparatedEnum(TestEnum)
+    enums?: string;
+  }
+
+  it('Should allow valid comma separated enum values', async () => {
+    const dto = new TestDto();
+    dto.enums = `${TestEnum.first},${TestEnum.second},${TestEnum.third}`;
+
+    const errors = await validate(dto);
+    expect(errors.length).toBe(0);
+  });
+
+  it('Should deny invalid comma separated enum values', async () => {
+    const dto = new TestDto();
+    dto.enums = 'regular,invalid';
+
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].constraints?.isCommaSeparatedEnum).toEqual(
+      `enums must be a comma separated list of the following values: ${Object.values(TestEnum).join(', ')}`,
+    );
+  });
+
+  it('Should deny other types than string', async () => {
+    const dto = new TestDto();
+    (dto as unknown as { enums: string[] }).enums = ['regular', 'admin'];
+
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].constraints?.isCommaSeparatedEnum).toEqual(
+      `enums must be a comma separated list of the following values: ${Object.values(TestEnum).join(', ')}`,
+    );
+  });
+});

--- a/src/common/base/application/validator/comma-separated-enum.validator.ts
+++ b/src/common/base/application/validator/comma-separated-enum.validator.ts
@@ -1,0 +1,33 @@
+import {
+  ValidationArguments,
+  ValidationOptions,
+  registerDecorator,
+} from 'class-validator';
+
+export function IsCommaSeparatedEnum(
+  enumType: object,
+  validationOptions?: ValidationOptions,
+) {
+  return function (object: object, propertyName: string): void {
+    registerDecorator({
+      name: 'isCommaSeparatedEnum',
+      target: object.constructor,
+      propertyName,
+      constraints: [enumType],
+      options: validationOptions,
+      validator: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        validate(value: any, args: ValidationArguments) {
+          const [enumObj] = args.constraints as [object];
+          if (typeof value !== 'string') return false;
+          const parts = value.split(',');
+          return parts.every((val) => Object.values(enumObj).includes(val));
+        },
+        defaultMessage(args: ValidationArguments) {
+          const [enumObj] = args.constraints as [object];
+          return `${args.property} must be a comma separated list of the following values: ${Object.values(enumObj).join(', ')}`;
+        },
+      },
+    });
+  };
+}

--- a/src/module/iam/user/application/dto/user-filter-query-params.dto.ts
+++ b/src/module/iam/user/application/dto/user-filter-query-params.dto.ts
@@ -1,5 +1,7 @@
 import { IsBoolean, IsEmail, IsOptional, IsString } from 'class-validator';
 
+import { IsCommaSeparatedEnum } from '@common/base/application/validator/comma-separated-enum.validator';
+
 import { AppRole } from '@module/iam/authorization/domain/app-role.enum';
 
 export class UserFilterQueryParamsDto {
@@ -15,7 +17,7 @@ export class UserFilterQueryParamsDto {
   @IsOptional()
   lastName?: string;
 
-  @IsString()
+  @IsCommaSeparatedEnum(AppRole)
   @IsOptional()
   roles?: AppRole[];
 


### PR DESCRIPTION
# Summary

This PR introduces a custom class validator to verify the comma separated enums such as the roles from the UserFilterQueryParams.

# Details

- Created the `IsCommaSeparatedEnum` custom class-validator.
- Added the `IsCommaSeparatedEnum` to the `UserFilterQueryParams` roles.