### PR TITLE
feat: Add slug to course entity

### DIFF
--- a/data/migrations/1748284919579-addSlugToCourseTable.ts
+++ b/data/migrations/1748284919579-addSlugToCourseTable.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddSlugToCourseTable1748284919579 implements MigrationInterface {
+    name = 'AddSlugToCourseTable1748284919579'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "course" ADD "slug" character varying`);
+        await queryRunner.query(`ALTER TABLE "course" ADD CONSTRAINT "UQ_a101f48e5045bcf501540a4a5b8" UNIQUE ("slug")`);
+        await queryRunner.query(`ALTER TABLE "course" ADD CONSTRAINT "UQ_bf95180dd756fd204fb01ce4916" UNIQUE ("id")`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "course" DROP CONSTRAINT "UQ_bf95180dd756fd204fb01ce4916"`);
+        await queryRunner.query(`ALTER TABLE "course" DROP CONSTRAINT "UQ_a101f48e5045bcf501540a4a5b8"`);
+        await queryRunner.query(`ALTER TABLE "course" DROP COLUMN "slug"`);
+    }
+
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "pg": "^8.15.6",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
+        "slugify": "^1.6.6",
         "typeorm": "^0.3.23",
         "typeorm-naming-strategies": "^4.1.0",
         "uuid": "^11.1.0"
@@ -16773,6 +16774,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slugify": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/sort-keys": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "pg": "^8.15.6",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
+    "slugify": "^1.6.6",
     "typeorm": "^0.3.23",
     "typeorm-naming-strategies": "^4.1.0",
     "uuid": "^11.1.0"

--- a/src/module/app.module.ts
+++ b/src/module/app.module.ts
@@ -6,6 +6,7 @@ import { environmentConfig } from '@config/environment.config';
 import { datasourceOptions } from '@config/orm.config';
 
 import { LinkBuilderService } from '@module/app/application/service/link-builder.service';
+import { SlugService } from '@module/app/application/service/slug.service';
 import { CloudModule } from '@module/cloud/cloud.module';
 import { CourseModule } from '@module/course/course.module';
 import { IamModule } from '@module/iam/iam.module';
@@ -27,7 +28,7 @@ import { IamModule } from '@module/iam/iam.module';
     IamModule,
     CourseModule,
   ],
-  providers: [LinkBuilderService],
-  exports: [LinkBuilderService],
+  providers: [LinkBuilderService, SlugService],
+  exports: [LinkBuilderService, SlugService],
 })
 export class AppModule {}

--- a/src/module/app/application/service/slug-service.interface.ts
+++ b/src/module/app/application/service/slug-service.interface.ts
@@ -1,0 +1,4 @@
+export interface ISlugService {
+  buildSlug(text: string): string;
+  buildUniqueSlug(baseText: string, existingSlugs: string[]): string;
+}

--- a/src/module/app/application/service/slug.service.ts
+++ b/src/module/app/application/service/slug.service.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@nestjs/common';
+import slugify from 'slugify';
+
+import { ISlugService } from '@module/app/application/service/slug-service.interface';
+
+@Injectable()
+export class SlugService implements ISlugService {
+  private readonly slugOptions = {
+    lower: true,
+    strict: true,
+    trim: true,
+  };
+
+  constructor() {}
+
+  public buildSlug(text: string): string {
+    return slugify(text, this.slugOptions);
+  }
+
+  public buildUniqueSlug(baseSlug: string, existingSlugs: string[]): string {
+    if (!this.slugExists(baseSlug, existingSlugs)) {
+      return baseSlug;
+    }
+
+    const nextSuffix = this.calculateNextSuffix(baseSlug, existingSlugs);
+    return `${baseSlug}-${nextSuffix}`;
+  }
+
+  private slugExists(slug: string, existingSlugs: string[]): boolean {
+    return existingSlugs.includes(slug);
+  }
+
+  private calculateNextSuffix(
+    baseSlug: string,
+    existingSlugs: string[],
+  ): number {
+    const suffixPattern = new RegExp(`^${baseSlug}-(\\d+)$`);
+    const suffixes = existingSlugs
+      .map((slug) => {
+        const match = slug.match(suffixPattern);
+        return match ? parseInt(match[1], 10) : null;
+      })
+      .filter((n): n is number => n !== null);
+
+    return suffixes.length > 0 ? Math.max(...suffixes) + 1 : 2;
+  }
+}

--- a/src/module/course/__test__/course.e2e.spec.ts
+++ b/src/module/course/__test__/course.e2e.spec.ts
@@ -73,6 +73,7 @@ describe('Course Module', () => {
                   price: expect.any(Number),
                   imageUrl: expect.any(String),
                   status: expect.any(String),
+                  slug: expect.any(String),
                 }),
               }),
             ]),
@@ -219,6 +220,7 @@ describe('Course Module', () => {
                 price: 49.99,
                 imageUrl: expect.stringContaining('intro-programming.jpg'),
                 status: 'published',
+                slug: 'introduction-to-programming',
               }),
             }),
             links: expect.arrayContaining([
@@ -285,6 +287,90 @@ describe('Course Module', () => {
                 price: createCourseDto.price,
                 imageUrl: 'test-url',
                 status: createCourseDto.status,
+                slug: 'introduction-to-programming-2',
+              }),
+            }),
+            links: expect.arrayContaining([
+              expect.objectContaining({
+                href: expect.stringContaining(endpoint),
+                rel: 'self',
+                method: HttpMethod.POST,
+              }),
+            ]),
+          };
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should generate a different slug if the title already exists', async () => {
+      const firstCreateCourseDto = {
+        title: 'Introduction to Fishing',
+        description: 'Learn the basics of fishing',
+        price: 49.99,
+        status: PublishStatus.drafted,
+      } as CreateCourseDto;
+      const secondCreateCourseDto = {
+        title: 'Introduction to Fishing',
+        description: 'Learn the basics of fishing',
+        price: 49.99,
+        status: PublishStatus.drafted,
+      } as CreateCourseDto;
+
+      await request(app.getHttpServer())
+        .post(endpoint)
+        .auth(adminToken, { type: 'bearer' })
+        .field('title', firstCreateCourseDto.title)
+        .field('description', firstCreateCourseDto.description)
+        .field('price', firstCreateCourseDto.price)
+        .field('status', firstCreateCourseDto.status)
+        .attach('image', imageMock)
+        .expect(HttpStatus.CREATED)
+        .then(({ body }) => {
+          const expectedResponse = {
+            data: expect.objectContaining({
+              type: 'course',
+              id: expect.any(String),
+              attributes: expect.objectContaining({
+                title: firstCreateCourseDto.title,
+                description: firstCreateCourseDto.description,
+                price: firstCreateCourseDto.price,
+                imageUrl: 'test-url',
+                status: firstCreateCourseDto.status,
+                slug: 'introduction-to-fishing',
+              }),
+            }),
+            links: expect.arrayContaining([
+              expect.objectContaining({
+                href: expect.stringContaining(endpoint),
+                rel: 'self',
+                method: HttpMethod.POST,
+              }),
+            ]),
+          };
+          expect(body).toEqual(expectedResponse);
+        });
+
+      await request(app.getHttpServer())
+        .post(endpoint)
+        .auth(adminToken, { type: 'bearer' })
+        .field('title', secondCreateCourseDto.title)
+        .field('description', secondCreateCourseDto.description)
+        .field('price', secondCreateCourseDto.price)
+        .field('status', secondCreateCourseDto.status)
+        .attach('image', imageMock)
+        .expect(HttpStatus.CREATED)
+        .then(({ body }) => {
+          const expectedResponse = {
+            data: expect.objectContaining({
+              type: 'course',
+              id: expect.any(String),
+              attributes: expect.objectContaining({
+                title: secondCreateCourseDto.title,
+                description: secondCreateCourseDto.description,
+                price: secondCreateCourseDto.price,
+                imageUrl: 'test-url',
+                status: secondCreateCourseDto.status,
+                slug: 'introduction-to-fishing-2',
               }),
             }),
             links: expect.arrayContaining([
@@ -303,15 +389,15 @@ describe('Course Module', () => {
   describe('PATCH - /course/:id', () => {
     it('Should update an existing course', async () => {
       const createCourseDto = {
-        title: 'Introduction to Programming 2',
-        description: 'Learn the basics of programming with JavaScript 2',
+        title: 'Introduction to English',
+        description: 'Learn the basics of english',
         price: 49.99,
         status: PublishStatus.drafted,
       } as CreateCourseDto;
 
       const updateCourseDto = {
-        title: 'Introduction to Programming 3',
-        description: 'Learn the basics of programming with JavaScript 3',
+        title: 'Introduction to English Language',
+        description: 'Learn the basics of English language',
         price: 49.99,
         status: PublishStatus.published,
       } as UpdateCourseDto;
@@ -339,6 +425,7 @@ describe('Course Module', () => {
                   price: createCourseDto.price,
                   imageUrl: 'test-url',
                   status: createCourseDto.status,
+                  slug: 'introduction-to-english',
                 }),
               }),
               links: expect.arrayContaining([
@@ -416,8 +503,8 @@ describe('Course Module', () => {
   describe('DELETE - /course/:id', () => {
     it('Should delete an existing course', async () => {
       const createCourseDto = {
-        title: 'Introduction to Programming 2',
-        description: 'Learn the basics of programming with JavaScript 2',
+        title: 'Introduction to football',
+        description: 'Learn the basics of football',
         price: 49.99,
         status: PublishStatus.drafted,
       } as CreateCourseDto;
@@ -445,6 +532,7 @@ describe('Course Module', () => {
                   price: createCourseDto.price,
                   imageUrl: 'test-url',
                   status: createCourseDto.status,
+                  slug: 'introduction-to-football',
                 }),
               }),
               links: expect.arrayContaining([

--- a/src/module/course/__test__/fixture/Course.yml
+++ b/src/module/course/__test__/fixture/Course.yml
@@ -7,21 +7,25 @@ items:
     price: 49.99
     imageUrl: '{{internet.url}}/intro-programming.jpg'
     status: published
+    slug: 'introduction-to-programming'
   course2:
     title: 'Advanced Web Development'
     description: 'Master React, Node.js and modern web architectures'
     price: 89.99
     imageUrl: '{{internet.url}}/advanced-web.jpg'
     status: archived
+    slug: 'advanced-web-development'
   course3:
     title: 'Data Science Fundamentals'
     description: 'Introduction to data analysis and machine learning'
     price: 79.99
     imageUrl: '{{internet.url}}/data-science.jpg'
     status: drafted
+    slug: 'data-science-fundamentals'
   course{4..23}:
     title: '{{commerce.productName}} Course'
     description: '{{lorem.paragraph}}'
     price: '{{commerce.price}}'
     imageUrl: '{{internet.url}}/course-{{@key.replace("course", "")}}.jpg'
     status: '{{@key % 3 == 0 ? "drafted" : (@key % 3 == 1 ? "published" : "archived")}}'
+    slug: '{{lorem.slug}}'

--- a/src/module/course/application/dto/course-fields-query-params.dto.ts
+++ b/src/module/course/application/dto/course-fields-query-params.dto.ts
@@ -17,6 +17,7 @@ export class CourseFieldsQueryParamsDto {
       'price',
       'imageUrl',
       'status',
+      'slug',
       'createdAt',
       'updatedAt',
       'deletedAt',

--- a/src/module/course/application/dto/course-filter-query-params.dto.ts
+++ b/src/module/course/application/dto/course-filter-query-params.dto.ts
@@ -15,6 +15,10 @@ export class CourseFilterQueryParamsDto {
   @IsOptional()
   price?: number;
 
+  @IsString()
+  @IsOptional()
+  slug: string;
+
   @IsEnum(PublishStatus)
   @IsOptional()
   status?: PublishStatus;

--- a/src/module/course/application/dto/course-response.dto.ts
+++ b/src/module/course/application/dto/course-response.dto.ts
@@ -7,6 +7,7 @@ export class CourseResponseDto extends BaseResponseDto {
   price: number;
   imageUrl: string;
   status: PublishStatus;
+  slug: string;
   constructor(
     type: string,
     title: string,
@@ -14,6 +15,7 @@ export class CourseResponseDto extends BaseResponseDto {
     price: number,
     imageUrl: string,
     status: PublishStatus,
+    slug: string,
     id?: string,
   ) {
     super(type, id);
@@ -23,5 +25,6 @@ export class CourseResponseDto extends BaseResponseDto {
     this.price = price;
     this.imageUrl = imageUrl;
     this.status = status;
+    this.slug = slug;
   }
 }

--- a/src/module/course/application/dto/course-sort-query-params.dto.ts
+++ b/src/module/course/application/dto/course-sort-query-params.dto.ts
@@ -21,6 +21,14 @@ export class CourseSortQueryParamsDto {
 
   @IsEnum(SortType)
   @IsOptional()
+  price?: SortType;
+
+  @IsEnum(SortType)
+  @IsOptional()
+  slug?: SortType;
+
+  @IsEnum(SortType)
+  @IsOptional()
   createdAt?: SortType;
 
   @IsEnum(SortType)

--- a/src/module/course/application/dto/course.dto.ts
+++ b/src/module/course/application/dto/course.dto.ts
@@ -23,4 +23,8 @@ export class CourseDto extends BaseDto {
   @IsOptional()
   @IsEnum(PublishStatus)
   status: PublishStatus;
+
+  @IsOptional()
+  @IsString()
+  slug: string;
 }

--- a/src/module/course/application/mapper/course.mapper.ts
+++ b/src/module/course/application/mapper/course.mapper.ts
@@ -17,6 +17,7 @@ export class CourseMapper
       dto.price,
       dto.imageUrl,
       dto.status,
+      dto.slug,
     );
   }
 
@@ -28,6 +29,7 @@ export class CourseMapper
       dto.price,
       dto.imageUrl,
       dto.status,
+      dto.slug,
     );
   }
 
@@ -39,6 +41,7 @@ export class CourseMapper
       entity.price,
       entity.imageUrl,
       entity.status,
+      entity.slug,
       entity.id,
     );
   }

--- a/src/module/course/application/repository/repository.interface.ts
+++ b/src/module/course/application/repository/repository.interface.ts
@@ -4,5 +4,6 @@ import { Course } from '@module/course/domain/course.entity';
 
 export const COURSE_REPOSITORY_KEY = 'course_repository';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface ICourseRepository extends BaseRepository<Course> {}
+export interface ICourseRepository extends BaseRepository<Course> {
+  getSlugsStartingWith(slug: string): Promise<string[]>;
+}

--- a/src/module/course/domain/course.entity.ts
+++ b/src/module/course/domain/course.entity.ts
@@ -7,6 +7,7 @@ export class Course extends Base {
   price: number;
   imageUrl: string;
   status: PublishStatus;
+  slug: string;
 
   constructor(
     id: string,
@@ -15,6 +16,7 @@ export class Course extends Base {
     price: number,
     imageUrl: string,
     status: PublishStatus,
+    slug: string,
   ) {
     super(id);
     this.title = title;
@@ -22,5 +24,6 @@ export class Course extends Base {
     this.price = price;
     this.imageUrl = imageUrl;
     this.status = status;
+    this.slug = slug;
   }
 }

--- a/src/module/course/infrastructure/database/course.postrges.repository.ts
+++ b/src/module/course/infrastructure/database/course.postrges.repository.ts
@@ -4,12 +4,26 @@ import { Repository } from 'typeorm';
 
 import BaseRepository from '@common/base/infrastructure/database/base.repository';
 
+import { ICourseRepository } from '@module/course/application/repository/repository.interface';
 import { Course } from '@module/course/domain/course.entity';
 import { CourseSchema } from '@module/course/infrastructure/database/course.schema';
 
 @Injectable()
-export class CoursePostgresRepository extends BaseRepository<Course> {
+export class CoursePostgresRepository
+  extends BaseRepository<Course>
+  implements ICourseRepository
+{
   constructor(@InjectRepository(CourseSchema) repository: Repository<Course>) {
     super(repository);
+  }
+
+  async getSlugsStartingWith(slug: string): Promise<string[]> {
+    const results: { course_slug: string }[] = await this.repository
+      .createQueryBuilder('course')
+      .select('course.slug')
+      .where('course.slug LIKE :slug', { slug: `${slug}%` })
+      .getRawMany();
+
+    return results.map((r) => r.course_slug);
   }
 }

--- a/src/module/course/infrastructure/database/course.schema.ts
+++ b/src/module/course/infrastructure/database/course.schema.ts
@@ -30,5 +30,10 @@ export const CourseSchema = new EntitySchema<Course>({
       type: String,
       default: PublishStatus.drafted,
     },
+    slug: {
+      type: String,
+      nullable: true,
+      unique: true,
+    },
   }),
 });


### PR DESCRIPTION
# Summary

This PR introduces the `slug` property to the `Course` entity along with logic for saving unique slugs on the database.

# Details

- Installed `slugify` dependency for generting slugs.
- Added a `SlugService` for creating slugs using `slugify`.
- Updated the `saveOne` mechanism for creating a unique slug based on the received title.
- Added tests to verify the slug property on the `CourseModule` E2E tests.  