### PR TITLE
fix: Handle user save when avatar is missing

### DIFF
--- a/src/module/iam/authentication/__test__/authentication.e2e.spec.ts
+++ b/src/module/iam/authentication/__test__/authentication.e2e.spec.ts
@@ -203,7 +203,11 @@ describe('Authentication Module', () => {
 
         await request(app.getHttpServer())
           .post('/api/v1/auth/sign-up')
-          .send(signUpDto)
+          .field('email', signUpDto.email)
+          .field('password', signUpDto.password)
+          .field('firstName', signUpDto.firstName)
+          .field('lastName', signUpDto.lastName)
+          .attach('avatar', imageMock)
           .expect(HttpStatus.INTERNAL_SERVER_ERROR);
 
         const externalId = '00000000-0000-0000-0000-000000000002';

--- a/src/module/iam/authentication/application/dto/sign-up.dto.ts
+++ b/src/module/iam/authentication/application/dto/sign-up.dto.ts
@@ -1,4 +1,4 @@
-import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
+import { IsEmail, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 import { IDto } from '@common/base/application/dto/dto.interface';
 
@@ -18,4 +18,8 @@ export class SignUpDto implements IDto {
   @IsNotEmpty()
   @IsString()
   lastName: string;
+
+  @IsOptional()
+  @IsString()
+  avatarUrl?: string;
 }

--- a/src/module/iam/authentication/application/service/authentication.service.ts
+++ b/src/module/iam/authentication/application/service/authentication.service.ts
@@ -49,11 +49,10 @@ export class AuthenticationService {
     signUpDto: SignUpDto,
     avatar?: Express.Multer.File,
   ): Promise<UserResponseDto> {
-    const avatarUrl = await this.imageStorageService.uploadImage(
-      avatar,
-      AVATARS_FOLDER,
-    );
-    const { email, password, firstName, lastName } = signUpDto;
+    signUpDto.avatarUrl = avatar
+      ? await this.imageStorageService.uploadImage(avatar, AVATARS_FOLDER)
+      : null;
+    const { email, password, firstName, lastName, avatarUrl } = signUpDto;
 
     const existingUser = await this.userRepository.getOneByEmail(email);
 


### PR DESCRIPTION
# Summary

This PR fixes a bug that caused errors when trying to save an user without avatar image file.

# Details

- Refactor `handleSignUp` method to just use the `imageStorageService` when receving an image file.