### PR TITLE
feat: Add updateMe mechanism to UserModule

### DIFF
--- a/src/common/base/application/enum/http-method.enum.ts
+++ b/src/common/base/application/enum/http-method.enum.ts
@@ -3,4 +3,5 @@ export enum HttpMethod {
   POST = 'POST',
   PUT = 'PUT',
   DELETE = 'DELETE',
+  PATCH = 'PATCH',
 }

--- a/src/module/iam/user/__test__/user.e2e.spec.ts
+++ b/src/module/iam/user/__test__/user.e2e.spec.ts
@@ -282,4 +282,46 @@ describe('User Module', () => {
         .expect(HttpStatus.UNAUTHORIZED);
     });
   });
+
+  describe('PATCH - /user/me', () => {
+    it('Should update current user', async () => {
+      await request(app.getHttpServer())
+        .get('/api/v1/user/me')
+        .auth(superAdminToken, { type: 'bearer' })
+        .expect(HttpStatus.OK)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            data: expect.objectContaining({
+              attributes: expect.objectContaining({
+                firstName: 'super-admin-name',
+              }),
+            }),
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+
+      await request(app.getHttpServer())
+        .patch('/api/v1/user/me')
+        .auth(superAdminToken, { type: 'bearer' })
+        .send({ firstName: 'updated' })
+        .expect(HttpStatus.OK)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            data: expect.objectContaining({
+              attributes: expect.objectContaining({
+                firstName: 'updated',
+              }),
+            }),
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should throw an error if user is not authenticated', async () => {
+      await request(app.getHttpServer())
+        .patch('/api/v1/user/me')
+        .send({ firstName: 'updated' })
+        .expect(HttpStatus.UNAUTHORIZED);
+    });
+  });
 });

--- a/src/module/iam/user/application/dto/update-user.dto.ts
+++ b/src/module/iam/user/application/dto/update-user.dto.ts
@@ -1,5 +1,25 @@
-import { PartialType } from '@nestjs/mapped-types';
+import { IsOptional, IsString } from 'class-validator';
 
 import { UserDto } from '@module/iam/user/application/dto/user.dto';
 
-export class UpdateUserDto extends PartialType(UserDto) {}
+export class UpdateUserDto
+  implements Pick<UserDto, 'firstName' | 'lastName' | 'avatarUrl'>
+{
+  @IsString()
+  @IsOptional()
+  firstName?: string;
+
+  @IsString()
+  @IsOptional()
+  lastName?: string;
+
+  @IsString()
+  @IsOptional()
+  avatarUrl?: string;
+
+  constructor(firstName?: string, lastName?: string, avatarUrl?: string) {
+    this.firstName = firstName;
+    this.lastName = lastName;
+    this.avatarUrl = avatarUrl;
+  }
+}

--- a/src/module/iam/user/application/mapper/user.mapper.ts
+++ b/src/module/iam/user/application/mapper/user.mapper.ts
@@ -25,4 +25,20 @@ export class UserMapper
       entity.externalId,
     );
   }
+
+  fromUpdateDtoToEntity(dto: UpdateUserDto, currentUser: User): User {
+    return new User(
+      currentUser.email,
+      dto.firstName,
+      dto.lastName,
+      currentUser.roles,
+      dto.avatarUrl,
+      currentUser.externalId,
+      currentUser.id,
+      currentUser.createdAt,
+      currentUser.updatedAt,
+      currentUser.deletedAt,
+      currentUser.isVerified,
+    );
+  }
 }

--- a/src/module/iam/user/application/service/user.service.ts
+++ b/src/module/iam/user/application/service/user.service.ts
@@ -3,6 +3,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { CollectionDto } from '@common/base/application/dto/collection.dto';
 import { IGetAllOptions } from '@common/base/application/dto/get-all-options.interface';
 
+import { UpdateUserDto } from '@module/iam/user/application/dto/update-user.dto';
 import { UserResponseDto } from '@module/iam/user/application/dto/user-response.dto';
 import { UserDto } from '@module/iam/user/application/dto/user.dto';
 import { UserMapper } from '@module/iam/user/application/mapper/user.mapper';
@@ -36,5 +37,18 @@ export class UserService {
 
   getMe(user: User): UserResponseDto {
     return this.mapper.fromEntityToResponseDto(user);
+  }
+
+  async updateMe(
+    user: User,
+    updateUserDto: UpdateUserDto,
+  ): Promise<UserResponseDto> {
+    const userToUpdate = this.mapper.fromUpdateDtoToEntity(updateUserDto, user);
+    const updatedUser = await this.repository.updateOneOrFail(
+      user.id,
+      userToUpdate,
+    );
+
+    return this.mapper.fromEntityToResponseDto(updatedUser);
   }
 }

--- a/src/module/iam/user/interface/user.controller.ts
+++ b/src/module/iam/user/interface/user.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Patch, Query, UseGuards } from '@nestjs/common';
 
 import { CollectionDto } from '@common/base/application/dto/collection.dto';
 import { PageQueryParamsDto } from '@common/base/application/dto/page-query-params';
@@ -6,6 +6,7 @@ import { PageQueryParamsDto } from '@common/base/application/dto/page-query-para
 import { CurrentUser } from '@module/iam/authentication/infrastructure/decorator/current-user.decorator';
 import { Policies } from '@module/iam/authorization/infrastructure/policy/decorator/policy.decorator';
 import { PoliciesGuard } from '@module/iam/authorization/infrastructure/policy/guard/policy.guard';
+import { UpdateUserDto } from '@module/iam/user/application/dto/update-user.dto';
 import { UserFieldsQueryParamsDto } from '@module/iam/user/application/dto/user-fields-query-params.dto';
 import { UserFilterQueryParamsDto } from '@module/iam/user/application/dto/user-filter-query-params.dto';
 import { UserResponseDto } from '@module/iam/user/application/dto/user-response.dto';
@@ -38,5 +39,13 @@ export class UserController {
   @Get('me')
   getMe(@CurrentUser() user: User): UserResponseDto {
     return this.userService.getMe(user);
+  }
+
+  @Patch('me')
+  async updateMe(
+    @CurrentUser() user: User,
+    @Body() updateUserDto: UpdateUserDto,
+  ): Promise<UserResponseDto> {
+    return await this.userService.updateMe(user, updateUserDto);
   }
 }


### PR DESCRIPTION
# Summary

This PR introduces an `updateMe` method to `UserController` and `UserService`.

# Details

- Updated the `UpdateUserDto` with only editable by user attributes.
- Added the `fromUpdateUserDtoToEntity` method to the `UserMapper`.
- Created the `updateMe` method to the `UserController` and `UserService`.

# Evidence

![image](https://github.com/user-attachments/assets/36251a2e-7357-40c2-bb24-df2040cfd289)
