### PR TITLE
feat: Add CloudModule with AmazonS3 as ImageStorageProvider

### DIFF
--- a/data/scripts/create_s3_bucket.sh
+++ b/data/scripts/create_s3_bucket.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+if [ -f .env ]; then
+  export $(grep -v '^#' .env | xargs)
+else
+  echo ".env file not found. Make sure it exists before running."
+  exit 1
+fi
+
+if [ -z "$S3_BUCKET" ]; then
+  echo "S3_BUCKET is not set. Please set it in your .env file."
+  exit 1
+fi
+
+if [ -z "$AWS_REGION" ]; then
+  echo "AWS_REGION is not set. Please set it in your .env file."
+  exit 1
+fi
+
+echo "Creating S3 bucket: ${S3_BUCKET} on AWS Region: ${AWS_REGION}"
+echo "==================="
+
+awslocal s3api create-bucket --bucket "${S3_BUCKET}" --acl public-read --region "${AWS_REGION}"
+
+awslocal s3 ls --region "${AWS_REGION}"
+
+echo "S3 Bucket created: ${S3_BUCKET}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,3 +15,15 @@ services:
       - '${COGNITO_PORT:-9229}:9229'
     volumes:
       - './data/docker/volumes/cognito:/app/.cognito'
+  localstack:
+    image: localstack/localstack
+    environment:
+      S3_BUCKET: '${S3_BUCKET}'
+      AWS_REGION: '${AWS_REGION}'
+      DEBUG: 1
+      SERVICES: 's3'
+    ports:
+      - '4566:4566'
+    volumes:
+      - './data/docker/volumes/localstack/var/run/docker.sock:/var/run/docker.sock'
+      - './data/docker/scripts:/etc/localstack/init/ready.d'

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.808.0",
+        "@aws-sdk/client-s3": "^3.812.0",
         "@casl/ability": "^6.7.3",
         "@nestjs/common": "^11.0.1",
         "@nestjs/config": "^4.0.2",
@@ -28,7 +29,8 @@
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
         "typeorm": "^0.3.23",
-        "typeorm-naming-strategies": "^4.1.0"
+        "typeorm-naming-strategies": "^4.1.0",
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
@@ -41,6 +43,7 @@
         "@trivago/prettier-plugin-sort-imports": "^4.3.0",
         "@types/express": "^5.0.0",
         "@types/jest": "^29.5.14",
+        "@types/multer": "^1.4.12",
         "@types/node": "^22.15.14",
         "@types/passport-jwt": "^4.0.1",
         "@types/supertest": "^6.0.2",
@@ -225,6 +228,83 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-crypto/sha256-browser": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
@@ -394,6 +474,73 @@
         "@smithy/util-middleware": "^4.0.2",
         "@smithy/util-retry": "^4.0.3",
         "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.812.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.812.0.tgz",
+      "integrity": "sha512-kHgw9JDXNPLa/mHtWpOd5btBVXFSe+wwp1Ed9+bqz9uLkv0iV4joZrdQwnydkO8zlTs60Sc5ez+P2OiZ76i2Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.812.0",
+        "@aws-sdk/credential-provider-node": "3.812.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.808.0",
+        "@aws-sdk/middleware-expect-continue": "3.804.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.812.0",
+        "@aws-sdk/middleware-host-header": "3.804.0",
+        "@aws-sdk/middleware-location-constraint": "3.804.0",
+        "@aws-sdk/middleware-logger": "3.804.0",
+        "@aws-sdk/middleware-recursion-detection": "3.804.0",
+        "@aws-sdk/middleware-sdk-s3": "3.812.0",
+        "@aws-sdk/middleware-ssec": "3.804.0",
+        "@aws-sdk/middleware-user-agent": "3.812.0",
+        "@aws-sdk/region-config-resolver": "3.808.0",
+        "@aws-sdk/signature-v4-multi-region": "3.812.0",
+        "@aws-sdk/types": "3.804.0",
+        "@aws-sdk/util-endpoints": "3.808.0",
+        "@aws-sdk/util-user-agent-browser": "3.804.0",
+        "@aws-sdk/util-user-agent-node": "3.812.0",
+        "@aws-sdk/xml-builder": "3.804.0",
+        "@smithy/config-resolver": "^4.1.2",
+        "@smithy/core": "^3.3.3",
+        "@smithy/eventstream-serde-browser": "^4.0.2",
+        "@smithy/eventstream-serde-config-resolver": "^4.1.0",
+        "@smithy/eventstream-serde-node": "^4.0.2",
+        "@smithy/fetch-http-handler": "^5.0.2",
+        "@smithy/hash-blob-browser": "^4.0.2",
+        "@smithy/hash-node": "^4.0.2",
+        "@smithy/hash-stream-node": "^4.0.2",
+        "@smithy/invalid-dependency": "^4.0.2",
+        "@smithy/md5-js": "^4.0.2",
+        "@smithy/middleware-content-length": "^4.0.2",
+        "@smithy/middleware-endpoint": "^4.1.6",
+        "@smithy/middleware-retry": "^4.1.7",
+        "@smithy/middleware-serde": "^4.0.5",
+        "@smithy/middleware-stack": "^4.0.2",
+        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/node-http-handler": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/smithy-client": "^4.2.6",
+        "@smithy/types": "^4.2.0",
+        "@smithy/url-parser": "^4.0.2",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.14",
+        "@smithy/util-defaults-mode-node": "^4.0.14",
+        "@smithy/util-endpoints": "^3.0.4",
+        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-retry": "^4.0.3",
+        "@smithy/util-stream": "^4.2.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/util-waiter": "^4.0.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -608,6 +755,63 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.808.0.tgz",
+      "integrity": "sha512-wEPlNcs8dir9lXbuviEGtSzYSxG/NRKQrJk5ybOc7OpPGHovsN+QhDOdY3lcjOFdwMTiMIG9foUkPz3zBpLB1A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.804.0",
+        "@aws-sdk/util-arn-parser": "3.804.0",
+        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-config-provider": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.804.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.804.0.tgz",
+      "integrity": "sha512-YW1hySBolALMII6C8y7Z0CRG2UX1dGJjLEBNFeefhO/xP7ZuE1dvnmfJGaEuBMnvc3wkRS63VZ3aqX6sevM1CA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.812.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.812.0.tgz",
+      "integrity": "sha512-/ayAooUZvV1GTomNMrfbhjUHAEaz0Wmio3lKyaTJsW4WdLJXBuzdo57YADRmYYUqx6awzJ6VJ6HGc1Uc6tOlbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "3.812.0",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/is-array-buffer": "^4.0.0",
+        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-stream": "^4.2.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@aws-sdk/middleware-host-header": {
       "version": "3.804.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.804.0.tgz",
@@ -616,6 +820,20 @@
       "dependencies": {
         "@aws-sdk/types": "3.804.0",
         "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.804.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.804.0.tgz",
+      "integrity": "sha512-AMtKnllIWKgoo7hiJfphLYotEwTERfjVMO2+cKAncz9w1g+bnYhHxiVhJJoR94y047c06X4PU5MsTxvdQ73Znw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.804.0",
         "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
@@ -645,6 +863,45 @@
       "dependencies": {
         "@aws-sdk/types": "3.804.0",
         "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.812.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.812.0.tgz",
+      "integrity": "sha512-e8AqRRIaTsunL1hqtO1hksa9oTYdsIbfezHUyVpPGugUIB1lMqPt/DlBsanI85OzUD711UfNSEcZ1mqAxpDOoA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.812.0",
+        "@aws-sdk/types": "3.804.0",
+        "@aws-sdk/util-arn-parser": "3.804.0",
+        "@smithy/core": "^3.3.3",
+        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/signature-v4": "^5.1.0",
+        "@smithy/smithy-client": "^4.2.6",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-config-provider": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-stream": "^4.2.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.804.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.804.0.tgz",
+      "integrity": "sha512-Tk8jK0gOIUBvEPTz/wwSlP1V70zVQ3QYqsLPAjQRMO6zfOK9ax31dln3MgKvFDJxBydS2tS3wsn53v+brxDxTA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.804.0",
         "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
@@ -736,6 +993,23 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.812.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.812.0.tgz",
+      "integrity": "sha512-JTpk3ZHf7TXYbicKfOKi+VrsBTqcAszg9QR9fQmT9aCxPp39gsF3WsXq7NjepwZ5So11ixGIsPE/jtMym399QQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "3.812.0",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/signature-v4": "^5.1.0",
+        "@smithy/types": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@aws-sdk/token-providers": {
       "version": "3.812.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.812.0.tgz",
@@ -760,6 +1034,18 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.804.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.804.0.tgz",
+      "integrity": "sha512-wmBJqn1DRXnZu3b4EkE6CWnoWMo1ZMvlfkqU5zPz67xx1GMaXlDCchFvKAXMjk4jn/L1O3tKnoFDNsoLV1kgNQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -827,6 +1113,19 @@
         "aws-crt": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.804.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.804.0.tgz",
+      "integrity": "sha512-JbGWp36IG9dgxtvC6+YXwt5WDZYfuamWFtVfK6fQpnmL96dx+GUPOXPKRWdw67WLKf2comHY28iX2d3z35I53Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4333,6 +4632,31 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@smithy/chunked-blob-reader": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.0.0.tgz",
+      "integrity": "sha512-+sKqDBQqb036hh4NPaUiEkYFkTUGYzRsn3EuFhyfQfMy6oGHEUJDurLP9Ufb5dasr/XiAmPNMr6wa9afjQB+Gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader-native": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.0.0.tgz",
+      "integrity": "sha512-R9wM2yPmfEMsUmlMlIgSzOyICs0x9uu7UTHoccMyt7BWw8shcGM8HqB355+BZCPBcySvbTYMs62EgEQkNxz2ig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-base64": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@smithy/config-resolver": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.3.tgz",
@@ -4384,6 +4708,76 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.0.3.tgz",
+      "integrity": "sha512-V22KIPXZsE2mc4zEgYGANM/7UbL9jWlOACEolyGyMuTY+jjHJ2PQ0FdopOTS1CS7u6PlAkALmypkv2oQ4aftcg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.3.0",
+        "@smithy/util-hex-encoding": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-browser": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.0.3.tgz",
+      "integrity": "sha512-oe1d/tfCGVZBMX8O6HApaM4G+fF9JNdyLP7tWXt00epuL/kLOdp/4o9VqheLFeJaXgao+9IaBgs/q/oM48hxzg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.0.3",
+        "@smithy/types": "^4.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.1.1.tgz",
+      "integrity": "sha512-XXCPGjRNwpFWHKQJMKIjGLfFKYULYckFnxGcWmBC2mBf3NsrvUKgqHax4NCqc0TfbDAimPDHOc6HOKtzsXK9Gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.0.3.tgz",
+      "integrity": "sha512-HOEbRmm9TrikCoFrypYu0J/gC4Lsk8gl5LtOz1G3laD2Jy44+ht2Pd2E9qjNQfhMJIzKDZ/gbuUH0s0v4kWQ0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.0.3",
+        "@smithy/types": "^4.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.0.3.tgz",
+      "integrity": "sha512-ShOP512CZrYI9n+h64PJ84udzoNHUQtPddyh1j175KNTKsSnMEDNscOWJWyEoLQiuhWWw51lSa+k6ea9ZGXcRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^4.0.3",
+        "@smithy/types": "^4.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@smithy/fetch-http-handler": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.3.tgz",
@@ -4400,6 +4794,21 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@smithy/hash-blob-browser": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.0.3.tgz",
+      "integrity": "sha512-37wZYU/XI2cOF4hgNDNMzZNAuNtJTkZFWxcpagQrnf6PYU/6sJ6y5Ey9Bp4vzi9nteex/ImxAugfsF3XGLrqWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/chunked-blob-reader": "^5.0.0",
+        "@smithy/chunked-blob-reader-native": "^4.0.0",
+        "@smithy/types": "^4.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@smithy/hash-node": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.3.tgz",
@@ -4408,6 +4817,20 @@
       "dependencies": {
         "@smithy/types": "^4.3.0",
         "@smithy/util-buffer-from": "^4.0.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-stream-node": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.0.3.tgz",
+      "integrity": "sha512-CAwAvztwGYHHZGGcXtbinNxytaj5FNZChz8V+o7eNUAi5BgVqnF91Z3cJSmaE9O7FYUQVrIzGAB25Aok9T5KHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.0",
         "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
       },
@@ -4434,6 +4857,20 @@
       "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
       "license": "Apache-2.0",
       "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/md5-js": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.0.3.tgz",
+      "integrity": "sha512-m95Z+1UJFPq4cv/R6TPMLYkoau7cNJYA5GLuuUJjfmF+Zrad4yaupIWeGGzIinf8pD1L+CIAxjh8eowPvyL7Dw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.0",
+        "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4491,6 +4928,19 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@smithy/middleware-serde": {
@@ -4880,6 +5330,20 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.0.4.tgz",
+      "integrity": "sha512-73aeIvHjtSB6fd9I08iFaQIGTICKpLrI3EtlWAkStVENGo1ARMq9qdoD4QwkY0RUp6A409xlgbD9NCCfCF5ieg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.0.3",
+        "@smithy/types": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5521,6 +5985,16 @@
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
       "license": "MIT"
+    },
+    "node_modules/@types/multer": {
+      "version": "1.4.12",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-1.4.12.tgz",
+      "integrity": "sha512-pQ2hoqvXiJt2FP9WQVLPRO+AmiIm/ZYkavPlIQnx282u4ZrVdztx0pkh3jjpQt0Kz+YI0YhSG264y08UJKoUQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "22.15.20",
@@ -17946,19 +18420,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/typeorm/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/typescript": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
@@ -18154,16 +18615,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "migration:create": "cross-var npm run typeorm -- migration:create ./data/migrations/$npm_config_name",
     "migration:run": "npm run typeorm -- migration:run -d ./src/config/orm.config.ts",
     "migration:generate": "cross-var npm run typeorm -- migration:generate -d ./src/config/orm.config.ts ./data/migrations/$npm_config_name",
-    "cognito:prepare": "cross-env ./data/scripts/create_user_pool.sh"
+    "cognito:prepare": "cross-env ./data/scripts/create_user_pool.sh",
+    "s3:prepare": "cross-env ./data/scripts/create_s3_bucket.sh",
+    "aws:prepare": "npm run cognito:prepare && npm run s3:prepare"
   },
   "lint-staged": {
     "src/**/*.ts": [

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-cognito-identity-provider": "^3.808.0",
+    "@aws-sdk/client-s3": "^3.812.0",
     "@casl/ability": "^6.7.3",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.2",
@@ -49,7 +50,8 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "typeorm": "^0.3.23",
-    "typeorm-naming-strategies": "^4.1.0"
+    "typeorm-naming-strategies": "^4.1.0",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
@@ -62,6 +64,7 @@
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
     "@types/express": "^5.0.0",
     "@types/jest": "^29.5.14",
+    "@types/multer": "^1.4.12",
     "@types/node": "^22.15.14",
     "@types/passport-jwt": "^4.0.1",
     "@types/supertest": "^6.0.2",

--- a/src/config/env.d.ts
+++ b/src/config/env.d.ts
@@ -13,6 +13,15 @@ declare global {
       PORT: string;
       BASE_APP_URL: string;
       FRONTEND_URL: string;
+      AWS_ACCESS_KEY_ID: string;
+      AWS_SECRET_ACCESS_KEY: string;
+      AWS_REGION: string;
+      AWS_ENDPOINT: string;
+      COGNITO_USER_POOL_ID: string;
+      COGNITO_CLIENT_ID: string;
+      COGNITO_ENDPOINT: string;
+      COGNITO_ISSUER: string;
+      S3_BUCKET: string;
     }
   }
 }

--- a/src/config/environment.config.ts
+++ b/src/config/environment.config.ts
@@ -13,4 +13,15 @@ export const environmentConfig = (): Record<string, any> => ({
   frontend: {
     url: process.env.FRONTEND_URL,
   },
+  aws: {
+    endpoint: process.env.AWS_ENDPOINT,
+    region: process.env.AWS_REGION,
+    credentials: {
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+    },
+  },
+  s3: {
+    bucket: process.env.S3_BUCKET,
+  },
 });

--- a/src/module/app.module.ts
+++ b/src/module/app.module.ts
@@ -6,6 +6,7 @@ import { environmentConfig } from '@config/environment.config';
 import { datasourceOptions } from '@config/orm.config';
 
 import { LinkBuilderService } from '@module/app/application/service/link-builder.service';
+import { CloudModule } from '@module/cloud/cloud.module';
 import { IamModule } from '@module/iam/iam.module';
 
 @Global()
@@ -21,6 +22,7 @@ import { IamModule } from '@module/iam/iam.module';
         autoLoadEntities: true,
       }),
     }),
+    CloudModule,
     IamModule,
   ],
   providers: [LinkBuilderService],

--- a/src/module/cloud/application/interface/image-storage-provider.interface.ts
+++ b/src/module/cloud/application/interface/image-storage-provider.interface.ts
@@ -1,0 +1,6 @@
+export const IMAGE_STORAGE_PROVIDER_SERVICE_KEY =
+  'image_storage_provider_service';
+
+export interface IImageStorageProvider {
+  uploadFile(file: Express.Multer.File, folder: string): Promise<string>;
+}

--- a/src/module/cloud/application/service/image-storage.service.ts
+++ b/src/module/cloud/application/service/image-storage.service.ts
@@ -1,0 +1,18 @@
+import { Inject, Injectable } from '@nestjs/common';
+
+import {
+  IImageStorageProvider,
+  IMAGE_STORAGE_PROVIDER_SERVICE_KEY,
+} from '@module/cloud/application/interface/image-storage-provider.interface';
+
+@Injectable()
+export class ImageStorageService {
+  constructor(
+    @Inject(IMAGE_STORAGE_PROVIDER_SERVICE_KEY)
+    private readonly imageStorageProvider: IImageStorageProvider,
+  ) {}
+
+  uploadImage(file: Express.Multer.File, folder: string): Promise<string> {
+    return this.imageStorageProvider.uploadFile(file, folder);
+  }
+}

--- a/src/module/cloud/cloud.module.ts
+++ b/src/module/cloud/cloud.module.ts
@@ -1,0 +1,18 @@
+import { Global, Module, Provider } from '@nestjs/common';
+
+import { IMAGE_STORAGE_PROVIDER_SERVICE_KEY } from '@module/cloud/application/interface/image-storage-provider.interface';
+import { ImageStorageService } from '@module/cloud/application/service/image-storage.service';
+import { AmazonS3Service } from '@module/cloud/infrastructure/aws/s3/s3.service';
+
+const imageStorageProvider: Provider = {
+  provide: IMAGE_STORAGE_PROVIDER_SERVICE_KEY,
+  useClass: AmazonS3Service,
+};
+
+@Global()
+@Module({
+  imports: [],
+  providers: [imageStorageProvider, ImageStorageService],
+  exports: [ImageStorageService],
+})
+export class CloudModule {}

--- a/src/module/cloud/infrastructure/aws/s3/__test__/s3.unit-test.spec.ts
+++ b/src/module/cloud/infrastructure/aws/s3/__test__/s3.unit-test.spec.ts
@@ -1,0 +1,92 @@
+import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { NestExpressApplication } from '@nestjs/platform-express';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { setupApp } from '@config/app.config';
+
+import { AppModule } from '@module/app.module';
+import { IMAGE_STORAGE_PROVIDER_SERVICE_KEY } from '@module/cloud/application/interface/image-storage-provider.interface';
+import { AmazonS3Service } from '@module/cloud/infrastructure/aws/s3/s3.service';
+
+const sendMock = jest.fn();
+
+jest.mock('@aws-sdk/client-s3', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  PutObjectCommand: jest.fn((input) => input),
+  S3Client: jest.fn().mockImplementation(() => ({
+    send: sendMock,
+  })),
+}));
+
+jest.mock('uuid', () => ({
+  v4: jest.fn(() => 'mock-uuid'),
+}));
+
+const mockFile: Express.Multer.File = {
+  fieldname: 'file',
+  originalname: 'test-video.mp4',
+  encoding: '7bit',
+  mimetype: 'video/mp4',
+  buffer: Buffer.from('fake-video-data'),
+  size: 1024,
+  destination: '',
+  filename: '',
+  path: '',
+  stream: null,
+};
+
+describe('AmazonS3Service', () => {
+  let app: NestExpressApplication;
+  let amazonS3Service: AmazonS3Service;
+
+  beforeAll(() => {
+    process.env.AWS_ACCESS_KEY_ID = 'mock-access-key-id';
+    process.env.AWS_SECRET_ACCESS_KEY = 'mock-secret-access-key';
+    process.env.AWS_REGION = 'mock-region';
+    process.env.S3_BUCKET = 'mock-bucket';
+    process.env.AWS_ENDPOINT = 'mock-endpoint';
+  });
+
+  beforeEach(async () => {
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+    app = moduleRef.createNestApplication();
+    setupApp(app);
+
+    amazonS3Service = moduleRef.get<AmazonS3Service>(
+      IMAGE_STORAGE_PROVIDER_SERVICE_KEY,
+    );
+  });
+
+  it('Should define the AmazonS3Service with the correct configuration', () => {
+    expect(amazonS3Service).toBeDefined();
+    expect(S3Client).toHaveBeenCalledTimes(1);
+    expect(S3Client).toHaveBeenCalledWith({
+      region: 'mock-region',
+      endpoint: 'mock-endpoint',
+      credentials: {
+        accessKeyId: 'mock-access-key-id',
+        secretAccessKey: 'mock-secret-access-key',
+      },
+      forcePathStyle: true,
+    });
+  });
+
+  it('Should upload a file to S3', async () => {
+    const url = await amazonS3Service.uploadFile(mockFile, 'folder');
+    const command = {
+      Bucket: 'mock-bucket',
+      Key: 'folder/mock-uuid.mp4',
+      Body: mockFile.buffer,
+      ACL: 'public-read',
+      ContentType: 'video/mp4',
+    };
+    expect(PutObjectCommand).toHaveBeenCalledTimes(1);
+    expect(PutObjectCommand).toHaveBeenCalledWith(command);
+
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    expect(sendMock).toHaveBeenCalledWith(command);
+    expect(url).toBe('mock-endpoint/mock-bucket/folder/mock-uuid.mp4');
+  });
+});

--- a/src/module/cloud/infrastructure/aws/s3/s3.service.ts
+++ b/src/module/cloud/infrastructure/aws/s3/s3.service.ts
@@ -1,0 +1,42 @@
+import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { v4 as uuidv4 } from 'uuid';
+
+import { IImageStorageProvider } from '@module/cloud/application/interface/image-storage-provider.interface';
+
+@Injectable()
+export class AmazonS3Service implements IImageStorageProvider {
+  s3: S3Client;
+
+  constructor(private readonly configService: ConfigService) {
+    this.s3 = new S3Client({
+      region: this.configService.get('aws.region'),
+      endpoint: this.configService.get('aws.endpoint'),
+      credentials: {
+        accessKeyId: this.configService.get('aws.credentials.accessKeyId'),
+        secretAccessKey: this.configService.get(
+          'aws.credentials.secretAccessKey',
+        ),
+      },
+      forcePathStyle: true,
+    });
+  }
+
+  async uploadFile(file: Express.Multer.File, folder: string): Promise<string> {
+    const id = uuidv4();
+    const positionSlash = file.mimetype.indexOf('/') + 1;
+    const key = `${id}.${file.mimetype.slice(positionSlash)}`;
+    const command = new PutObjectCommand({
+      Bucket: this.configService.get('s3.bucket'),
+      Key: `${folder}/${key}`,
+      Body: file.buffer,
+      ACL: 'public-read',
+      ContentType: file.mimetype,
+    });
+
+    await this.s3.send(command);
+
+    return `${this.configService.get('aws.endpoint')}/${this.configService.get('S3_BUCKET')}/${folder}/${key}`;
+  }
+}


### PR DESCRIPTION
# Summary

This PR introduces a `CloudModule` with a config for using Amazon S3 as image storage provider, using `LocalStack` with docker.

# Details

- Installed dependencies for creating the `AmazonS3Service`.
- Created the `CloudModule` with an `ImageStorageService` along with a generic `IImageStorageProviderService` interface.
- Added an `AmazonS3Service` that implements the `IImageStorageProviderService` and works as injectble provider for the `ImageStorageService`.