### PR TITLE
feat: Add user permissions for reading resources

### DIFF
--- a/src/module/iam/authentication/__test__/fixture/User.yml
+++ b/src/module/iam/authentication/__test__/fixture/User.yml
@@ -1,16 +1,23 @@
 entity: User
 items:
+  super-admin-user:
+    email: 'test_super_admin@email.co'
+    firstName: test_super_admin
+    lastName: test_super_admin
+    externalId: '00000000-0000-0000-0000-00000000000X'
+    roles: regular,admin,superAdmin
+    isVerified: true
   admin-user:
     email: 'test_admin@email.co'
     firstName: test_admin
     lastName: test_admin
-    externalId: '00000000-0000-0000-0000-00000000000X'
+    externalId: '00000000-0000-0000-0000-00000000000Y'
     roles: admin
     isVerified: true
   confirm-user:
     email: 'test_confirm@email.co'
     firstName: test_confirm
     lastName: email
-    externalId: '00000000-0000-0000-0000-00000000000Y'
+    externalId: '00000000-0000-0000-0000-00000000000Z'
     roles: admin
     isVerified: false

--- a/src/module/iam/user/__test__/fixture/User.yml
+++ b/src/module/iam/user/__test__/fixture/User.yml
@@ -1,11 +1,18 @@
 entity: User
 items:
+  super-admin-user:
+    firstName: super-admin-name
+    lastName: super-admin-surname
+    email: 'test_super_admin@email.co'
+    avatarUrl: '{{internet.url}}'
+    externalId: '00000000-0000-0000-0000-00000000000X'
+    roles: regular,admin,superAdmin
   admin-user:
     firstName: admin-name
     lastName: admin-surname
     email: 'test_admin@email.co'
     avatarUrl: '{{internet.url}}'
-    externalId: '00000000-0000-0000-0000-00000000000X'
+    externalId: '00000000-0000-0000-0000-00000000000Y'
     roles: regular,admin
   user{2..23}:
     firstName: '{{person.firstName}}'

--- a/src/module/iam/user/application/policy/read-user-policy.handler.ts
+++ b/src/module/iam/user/application/policy/read-user-policy.handler.ts
@@ -1,0 +1,41 @@
+import { ForbiddenException, Injectable } from '@nestjs/common';
+import { Request } from 'express';
+
+import { REQUEST_USER_KEY } from '@module/iam/authentication/infrastructure/decorator/current-user.decorator';
+import { AuthorizationService } from '@module/iam/authorization/application/service/authorization.service';
+import { AppAction } from '@module/iam/authorization/domain/app.action.enum';
+import { IPolicyHandler } from '@module/iam/authorization/infrastructure/policy/handler/policy-handler.interface';
+import { PolicyHandlerStorage } from '@module/iam/authorization/infrastructure/policy/storage/policies-handler.storage';
+import { User } from '@module/iam/user/domain/user.entity';
+
+@Injectable()
+export class ReadUserPolicyHandler implements IPolicyHandler {
+  private readonly action = AppAction.Read;
+
+  constructor(
+    private readonly policyHandlerStorage: PolicyHandlerStorage,
+    private readonly authorizationService: AuthorizationService,
+  ) {
+    this.policyHandlerStorage.add(ReadUserPolicyHandler, this);
+  }
+
+  handle(request: Request): void {
+    const currentUser = this.getCurrentUser(request);
+
+    const isAllowed = this.authorizationService.isAllowed(
+      currentUser,
+      this.action,
+      User,
+    );
+
+    if (!isAllowed) {
+      throw new ForbiddenException(
+        `You are not allowed to ${this.action.toUpperCase()} this resource`,
+      );
+    }
+  }
+
+  private getCurrentUser(request: Request): User {
+    return request[REQUEST_USER_KEY] as User;
+  }
+}

--- a/src/module/iam/user/domain/user.permission.ts
+++ b/src/module/iam/user/domain/user.permission.ts
@@ -1,0 +1,18 @@
+import { AppRole } from '@module/iam/authorization/domain/app-role.enum';
+import { AppAction } from '@module/iam/authorization/domain/app.action.enum';
+import { IPermissionsDefinition } from '@module/iam/authorization/infrastructure/policy/type/permissions-definition.interface';
+import { User } from '@module/iam/user/domain/user.entity';
+
+export const userPermissions: IPermissionsDefinition = {
+  [AppRole.Regular](user, { can, cannot }) {
+    cannot(AppAction.Manage, User);
+    can(AppAction.Update, User, { id: user.id });
+  },
+  [AppRole.Admin](user, { can, cannot }) {
+    cannot(AppAction.Manage, User);
+    can(AppAction.Update, User, { id: user.id });
+  },
+  [AppRole.SuperAdmin](_, { can }) {
+    can(AppAction.Manage, User);
+  },
+};

--- a/src/module/iam/user/interface/user.controller.ts
+++ b/src/module/iam/user/interface/user.controller.ts
@@ -1,21 +1,26 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
 
 import { CollectionDto } from '@common/base/application/dto/collection.dto';
 import { PageQueryParamsDto } from '@common/base/application/dto/page-query-params';
 
 import { CurrentUser } from '@module/iam/authentication/infrastructure/decorator/current-user.decorator';
+import { Policies } from '@module/iam/authorization/infrastructure/policy/decorator/policy.decorator';
+import { PoliciesGuard } from '@module/iam/authorization/infrastructure/policy/guard/policy.guard';
 import { UserFieldsQueryParamsDto } from '@module/iam/user/application/dto/user-fields-query-params.dto';
 import { UserFilterQueryParamsDto } from '@module/iam/user/application/dto/user-filter-query-params.dto';
 import { UserResponseDto } from '@module/iam/user/application/dto/user-response.dto';
 import { UserSortQueryParamsDto } from '@module/iam/user/application/dto/user-sort-query-params.dto';
+import { ReadUserPolicyHandler } from '@module/iam/user/application/policy/read-user-policy.handler';
 import { UserService } from '@module/iam/user/application/service/user.service';
 import { User } from '@module/iam/user/domain/user.entity';
 
+@UseGuards(PoliciesGuard)
 @Controller('user')
 export class UserController {
   constructor(private readonly userService: UserService) {}
 
   @Get()
+  @Policies(ReadUserPolicyHandler)
   async getAll(
     @Query('page') page: PageQueryParamsDto,
     @Query('filter') filter: UserFilterQueryParamsDto,

--- a/src/module/iam/user/user.module.ts
+++ b/src/module/iam/user/user.module.ts
@@ -1,12 +1,17 @@
 import { Module, Provider } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { AuthorizationModule } from '@module/iam/authorization/authorization.module';
 import { UserMapper } from '@module/iam/user/application/mapper/user.mapper';
+import { ReadUserPolicyHandler } from '@module/iam/user/application/policy/read-user-policy.handler';
 import { USER_REPOSITORY_KEY } from '@module/iam/user/application/repository/user.repository.interface';
 import { UserService } from '@module/iam/user/application/service/user.service';
+import { userPermissions } from '@module/iam/user/domain/user.permission';
 import { UserPostgresRepository } from '@module/iam/user/infrastructure/database/user.postgres.repository';
 import { UserSchema } from '@module/iam/user/infrastructure/database/user.schema';
 import { UserController } from '@module/iam/user/interface/user.controller';
+
+const policyHandlersProviders = [ReadUserPolicyHandler];
 
 const userRepositoryProvider: Provider = {
   provide: USER_REPOSITORY_KEY,
@@ -14,9 +19,17 @@ const userRepositoryProvider: Provider = {
 };
 
 @Module({
-  imports: [TypeOrmModule.forFeature([UserSchema])],
+  imports: [
+    TypeOrmModule.forFeature([UserSchema]),
+    AuthorizationModule.forFeature({ permissions: userPermissions }),
+  ],
   controllers: [UserController],
-  providers: [userRepositoryProvider, UserMapper, UserService],
+  providers: [
+    userRepositoryProvider,
+    UserMapper,
+    UserService,
+    ...policyHandlersProviders,
+  ],
   exports: [userRepositoryProvider, UserMapper],
 })
 export class UserModule {}


### PR DESCRIPTION
# Summary

This PR introduces user permissions to protect `getAll` method from non-superAdmin users.

# Details

- Created user permissions for `regular`, `admin` and `superAdmin` users.
- Added a `ReadUserPolicyHandler` for handling the permissions of the current request's user.
- Update tests to verify the protection of the `getAll` route.

# Evidence

![image](https://github.com/user-attachments/assets/4e690492-2a7b-4957-99fa-41b6d5a3c605)


# Reference

[NestJS Docs - Authorization](https://docs.nestjs.com/security/authorization)