### PR TITLE
feat: Add course module with CRUD operations

### DIFF
--- a/data/migrations/1748282021077-addCourseTable.ts
+++ b/data/migrations/1748282021077-addCourseTable.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddCourseTable1748282021077 implements MigrationInterface {
+    name = 'AddCourseTable1748282021077'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "course" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "title" character varying NOT NULL, "description" character varying, "price" numeric(2), "image_url" character varying, "status" character varying NOT NULL DEFAULT 'drafted', "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), "deleted_at" TIMESTAMP, CONSTRAINT "UQ_bf95180dd756fd204fb01ce4916" UNIQUE ("id"), CONSTRAINT "PK_bf95180dd756fd204fb01ce4916" PRIMARY KEY ("id"))`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE "course"`);
+    }
+
+}

--- a/src/common/base/application/enum/publish-status.enum.ts
+++ b/src/common/base/application/enum/publish-status.enum.ts
@@ -1,0 +1,5 @@
+export enum PublishStatus {
+  published = 'published',
+  drafted = 'drafted',
+  archived = 'archived',
+}

--- a/src/common/base/application/service/crud-service.interface.ts
+++ b/src/common/base/application/service/crud-service.interface.ts
@@ -1,6 +1,7 @@
 import { CollectionDto } from '@common/base/application/dto/collection.dto';
 import { IDto, IResponseDto } from '@common/base/application/dto/dto.interface';
 import { IGetAllOptions } from '@common/base/application/dto/get-all-options.interface';
+import { SuccessOperationResponseDto } from '@common/base/application/dto/success-operation-response.dto';
 import IEntity from '@common/base/domain/entity.interface';
 
 export interface ICRUDService<
@@ -13,5 +14,5 @@ export interface ICRUDService<
   getOneByIdOrFail(id: string): Promise<ResponseDto>;
   saveOne(createDto: CreateDto): Promise<ResponseDto>;
   updateOne(id: string, updateDto: UpdateDto): Promise<ResponseDto>;
-  deleteOneByIdOrFail(id: string): Promise<void>;
+  deleteOneByIdOrFail(id: string): Promise<SuccessOperationResponseDto>;
 }

--- a/src/module/app.module.ts
+++ b/src/module/app.module.ts
@@ -7,6 +7,7 @@ import { datasourceOptions } from '@config/orm.config';
 
 import { LinkBuilderService } from '@module/app/application/service/link-builder.service';
 import { CloudModule } from '@module/cloud/cloud.module';
+import { CourseModule } from '@module/course/course.module';
 import { IamModule } from '@module/iam/iam.module';
 
 @Global()
@@ -24,6 +25,7 @@ import { IamModule } from '@module/iam/iam.module';
     }),
     CloudModule,
     IamModule,
+    CourseModule,
   ],
   providers: [LinkBuilderService],
   exports: [LinkBuilderService],

--- a/src/module/cloud/application/constants/image-storage-folders.constants.ts
+++ b/src/module/cloud/application/constants/image-storage-folders.constants.ts
@@ -1,1 +1,2 @@
 export const AVATARS_FOLDER = 'avatars';
+export const COURSES_IMAGES_FOLDER = 'courses/images';

--- a/src/module/course/__test__/course.e2e.spec.ts
+++ b/src/module/course/__test__/course.e2e.spec.ts
@@ -1,0 +1,494 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { HttpStatus } from '@nestjs/common';
+import { NestExpressApplication } from '@nestjs/platform-express';
+import path from 'path';
+import request from 'supertest';
+
+import { loadFixtures } from '@data/util/fixture-loader';
+
+import {
+  SerializedResponseDto,
+  SerializedResponseDtoCollection,
+} from '@common/base/application/dto/serialized-response.dto';
+import { SuccessOperationResponseDto } from '@common/base/application/dto/success-operation-response.dto';
+import { HttpMethod } from '@common/base/application/enum/http-method.enum';
+import { PublishStatus } from '@common/base/application/enum/publish-status.enum';
+
+import { setupApp } from '@config/app.config';
+import { datasourceOptions } from '@config/orm.config';
+
+import { testModuleBootstrapper } from '@test/test.module.bootstrapper';
+import { createAccessToken } from '@test/test.util';
+
+import { CourseResponseDto } from '@module/course/application/dto/course-response.dto';
+import { CourseDto } from '@module/course/application/dto/course.dto';
+import { CreateCourseDto } from '@module/course/application/dto/create-course.dto';
+import { UpdateCourseDto } from '@module/course/application/dto/update-course.dto';
+
+describe('Course Module', () => {
+  let app: NestExpressApplication;
+
+  const imageMock = path.resolve(
+    __dirname,
+    '../../../test/__mocks__/avatar.jpg',
+  );
+
+  const adminToken = createAccessToken({
+    sub: '00000000-0000-0000-0000-00000000000Y',
+  });
+
+  beforeAll(async () => {
+    await loadFixtures(`${__dirname}/fixture`, datasourceOptions);
+    const moduleRef = await testModuleBootstrapper();
+    app = moduleRef.createNestApplication({ logger: false });
+    setupApp(app);
+    await app.init();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  const endpoint = '/api/v1/course';
+
+  describe('GET - /course', () => {
+    it('Should return paginated courses', async () => {
+      return await request(app.getHttpServer())
+        .get(endpoint)
+        .auth(adminToken, { type: 'bearer' })
+        .expect(HttpStatus.OK)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            data: expect.arrayContaining([
+              expect.objectContaining({
+                id: expect.any(String),
+                type: 'course',
+                attributes: expect.objectContaining({
+                  title: expect.any(String),
+                  description: expect.any(String),
+                  price: expect.any(Number),
+                  imageUrl: expect.any(String),
+                  status: expect.any(String),
+                }),
+              }),
+            ]),
+            links: expect.arrayContaining([
+              expect.objectContaining({
+                rel: 'self',
+                href: expect.any(String),
+                method: HttpMethod.GET,
+              }),
+              expect.objectContaining({
+                rel: 'first',
+                href: expect.any(String),
+                method: HttpMethod.GET,
+              }),
+              expect.objectContaining({
+                rel: 'last',
+                href: expect.any(String),
+                method: HttpMethod.GET,
+              }),
+              expect.objectContaining({
+                rel: 'next',
+                href: expect.any(String),
+                method: HttpMethod.GET,
+              }),
+            ]),
+            meta: expect.objectContaining({
+              pageNumber: expect.any(Number),
+              pageSize: expect.any(Number),
+              pageCount: expect.any(Number),
+              itemCount: expect.any(Number),
+            }),
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should allow to filter by attributes', async () => {
+      const firstName = 'Introduction to Programming';
+      return request(app.getHttpServer())
+        .get(`${endpoint}?filter[title]=${firstName}`)
+        .auth(adminToken, { type: 'bearer' })
+        .expect(HttpStatus.OK)
+        .then(
+          ({
+            body,
+          }: {
+            body: SerializedResponseDtoCollection<CourseResponseDto>;
+          }) => {
+            const expectedResponse = expect.objectContaining({
+              data: expect.arrayContaining([
+                expect.objectContaining({
+                  attributes: expect.objectContaining({
+                    title: firstName,
+                  }),
+                }),
+              ]),
+            });
+            expect(body).toEqual(expectedResponse);
+            expect(body.data).toHaveLength(1);
+          },
+        );
+    });
+
+    it('Should allow to sort by attributes', async () => {
+      const firstCourse = { title: '' } as CourseDto;
+      const lastCourse = { title: '' } as CourseDto;
+      let pageCount: number;
+
+      await request(app.getHttpServer())
+        .get(`${endpoint}?sort[title]=DESC&page[size]=10`)
+        .auth(adminToken, { type: 'bearer' })
+        .expect(HttpStatus.OK)
+        .then(
+          ({
+            body,
+          }: {
+            body: SerializedResponseDtoCollection<CourseResponseDto>;
+          }) => {
+            firstCourse.title = body.data[0].attributes.title;
+            pageCount = body.meta.pageCount;
+          },
+        );
+
+      await request(app.getHttpServer())
+        .get(
+          `${endpoint}?page[size]=10&sort[title]=ASC&page[number]=${pageCount}`,
+        )
+        .auth(adminToken, { type: 'bearer' })
+        .expect(HttpStatus.OK)
+        .then(
+          ({
+            body,
+          }: {
+            body: SerializedResponseDtoCollection<CourseResponseDto>;
+          }) => {
+            const resources = body.data;
+            lastCourse.title = resources[resources.length - 1].attributes.title;
+            expect(lastCourse.title).toBe(firstCourse.title);
+          },
+        );
+    });
+
+    it('Should allow to select specific attributes', async () => {
+      const attributes = ['title', 'description'] as (keyof CourseDto)[];
+
+      await request(app.getHttpServer())
+        .get(`${endpoint}?page[size]=10&fields[target]=${attributes.join(',')}`)
+        .auth(adminToken, { type: 'bearer' })
+        .expect(HttpStatus.OK)
+        .then(
+          ({
+            body,
+          }: {
+            body: SerializedResponseDtoCollection<CourseResponseDto>;
+          }) => {
+            const resourceAttributes = body.data[0].attributes;
+            expect(Object.keys(resourceAttributes).length).toBe(
+              attributes.length,
+            );
+            expect(resourceAttributes).toEqual({
+              title: expect.any(String),
+              description: expect.any(String),
+            });
+          },
+        );
+    });
+  });
+
+  describe('GET - /course/:id', () => {
+    it('Should return a course by its id', async () => {
+      const courseId = '22f38dae-00f1-49ff-8f3f-0dd6539af032';
+      await request(app.getHttpServer())
+        .get(`${endpoint}/${courseId}`)
+        .auth(adminToken, { type: 'bearer' })
+        .expect(HttpStatus.OK)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            data: expect.objectContaining({
+              type: 'course',
+              id: courseId,
+              attributes: expect.objectContaining({
+                title: 'Introduction to Programming',
+                description: 'Learn the basics of programming with JavaScript',
+                price: 49.99,
+                imageUrl: expect.stringContaining('intro-programming.jpg'),
+                status: 'published',
+              }),
+            }),
+            links: expect.arrayContaining([
+              expect.objectContaining({
+                rel: 'self',
+                href: expect.stringContaining(`${endpoint}/${courseId}`),
+                method: HttpMethod.GET,
+              }),
+            ]),
+          });
+
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should throw an error if course is not found', async () => {
+      const nonExistingCourseId = '22f38dae-00f1-49ff-8f3f-0dd6539af039';
+      await request(app.getHttpServer())
+        .get(`${endpoint}/${nonExistingCourseId}`)
+        .auth(adminToken, { type: 'bearer' })
+        .expect(HttpStatus.NOT_FOUND)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `Entity with id ${nonExistingCourseId} not found`,
+              source: {
+                pointer: `${endpoint}/${nonExistingCourseId}`,
+              },
+              status: HttpStatus.NOT_FOUND.toString(),
+              title: 'Entity not found',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+  });
+
+  describe('POST - /course', () => {
+    it('Should create a new customer', async () => {
+      const createCourseDto = {
+        title: 'Introduction to Programming 2',
+        description: 'Learn the basics of programming with JavaScript 2',
+        price: 49.99,
+        status: PublishStatus.drafted,
+      } as CreateCourseDto;
+
+      await request(app.getHttpServer())
+        .post(endpoint)
+        .auth(adminToken, { type: 'bearer' })
+        .field('title', createCourseDto.title)
+        .field('description', createCourseDto.description)
+        .field('price', createCourseDto.price)
+        .field('status', createCourseDto.status)
+        .attach('image', imageMock)
+        .expect(HttpStatus.CREATED)
+        .then(({ body }) => {
+          const expectedResponse = {
+            data: expect.objectContaining({
+              type: 'course',
+              id: expect.any(String),
+              attributes: expect.objectContaining({
+                title: createCourseDto.title,
+                description: createCourseDto.description,
+                price: createCourseDto.price,
+                imageUrl: 'test-url',
+                status: createCourseDto.status,
+              }),
+            }),
+            links: expect.arrayContaining([
+              expect.objectContaining({
+                href: expect.stringContaining(endpoint),
+                rel: 'self',
+                method: HttpMethod.POST,
+              }),
+            ]),
+          };
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+  });
+
+  describe('PATCH - /course/:id', () => {
+    it('Should update an existing course', async () => {
+      const createCourseDto = {
+        title: 'Introduction to Programming 2',
+        description: 'Learn the basics of programming with JavaScript 2',
+        price: 49.99,
+        status: PublishStatus.drafted,
+      } as CreateCourseDto;
+
+      const updateCourseDto = {
+        title: 'Introduction to Programming 3',
+        description: 'Learn the basics of programming with JavaScript 3',
+        price: 49.99,
+        status: PublishStatus.published,
+      } as UpdateCourseDto;
+
+      let courseId: string;
+
+      await request(app.getHttpServer())
+        .post(endpoint)
+        .auth(adminToken, { type: 'bearer' })
+        .field('title', createCourseDto.title)
+        .field('description', createCourseDto.description)
+        .field('price', createCourseDto.price)
+        .field('status', createCourseDto.status)
+        .attach('image', imageMock)
+        .expect(HttpStatus.CREATED)
+        .then(
+          ({ body }: { body: SerializedResponseDto<CourseResponseDto> }) => {
+            const expectedResponse = {
+              data: expect.objectContaining({
+                type: 'course',
+                id: expect.any(String),
+                attributes: expect.objectContaining({
+                  title: createCourseDto.title,
+                  description: createCourseDto.description,
+                  price: createCourseDto.price,
+                  imageUrl: 'test-url',
+                  status: createCourseDto.status,
+                }),
+              }),
+              links: expect.arrayContaining([
+                expect.objectContaining({
+                  href: expect.stringContaining(endpoint),
+                  rel: 'self',
+                  method: HttpMethod.POST,
+                }),
+              ]),
+            };
+            expect(body).toEqual(expectedResponse);
+            courseId = body.data.id;
+          },
+        );
+
+      await request(app.getHttpServer())
+        .patch(`${endpoint}/${courseId}`)
+        .auth(adminToken, { type: 'bearer' })
+        .field('title', updateCourseDto.title)
+        .field('description', updateCourseDto.description)
+        .field('price', updateCourseDto.price)
+        .field('status', updateCourseDto.status)
+        .attach('image', imageMock)
+        .expect(HttpStatus.OK)
+        .then(
+          ({ body }: { body: SerializedResponseDto<CourseResponseDto> }) => {
+            const expectedResponse = {
+              data: expect.objectContaining({
+                type: 'course',
+                id: expect.any(String),
+                attributes: expect.objectContaining({
+                  title: updateCourseDto.title,
+                  description: updateCourseDto.description,
+                  price: updateCourseDto.price,
+                  imageUrl: 'test-url',
+                  status: updateCourseDto.status,
+                }),
+              }),
+              links: expect.arrayContaining([
+                expect.objectContaining({
+                  href: expect.stringContaining(endpoint),
+                  rel: 'self',
+                  method: HttpMethod.PATCH,
+                }),
+              ]),
+            };
+            expect(body).toEqual(expectedResponse);
+          },
+        );
+    });
+
+    it('Should throw an error if course to update is not found', async () => {
+      const nonExistingCustomerId = '22f38dae-00f1-49ff-8f3f-0dd6539af039';
+
+      await request(app.getHttpServer())
+        .patch(`${endpoint}/${nonExistingCustomerId}`)
+        .auth(adminToken, { type: 'bearer' })
+        .expect(HttpStatus.NOT_FOUND)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `Entity with id ${nonExistingCustomerId} not found`,
+              source: {
+                pointer: `${endpoint}/${nonExistingCustomerId}`,
+              },
+              status: '404',
+              title: 'Entity not found',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+  });
+
+  describe('DELETE - /course/:id', () => {
+    it('Should delete an existing course', async () => {
+      const createCourseDto = {
+        title: 'Introduction to Programming 2',
+        description: 'Learn the basics of programming with JavaScript 2',
+        price: 49.99,
+        status: PublishStatus.drafted,
+      } as CreateCourseDto;
+
+      let courseId: string;
+
+      await request(app.getHttpServer())
+        .post(endpoint)
+        .auth(adminToken, { type: 'bearer' })
+        .field('title', createCourseDto.title)
+        .field('description', createCourseDto.description)
+        .field('price', createCourseDto.price)
+        .field('status', createCourseDto.status)
+        .attach('image', imageMock)
+        .expect(HttpStatus.CREATED)
+        .then(
+          ({ body }: { body: SerializedResponseDto<CourseResponseDto> }) => {
+            const expectedResponse = {
+              data: expect.objectContaining({
+                type: 'course',
+                id: expect.any(String),
+                attributes: expect.objectContaining({
+                  title: createCourseDto.title,
+                  description: createCourseDto.description,
+                  price: createCourseDto.price,
+                  imageUrl: 'test-url',
+                  status: createCourseDto.status,
+                }),
+              }),
+              links: expect.arrayContaining([
+                expect.objectContaining({
+                  href: expect.stringContaining(endpoint),
+                  rel: 'self',
+                  method: HttpMethod.POST,
+                }),
+              ]),
+            };
+            expect(body).toEqual(expectedResponse);
+            courseId = body.data.id;
+          },
+        );
+
+      await request(app.getHttpServer())
+        .delete(`${endpoint}/${courseId}`)
+        .auth(adminToken, { type: 'bearer' })
+        .expect(HttpStatus.OK)
+        .then(
+          ({
+            body,
+          }: {
+            body: SerializedResponseDto<SuccessOperationResponseDto>;
+          }) => {
+            const expectedResponse = expect.objectContaining({
+              data: expect.objectContaining({
+                type: 'operation',
+                attributes: expect.objectContaining({
+                  message: `The course with id ${courseId} has been deleted successfully`,
+                  success: true,
+                }),
+              }),
+              links: expect.arrayContaining([
+                expect.objectContaining({
+                  href: expect.stringContaining(endpoint),
+                  rel: 'self',
+                  method: HttpMethod.DELETE,
+                }),
+              ]),
+            });
+            expect(body).toEqual(expectedResponse);
+          },
+        );
+    });
+  });
+});

--- a/src/module/course/__test__/fixture/Course.yml
+++ b/src/module/course/__test__/fixture/Course.yml
@@ -1,0 +1,27 @@
+entity: Course
+items:
+  course1:
+    id: '22f38dae-00f1-49ff-8f3f-0dd6539af032'
+    title: 'Introduction to Programming'
+    description: 'Learn the basics of programming with JavaScript'
+    price: 49.99
+    imageUrl: '{{internet.url}}/intro-programming.jpg'
+    status: published
+  course2:
+    title: 'Advanced Web Development'
+    description: 'Master React, Node.js and modern web architectures'
+    price: 89.99
+    imageUrl: '{{internet.url}}/advanced-web.jpg'
+    status: archived
+  course3:
+    title: 'Data Science Fundamentals'
+    description: 'Introduction to data analysis and machine learning'
+    price: 79.99
+    imageUrl: '{{internet.url}}/data-science.jpg'
+    status: drafted
+  course{4..23}:
+    title: '{{commerce.productName}} Course'
+    description: '{{lorem.paragraph}}'
+    price: '{{commerce.price}}'
+    imageUrl: '{{internet.url}}/course-{{@key.replace("course", "")}}.jpg'
+    status: '{{@key % 3 == 0 ? "drafted" : (@key % 3 == 1 ? "published" : "archived")}}'

--- a/src/module/course/__test__/fixture/User.yml
+++ b/src/module/course/__test__/fixture/User.yml
@@ -1,0 +1,23 @@
+entity: User
+items:
+  super-admin-user:
+    firstName: super-admin-name
+    lastName: super-admin-surname
+    email: 'test_super_admin@email.co'
+    avatarUrl: '{{internet.url}}'
+    externalId: '00000000-0000-0000-0000-00000000000X'
+    roles: regular,admin,superAdmin
+  admin-user:
+    firstName: admin-name
+    lastName: admin-surname
+    email: 'test_admin@email.co'
+    avatarUrl: '{{internet.url}}'
+    externalId: '00000000-0000-0000-0000-00000000000Y'
+    roles: regular,admin
+  user{2..23}:
+    firstName: '{{person.firstName}}'
+    lastName: '{{person.lastName}}'
+    avatarUrl: '{{internet.url}}'
+    email: '{{internet.email}}'
+    externalId: '{{string.uuid}}'
+    roles: regular

--- a/src/module/course/application/dto/course-fields-query-params.dto.ts
+++ b/src/module/course/application/dto/course-fields-query-params.dto.ts
@@ -1,0 +1,33 @@
+import { Transform } from 'class-transformer';
+import { IsIn, IsOptional } from 'class-validator';
+
+import { IGetAllOptions } from '@common/base/application/dto/get-all-options.interface';
+import { fromCommaSeparatedToArray } from '@common/base/application/mapper/base.mapper';
+
+import { Course } from '@module/course/domain/course.entity';
+
+type CourseFields = IGetAllOptions<Course>['fields'];
+
+export class CourseFieldsQueryParamsDto {
+  @IsIn(
+    [
+      'id',
+      'title',
+      'description',
+      'price',
+      'imageUrl',
+      'status',
+      'createdAt',
+      'updatedAt',
+      'deletedAt',
+    ] as CourseFields,
+    {
+      each: true,
+    },
+  )
+  @Transform((params) => {
+    return fromCommaSeparatedToArray(params.value as string);
+  })
+  @IsOptional()
+  target?: CourseFields;
+}

--- a/src/module/course/application/dto/course-filter-query-params.dto.ts
+++ b/src/module/course/application/dto/course-filter-query-params.dto.ts
@@ -1,0 +1,33 @@
+import { IsEnum, IsNumber, IsOptional, IsString } from 'class-validator';
+
+import { PublishStatus } from '@common/base/application/enum/publish-status.enum';
+
+export class CourseFilterQueryParamsDto {
+  @IsString()
+  @IsOptional()
+  title?: string;
+
+  @IsString()
+  @IsOptional()
+  description?: string;
+
+  @IsNumber()
+  @IsOptional()
+  price?: number;
+
+  @IsEnum(PublishStatus)
+  @IsOptional()
+  status?: PublishStatus;
+
+  @IsString()
+  @IsOptional()
+  createdAt?: string;
+
+  @IsString()
+  @IsOptional()
+  updatedAt?: string;
+
+  @IsString()
+  @IsOptional()
+  deletedAt?: string;
+}

--- a/src/module/course/application/dto/course-response.dto.ts
+++ b/src/module/course/application/dto/course-response.dto.ts
@@ -1,0 +1,27 @@
+import { BaseResponseDto } from '@common/base/application/dto/base.response.dto';
+import { PublishStatus } from '@common/base/application/enum/publish-status.enum';
+
+export class CourseResponseDto extends BaseResponseDto {
+  title: string;
+  description: string;
+  price: number;
+  imageUrl: string;
+  status: PublishStatus;
+  constructor(
+    type: string,
+    title: string,
+    description: string,
+    price: number,
+    imageUrl: string,
+    status: PublishStatus,
+    id?: string,
+  ) {
+    super(type, id);
+
+    this.title = title;
+    this.description = description;
+    this.price = price;
+    this.imageUrl = imageUrl;
+    this.status = status;
+  }
+}

--- a/src/module/course/application/dto/course-sort-query-params.dto.ts
+++ b/src/module/course/application/dto/course-sort-query-params.dto.ts
@@ -1,0 +1,29 @@
+import { IsEnum, IsOptional } from 'class-validator';
+
+import { SortType } from '@common/base/application/enum/sort-type.enum';
+
+export class CourseSortQueryParamsDto {
+  @IsEnum(SortType)
+  @IsOptional()
+  title?: SortType;
+
+  @IsEnum(SortType)
+  @IsOptional()
+  description?: SortType;
+
+  @IsEnum(SortType)
+  @IsOptional()
+  number?: SortType;
+
+  @IsEnum(SortType)
+  @IsOptional()
+  status?: SortType;
+
+  @IsEnum(SortType)
+  @IsOptional()
+  createdAt?: SortType;
+
+  @IsEnum(SortType)
+  @IsOptional()
+  updatedAt?: SortType;
+}

--- a/src/module/course/application/dto/course.dto.ts
+++ b/src/module/course/application/dto/course.dto.ts
@@ -1,0 +1,26 @@
+import { IsEnum, IsNumber, IsOptional, IsString } from 'class-validator';
+
+import { BaseDto } from '@common/base/application/dto/base.dto';
+import { PublishStatus } from '@common/base/application/enum/publish-status.enum';
+
+export class CourseDto extends BaseDto {
+  @IsOptional()
+  @IsString()
+  title: string;
+
+  @IsOptional()
+  @IsString()
+  description: string;
+
+  @IsOptional()
+  @IsNumber()
+  price: number;
+
+  @IsOptional()
+  @IsString()
+  imageUrl: string;
+
+  @IsOptional()
+  @IsEnum(PublishStatus)
+  status: PublishStatus;
+}

--- a/src/module/course/application/dto/create-course.dto.ts
+++ b/src/module/course/application/dto/create-course.dto.ts
@@ -1,0 +1,3 @@
+import { CourseDto } from '@module/course/application/dto/course.dto';
+
+export class CreateCourseDto extends CourseDto {}

--- a/src/module/course/application/dto/update-course.dto.ts
+++ b/src/module/course/application/dto/update-course.dto.ts
@@ -1,0 +1,5 @@
+import { PartialType } from '@nestjs/mapped-types';
+
+import { CreateCourseDto } from '@module/course/application/dto/create-course.dto';
+
+export class UpdateCourseDto extends PartialType(CreateCourseDto) {}

--- a/src/module/course/application/mapper/course.mapper.ts
+++ b/src/module/course/application/mapper/course.mapper.ts
@@ -1,0 +1,45 @@
+import { IDtoMapper } from '@common/base/application/dto/dto.interface';
+
+import { CourseResponseDto } from '@module/course/application/dto/course-response.dto';
+import { CreateCourseDto } from '@module/course/application/dto/create-course.dto';
+import { UpdateCourseDto } from '@module/course/application/dto/update-course.dto';
+import { Course } from '@module/course/domain/course.entity';
+
+export class CourseMapper
+  implements
+    IDtoMapper<Course, CreateCourseDto, UpdateCourseDto, CourseResponseDto>
+{
+  fromCreateDtoToEntity(dto: CreateCourseDto): Course {
+    return new Course(
+      dto.id,
+      dto.title,
+      dto.description,
+      dto.price,
+      dto.imageUrl,
+      dto.status,
+    );
+  }
+
+  fromUpdateDtoToEntity(dto: UpdateCourseDto): Course {
+    return new Course(
+      dto.id,
+      dto.title,
+      dto.description,
+      dto.price,
+      dto.imageUrl,
+      dto.status,
+    );
+  }
+
+  fromEntityToResponseDto(entity: Course): CourseResponseDto {
+    return new CourseResponseDto(
+      Course.getEntityName(),
+      entity.title,
+      entity.description,
+      entity.price,
+      entity.imageUrl,
+      entity.status,
+      entity.id,
+    );
+  }
+}

--- a/src/module/course/application/repository/repository.interface.ts
+++ b/src/module/course/application/repository/repository.interface.ts
@@ -1,0 +1,8 @@
+import BaseRepository from '@common/base/infrastructure/database/base.repository';
+
+import { Course } from '@module/course/domain/course.entity';
+
+export const COURSE_REPOSITORY_KEY = 'course_repository';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface ICourseRepository extends BaseRepository<Course> {}

--- a/src/module/course/application/service/course.service.ts
+++ b/src/module/course/application/service/course.service.ts
@@ -1,0 +1,52 @@
+import { Inject, Injectable } from '@nestjs/common';
+
+import { BaseCRUDService } from '@common/base/application/service/base-crud.service';
+
+import { COURSES_IMAGES_FOLDER } from '@module/cloud/application/constants/image-storage-folders.constants';
+import { ImageStorageService } from '@module/cloud/application/service/image-storage.service';
+import { CourseResponseDto } from '@module/course/application/dto/course-response.dto';
+import { CreateCourseDto } from '@module/course/application/dto/create-course.dto';
+import { UpdateCourseDto } from '@module/course/application/dto/update-course.dto';
+import { CourseMapper } from '@module/course/application/mapper/course.mapper';
+import {
+  COURSE_REPOSITORY_KEY,
+  ICourseRepository,
+} from '@module/course/application/repository/repository.interface';
+import { Course } from '@module/course/domain/course.entity';
+
+@Injectable()
+export class CourseService extends BaseCRUDService<
+  Course,
+  CreateCourseDto,
+  UpdateCourseDto,
+  CourseResponseDto
+> {
+  constructor(
+    @Inject(COURSE_REPOSITORY_KEY) repository: ICourseRepository,
+    protected readonly mapper: CourseMapper,
+    private readonly imageStorageService: ImageStorageService,
+  ) {
+    super(repository, mapper, Course.getEntityName());
+  }
+
+  async saveOne(
+    createDto: CreateCourseDto,
+    image?: Express.Multer.File,
+  ): Promise<CourseResponseDto> {
+    createDto.imageUrl = image
+      ? await this.imageStorageService.uploadImage(image, COURSES_IMAGES_FOLDER)
+      : null;
+    return super.saveOne(createDto);
+  }
+
+  async updateOne(
+    id: string,
+    updateDto: UpdateCourseDto,
+    image?: Express.Multer.File,
+  ): Promise<CourseResponseDto> {
+    updateDto.imageUrl = image
+      ? await this.imageStorageService.uploadImage(image, COURSES_IMAGES_FOLDER)
+      : null;
+    return super.updateOne(id, updateDto);
+  }
+}

--- a/src/module/course/course.module.ts
+++ b/src/module/course/course.module.ts
@@ -1,0 +1,21 @@
+import { Module, Provider } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { CourseMapper } from '@module/course/application/mapper/course.mapper';
+import { COURSE_REPOSITORY_KEY } from '@module/course/application/repository/repository.interface';
+import { CourseService } from '@module/course/application/service/course.service';
+import { CoursePostgresRepository } from '@module/course/infrastructure/database/course.postrges.repository';
+import { CourseSchema } from '@module/course/infrastructure/database/course.schema';
+import { CourseController } from '@module/course/interface/course.controller';
+
+const courseRepositoryProvider: Provider = {
+  provide: COURSE_REPOSITORY_KEY,
+  useClass: CoursePostgresRepository,
+};
+
+@Module({
+  imports: [TypeOrmModule.forFeature([CourseSchema])],
+  providers: [CourseService, courseRepositoryProvider, CourseMapper],
+  controllers: [CourseController],
+})
+export class CourseModule {}

--- a/src/module/course/domain/course.entity.ts
+++ b/src/module/course/domain/course.entity.ts
@@ -1,0 +1,26 @@
+import { PublishStatus } from '@common/base/application/enum/publish-status.enum';
+import { Base } from '@common/base/domain/base.entity';
+
+export class Course extends Base {
+  title: string;
+  description: string;
+  price: number;
+  imageUrl: string;
+  status: PublishStatus;
+
+  constructor(
+    id: string,
+    title: string,
+    description: string,
+    price: number,
+    imageUrl: string,
+    status: PublishStatus,
+  ) {
+    super(id);
+    this.title = title;
+    this.description = description;
+    this.price = price;
+    this.imageUrl = imageUrl;
+    this.status = status;
+  }
+}

--- a/src/module/course/infrastructure/database/course.postrges.repository.ts
+++ b/src/module/course/infrastructure/database/course.postrges.repository.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import BaseRepository from '@common/base/infrastructure/database/base.repository';
+
+import { Course } from '@module/course/domain/course.entity';
+import { CourseSchema } from '@module/course/infrastructure/database/course.schema';
+
+@Injectable()
+export class CoursePostgresRepository extends BaseRepository<Course> {
+  constructor(@InjectRepository(CourseSchema) repository: Repository<Course>) {
+    super(repository);
+  }
+}

--- a/src/module/course/infrastructure/database/course.schema.ts
+++ b/src/module/course/infrastructure/database/course.schema.ts
@@ -1,0 +1,34 @@
+import { EntitySchema } from 'typeorm';
+
+import { PublishStatus } from '@common/base/application/enum/publish-status.enum';
+import { withBaseSchemaColumns } from '@common/base/infrastructure/database/base.schema';
+
+import { Course } from '@module/course/domain/course.entity';
+
+export const CourseSchema = new EntitySchema<Course>({
+  name: 'Course',
+  target: Course,
+  tableName: 'course',
+  columns: withBaseSchemaColumns({
+    title: {
+      type: String,
+    },
+    description: {
+      type: String,
+      nullable: true,
+    },
+    price: {
+      type: 'decimal',
+      precision: 2,
+      nullable: true,
+    },
+    imageUrl: {
+      type: String,
+      nullable: true,
+    },
+    status: {
+      type: String,
+      default: PublishStatus.drafted,
+    },
+  }),
+});

--- a/src/module/course/interface/course.controller.ts
+++ b/src/module/course/interface/course.controller.ts
@@ -1,0 +1,79 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  Query,
+  UploadedFile,
+  UseInterceptors,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+
+import { CollectionDto } from '@common/base/application/dto/collection.dto';
+import { PageQueryParamsDto } from '@common/base/application/dto/page-query-params';
+import { SuccessOperationResponseDto } from '@common/base/application/dto/success-operation-response.dto';
+import { ImageOptionsFactory } from '@common/base/application/factory/image-options.factory';
+
+import { CourseFieldsQueryParamsDto } from '@module/course/application/dto/course-fields-query-params.dto';
+import { CourseFilterQueryParamsDto } from '@module/course/application/dto/course-filter-query-params.dto';
+import { CourseResponseDto } from '@module/course/application/dto/course-response.dto';
+import { CourseSortQueryParamsDto } from '@module/course/application/dto/course-sort-query-params.dto';
+import { CreateCourseDto } from '@module/course/application/dto/create-course.dto';
+import { UpdateCourseDto } from '@module/course/application/dto/update-course.dto';
+import { CourseService } from '@module/course/application/service/course.service';
+
+@UseInterceptors(FileInterceptor('image', ImageOptionsFactory.create('image')))
+@Controller('course')
+export class CourseController {
+  constructor(private readonly courseService: CourseService) {}
+
+  @Get()
+  async getAll(
+    @Query('page') page: PageQueryParamsDto,
+    @Query('filter') filter: CourseFilterQueryParamsDto,
+    @Query('fields') fields: CourseFieldsQueryParamsDto,
+    @Query('sort') sort: CourseSortQueryParamsDto,
+  ): Promise<CollectionDto<CourseResponseDto>> {
+    return await this.courseService.getAll({
+      page,
+      filter,
+      fields: fields.target,
+      sort,
+    });
+  }
+
+  @Get(':id')
+  async getOne(
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<CourseResponseDto> {
+    return await this.courseService.getOneByIdOrFail(id);
+  }
+
+  @Post()
+  async saveOne(
+    @Body() createDto: CreateCourseDto,
+    @UploadedFile() image?: Express.Multer.File,
+  ): Promise<CourseResponseDto> {
+    return await this.courseService.saveOne(createDto, image);
+  }
+
+  @Patch(':id')
+  async updateOne(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() updateDto: UpdateCourseDto,
+    @UploadedFile() image?: Express.Multer.File,
+  ): Promise<CourseResponseDto> {
+    return await this.courseService.updateOne(id, updateDto, image);
+  }
+
+  @Delete(':id')
+  async deleteOneByIdOrFail(
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<SuccessOperationResponseDto> {
+    return await this.courseService.deleteOneByIdOrFail(id);
+  }
+}


### PR DESCRIPTION
# Summary

This PR introduces a `CourseModule` with it `Controller`, `Service` and `PostgresRepository` in order to implement CRUD operations.

# Details

- Added the `Course` domain and schema entities.
- Created the necessary Dtos for validating request and responses.
- Implemented a mapper to handle transformations between DTOs and entities.
- Added the `CourseController`, `CourseService`, `CoursePostgresRepository` for handling CRUD operations.
- Developed E2E tests to verify the functionality of the CourseModule CRUD operations.