### PR TITLE
feat: Add base dto with common properties

### DIFF
--- a/src/common/base/application/dto/base.dto.ts
+++ b/src/common/base/application/dto/base.dto.ts
@@ -1,0 +1,21 @@
+import { IsOptional, IsString } from 'class-validator';
+
+import { IDto } from '@common/base/application/dto/dto.interface';
+
+export class BaseDto implements IDto {
+  @IsString()
+  @IsOptional()
+  id: string;
+
+  @IsString()
+  @IsOptional()
+  createdAt?: string;
+
+  @IsString()
+  @IsOptional()
+  updatedAt?: string;
+
+  @IsString()
+  @IsOptional()
+  deletedAt?: string;
+}

--- a/src/common/base/application/dto/success-operation-response.dto.ts
+++ b/src/common/base/application/dto/success-operation-response.dto.ts
@@ -1,6 +1,8 @@
 import { BaseResponseDto } from '@common/base/application/dto/base.response.dto';
 import { ISuccessfulOperationResponse } from '@common/base/application/dto/successful-operation-response.interface';
 
+export const OPERATION_RESPONSE_TYPE = 'operation';
+
 export class SuccessOperationResponseDto
   extends BaseResponseDto
   implements ISuccessfulOperationResponse

--- a/src/common/base/application/service/base-crud.service.ts
+++ b/src/common/base/application/service/base-crud.service.ts
@@ -5,6 +5,10 @@ import {
   IResponseDto,
 } from '@common/base/application/dto/dto.interface';
 import { IGetAllOptions } from '@common/base/application/dto/get-all-options.interface';
+import {
+  OPERATION_RESPONSE_TYPE,
+  SuccessOperationResponseDto,
+} from '@common/base/application/dto/success-operation-response.dto';
 import { ICRUDService } from '@common/base/application/service/crud-service.interface';
 import IEntity from '@common/base/domain/entity.interface';
 import BaseRepository from '@common/base/infrastructure/database/base.repository';
@@ -67,7 +71,13 @@ export class BaseCRUDService<
     return responseDto;
   }
 
-  async deleteOneByIdOrFail(id: string): Promise<void> {
+  async deleteOneByIdOrFail(id: string): Promise<SuccessOperationResponseDto> {
     await this.repository.deleteOneByIdOrFail(id);
+
+    return new SuccessOperationResponseDto(
+      `The ${this.entityName} with id ${id} has been deleted successfully`,
+      true,
+      OPERATION_RESPONSE_TYPE,
+    );
   }
 }

--- a/src/module/iam/user/application/dto/user.dto.ts
+++ b/src/module/iam/user/application/dto/user.dto.ts
@@ -7,14 +7,11 @@ import {
   IsString,
 } from 'class-validator';
 
-import { IDto } from '@common/base/application/dto/dto.interface';
+import { BaseDto } from '@common/base/application/dto/base.dto';
 
 import { AppRole } from '@module/iam/authorization/domain/app-role.enum';
 
-export class UserDto implements IDto {
-  @IsString()
-  id: string;
-
+export class UserDto extends BaseDto {
   @IsEmail()
   @IsOptional()
   email?: string;
@@ -40,19 +37,7 @@ export class UserDto implements IDto {
   @IsOptional()
   roles?: AppRole[];
 
-  @IsString()
-  @IsOptional()
-  createdAt?: string;
-
-  @IsString()
-  @IsOptional()
-  updatedAt?: string;
-
   @IsBoolean()
   @IsOptional()
   isVerified: boolean;
-
-  @IsString()
-  @IsOptional()
-  deletedAt?: string;
 }


### PR DESCRIPTION
# Summary

This PR introduces a `BaseDto` with common properties such as `id`, `createdAt`, `deletedAt` and `updatedAt`. Also, add `SuccessResponseOperationDto` to the delete method from the `BaseCRUDService`.

# Details

- Added the `BaseDto` with common properties.
- Refactored the `UserDto` to extend the `BaseDto`.
- Updated the delete method from the `BaseCRUDService` to return a `SuccessResponseOperationDto`.