### PR TITLE
feat: Add difficulty property to course entity

### DIFF
--- a/data/migrations/1748302986241-addDifficultyToCourseTable.ts
+++ b/data/migrations/1748302986241-addDifficultyToCourseTable.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddDifficultyToCourseTable1748302986241 implements MigrationInterface {
+    name = 'AddDifficultyToCourseTable1748302986241'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "course" ADD "difficulty" character varying`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "course" DROP COLUMN "difficulty"`);
+    }
+
+}

--- a/src/common/base/application/enum/difficulty.enum.ts
+++ b/src/common/base/application/enum/difficulty.enum.ts
@@ -1,0 +1,5 @@
+export enum Difficulty {
+  BEGINNER = 'beginner',
+  INTERMEDIATE = 'intermediate',
+  ADVANCED = 'advanced',
+}

--- a/src/module/course/__test__/course.e2e.spec.ts
+++ b/src/module/course/__test__/course.e2e.spec.ts
@@ -11,6 +11,7 @@ import {
   SerializedResponseDtoCollection,
 } from '@common/base/application/dto/serialized-response.dto';
 import { SuccessOperationResponseDto } from '@common/base/application/dto/success-operation-response.dto';
+import { Difficulty } from '@common/base/application/enum/difficulty.enum';
 import { HttpMethod } from '@common/base/application/enum/http-method.enum';
 import { PublishStatus } from '@common/base/application/enum/publish-status.enum';
 
@@ -74,6 +75,7 @@ describe('Course Module', () => {
                   imageUrl: expect.any(String),
                   status: expect.any(String),
                   slug: expect.any(String),
+                  difficulty: expect.any(String),
                 }),
               }),
             ]),
@@ -221,6 +223,7 @@ describe('Course Module', () => {
                 imageUrl: expect.stringContaining('intro-programming.jpg'),
                 status: 'published',
                 slug: 'introduction-to-programming',
+                difficulty: Difficulty.BEGINNER,
               }),
             }),
             links: expect.arrayContaining([
@@ -265,6 +268,7 @@ describe('Course Module', () => {
         description: 'Learn the basics of programming with JavaScript 2',
         price: 49.99,
         status: PublishStatus.drafted,
+        difficulty: Difficulty.BEGINNER,
       } as CreateCourseDto;
 
       await request(app.getHttpServer())
@@ -274,6 +278,7 @@ describe('Course Module', () => {
         .field('description', createCourseDto.description)
         .field('price', createCourseDto.price)
         .field('status', createCourseDto.status)
+        .field('difficulty', createCourseDto.difficulty)
         .attach('image', imageMock)
         .expect(HttpStatus.CREATED)
         .then(({ body }) => {
@@ -288,6 +293,7 @@ describe('Course Module', () => {
                 imageUrl: 'test-url',
                 status: createCourseDto.status,
                 slug: 'introduction-to-programming-2',
+                difficulty: Difficulty.BEGINNER,
               }),
             }),
             links: expect.arrayContaining([
@@ -308,12 +314,14 @@ describe('Course Module', () => {
         description: 'Learn the basics of fishing',
         price: 49.99,
         status: PublishStatus.drafted,
+        difficulty: Difficulty.BEGINNER,
       } as CreateCourseDto;
       const secondCreateCourseDto = {
         title: 'Introduction to Fishing',
         description: 'Learn the basics of fishing',
         price: 49.99,
         status: PublishStatus.drafted,
+        difficulty: Difficulty.INTERMEDIATE,
       } as CreateCourseDto;
 
       await request(app.getHttpServer())
@@ -323,6 +331,7 @@ describe('Course Module', () => {
         .field('description', firstCreateCourseDto.description)
         .field('price', firstCreateCourseDto.price)
         .field('status', firstCreateCourseDto.status)
+        .field('difficulty', firstCreateCourseDto.difficulty)
         .attach('image', imageMock)
         .expect(HttpStatus.CREATED)
         .then(({ body }) => {
@@ -337,6 +346,7 @@ describe('Course Module', () => {
                 imageUrl: 'test-url',
                 status: firstCreateCourseDto.status,
                 slug: 'introduction-to-fishing',
+                difficulty: Difficulty.BEGINNER,
               }),
             }),
             links: expect.arrayContaining([
@@ -357,6 +367,7 @@ describe('Course Module', () => {
         .field('description', secondCreateCourseDto.description)
         .field('price', secondCreateCourseDto.price)
         .field('status', secondCreateCourseDto.status)
+        .field('difficulty', secondCreateCourseDto.difficulty)
         .attach('image', imageMock)
         .expect(HttpStatus.CREATED)
         .then(({ body }) => {
@@ -371,6 +382,7 @@ describe('Course Module', () => {
                 imageUrl: 'test-url',
                 status: secondCreateCourseDto.status,
                 slug: 'introduction-to-fishing-2',
+                difficulty: Difficulty.INTERMEDIATE,
               }),
             }),
             links: expect.arrayContaining([
@@ -393,6 +405,7 @@ describe('Course Module', () => {
         description: 'Learn the basics of english',
         price: 49.99,
         status: PublishStatus.drafted,
+        difficulty: Difficulty.BEGINNER,
       } as CreateCourseDto;
 
       const updateCourseDto = {
@@ -400,6 +413,7 @@ describe('Course Module', () => {
         description: 'Learn the basics of English language',
         price: 49.99,
         status: PublishStatus.published,
+        difficulty: Difficulty.BEGINNER,
       } as UpdateCourseDto;
 
       let courseId: string;
@@ -411,6 +425,7 @@ describe('Course Module', () => {
         .field('description', createCourseDto.description)
         .field('price', createCourseDto.price)
         .field('status', createCourseDto.status)
+        .field('difficulty', createCourseDto.difficulty)
         .attach('image', imageMock)
         .expect(HttpStatus.CREATED)
         .then(
@@ -426,6 +441,7 @@ describe('Course Module', () => {
                   imageUrl: 'test-url',
                   status: createCourseDto.status,
                   slug: 'introduction-to-english',
+                  difficulty: Difficulty.BEGINNER,
                 }),
               }),
               links: expect.arrayContaining([
@@ -448,6 +464,7 @@ describe('Course Module', () => {
         .field('description', updateCourseDto.description)
         .field('price', updateCourseDto.price)
         .field('status', updateCourseDto.status)
+        .field('difficulty', updateCourseDto.difficulty)
         .attach('image', imageMock)
         .expect(HttpStatus.OK)
         .then(
@@ -462,6 +479,8 @@ describe('Course Module', () => {
                   price: updateCourseDto.price,
                   imageUrl: 'test-url',
                   status: updateCourseDto.status,
+                  slug: 'introduction-to-english',
+                  difficulty: Difficulty.BEGINNER,
                 }),
               }),
               links: expect.arrayContaining([
@@ -507,6 +526,7 @@ describe('Course Module', () => {
         description: 'Learn the basics of football',
         price: 49.99,
         status: PublishStatus.drafted,
+        difficulty: Difficulty.BEGINNER,
       } as CreateCourseDto;
 
       let courseId: string;
@@ -518,6 +538,7 @@ describe('Course Module', () => {
         .field('description', createCourseDto.description)
         .field('price', createCourseDto.price)
         .field('status', createCourseDto.status)
+        .field('difficulty', createCourseDto.difficulty)
         .attach('image', imageMock)
         .expect(HttpStatus.CREATED)
         .then(
@@ -533,6 +554,7 @@ describe('Course Module', () => {
                   imageUrl: 'test-url',
                   status: createCourseDto.status,
                   slug: 'introduction-to-football',
+                  difficulty: Difficulty.BEGINNER,
                 }),
               }),
               links: expect.arrayContaining([

--- a/src/module/course/__test__/fixture/Course.yml
+++ b/src/module/course/__test__/fixture/Course.yml
@@ -8,6 +8,7 @@ items:
     imageUrl: '{{internet.url}}/intro-programming.jpg'
     status: published
     slug: 'introduction-to-programming'
+    difficulty: beginner
   course2:
     title: 'Advanced Web Development'
     description: 'Master React, Node.js and modern web architectures'
@@ -15,6 +16,7 @@ items:
     imageUrl: '{{internet.url}}/advanced-web.jpg'
     status: archived
     slug: 'advanced-web-development'
+    difficulty: advanced
   course3:
     title: 'Data Science Fundamentals'
     description: 'Introduction to data analysis and machine learning'
@@ -22,6 +24,7 @@ items:
     imageUrl: '{{internet.url}}/data-science.jpg'
     status: drafted
     slug: 'data-science-fundamentals'
+    difficulty: intermediate
   course{4..23}:
     title: '{{commerce.productName}} Course'
     description: '{{lorem.paragraph}}'
@@ -29,3 +32,4 @@ items:
     imageUrl: '{{internet.url}}/course-{{@key.replace("course", "")}}.jpg'
     status: '{{@key % 3 == 0 ? "drafted" : (@key % 3 == 1 ? "published" : "archived")}}'
     slug: '{{lorem.slug}}'
+    difficulty: '{{@key % 3 == 0 ? "beginner" : (@key % 3 == 1 ? "intermediate" : "advanced")}}'

--- a/src/module/course/application/dto/course-fields-query-params.dto.ts
+++ b/src/module/course/application/dto/course-fields-query-params.dto.ts
@@ -18,6 +18,7 @@ export class CourseFieldsQueryParamsDto {
       'imageUrl',
       'status',
       'slug',
+      'difficulty',
       'createdAt',
       'updatedAt',
       'deletedAt',

--- a/src/module/course/application/dto/course-filter-query-params.dto.ts
+++ b/src/module/course/application/dto/course-filter-query-params.dto.ts
@@ -1,5 +1,6 @@
 import { IsEnum, IsNumber, IsOptional, IsString } from 'class-validator';
 
+import { Difficulty } from '@common/base/application/enum/difficulty.enum';
 import { PublishStatus } from '@common/base/application/enum/publish-status.enum';
 
 export class CourseFilterQueryParamsDto {
@@ -18,6 +19,10 @@ export class CourseFilterQueryParamsDto {
   @IsString()
   @IsOptional()
   slug: string;
+
+  @IsEnum(Difficulty)
+  @IsOptional()
+  difficulty?: Difficulty;
 
   @IsEnum(PublishStatus)
   @IsOptional()

--- a/src/module/course/application/dto/course-response.dto.ts
+++ b/src/module/course/application/dto/course-response.dto.ts
@@ -1,4 +1,5 @@
 import { BaseResponseDto } from '@common/base/application/dto/base.response.dto';
+import { Difficulty } from '@common/base/application/enum/difficulty.enum';
 import { PublishStatus } from '@common/base/application/enum/publish-status.enum';
 
 export class CourseResponseDto extends BaseResponseDto {
@@ -8,6 +9,7 @@ export class CourseResponseDto extends BaseResponseDto {
   imageUrl: string;
   status: PublishStatus;
   slug: string;
+  difficulty: Difficulty;
   constructor(
     type: string,
     title: string,
@@ -16,6 +18,7 @@ export class CourseResponseDto extends BaseResponseDto {
     imageUrl: string,
     status: PublishStatus,
     slug: string,
+    difficulty: Difficulty,
     id?: string,
   ) {
     super(type, id);
@@ -26,5 +29,6 @@ export class CourseResponseDto extends BaseResponseDto {
     this.imageUrl = imageUrl;
     this.status = status;
     this.slug = slug;
+    this.difficulty = difficulty;
   }
 }

--- a/src/module/course/application/dto/course-sort-query-params.dto.ts
+++ b/src/module/course/application/dto/course-sort-query-params.dto.ts
@@ -29,6 +29,10 @@ export class CourseSortQueryParamsDto {
 
   @IsEnum(SortType)
   @IsOptional()
+  difficulty?: SortType;
+
+  @IsEnum(SortType)
+  @IsOptional()
   createdAt?: SortType;
 
   @IsEnum(SortType)

--- a/src/module/course/application/dto/course.dto.ts
+++ b/src/module/course/application/dto/course.dto.ts
@@ -1,6 +1,7 @@
 import { IsEnum, IsNumber, IsOptional, IsString } from 'class-validator';
 
 import { BaseDto } from '@common/base/application/dto/base.dto';
+import { Difficulty } from '@common/base/application/enum/difficulty.enum';
 import { PublishStatus } from '@common/base/application/enum/publish-status.enum';
 
 export class CourseDto extends BaseDto {
@@ -27,4 +28,8 @@ export class CourseDto extends BaseDto {
   @IsOptional()
   @IsString()
   slug: string;
+
+  @IsOptional()
+  @IsEnum(Difficulty)
+  difficulty: Difficulty;
 }

--- a/src/module/course/application/mapper/course.mapper.ts
+++ b/src/module/course/application/mapper/course.mapper.ts
@@ -18,6 +18,7 @@ export class CourseMapper
       dto.imageUrl,
       dto.status,
       dto.slug,
+      dto.difficulty,
     );
   }
 
@@ -30,6 +31,7 @@ export class CourseMapper
       dto.imageUrl,
       dto.status,
       dto.slug,
+      dto.difficulty,
     );
   }
 
@@ -42,6 +44,7 @@ export class CourseMapper
       entity.imageUrl,
       entity.status,
       entity.slug,
+      entity.difficulty,
       entity.id,
     );
   }

--- a/src/module/course/domain/course.entity.ts
+++ b/src/module/course/domain/course.entity.ts
@@ -1,3 +1,4 @@
+import { Difficulty } from '@common/base/application/enum/difficulty.enum';
 import { PublishStatus } from '@common/base/application/enum/publish-status.enum';
 import { Base } from '@common/base/domain/base.entity';
 
@@ -8,6 +9,7 @@ export class Course extends Base {
   imageUrl: string;
   status: PublishStatus;
   slug: string;
+  difficulty: Difficulty;
 
   constructor(
     id: string,
@@ -17,6 +19,7 @@ export class Course extends Base {
     imageUrl: string,
     status: PublishStatus,
     slug: string,
+    difficulty: Difficulty,
   ) {
     super(id);
     this.title = title;
@@ -25,5 +28,6 @@ export class Course extends Base {
     this.imageUrl = imageUrl;
     this.status = status;
     this.slug = slug;
+    this.difficulty = difficulty;
   }
 }

--- a/src/module/course/infrastructure/database/course.schema.ts
+++ b/src/module/course/infrastructure/database/course.schema.ts
@@ -35,5 +35,9 @@ export const CourseSchema = new EntitySchema<Course>({
       nullable: true,
       unique: true,
     },
+    difficulty: {
+      type: String,
+      nullable: true,
+    },
   }),
 });


### PR DESCRIPTION
# Summar

This PR introduces the `difficulty` property to the `Course` entity.

# Details

- Added the `Difficulty` enum with `beginner`, `intermediate` and `advanced` levels.
- Updated the domain/schema entities and dtos with the new property.
- Updated the Course E2E tests with the difficulty property.