### PR TITLE
feat: Add instructor relation to Course entity

### DIFF
--- a/data/migrations/1748310859253-addInstructorRelationToCourseTable.ts
+++ b/data/migrations/1748310859253-addInstructorRelationToCourseTable.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddInstructorRelationToCourseTable1748310859253 implements MigrationInterface {
+    name = 'AddInstructorRelationToCourseTable1748310859253'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "course" ADD "instructor_id" uuid`);
+        await queryRunner.query(`ALTER TABLE "course" ADD CONSTRAINT "FK_deca5c9911b3b2100b361060826" FOREIGN KEY ("instructor_id") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "course" DROP CONSTRAINT "FK_deca5c9911b3b2100b361060826"`);
+        await queryRunner.query(`ALTER TABLE "course" DROP COLUMN "instructor_id"`);
+    }
+
+}

--- a/src/common/base/application/dto/base.dto.ts
+++ b/src/common/base/application/dto/base.dto.ts
@@ -1,21 +1,8 @@
-import { IsOptional, IsString } from 'class-validator';
-
 import { IDto } from '@common/base/application/dto/dto.interface';
 
 export class BaseDto implements IDto {
-  @IsString()
-  @IsOptional()
   id: string;
-
-  @IsString()
-  @IsOptional()
   createdAt?: string;
-
-  @IsString()
-  @IsOptional()
   updatedAt?: string;
-
-  @IsString()
-  @IsOptional()
   deletedAt?: string;
 }

--- a/src/common/base/application/dto/get-all-options.interface.ts
+++ b/src/common/base/application/dto/get-all-options.interface.ts
@@ -8,9 +8,14 @@ export type SimpleProps<T> = {
   [K in keyof T]: T[K] extends Base | Base[] | Function ? never : K;
 }[keyof T];
 
+type ComplexProps<T> = {
+  [K in keyof T]: T[K] extends object | object[] ? K : never;
+}[keyof T];
+
 export type Filter<T> = Partial<Pick<T, SimpleProps<T>>>;
 export type Sort<T> = Partial<Record<SimpleProps<T>, SortType>>;
 export type Fields<T> = SimpleProps<T>[];
+export type Relations<T> = ComplexProps<T>[];
 
 export type Page = {
   number?: number;
@@ -18,10 +23,10 @@ export type Page = {
   offset?: number;
 };
 
-export interface IGetAllOptions<T extends IDto | IEntity, Include = []> {
+export interface IGetAllOptions<T extends IDto | IEntity> {
   page?: Page;
   filter?: Filter<T>;
   sort?: Sort<T>;
   fields?: Fields<T>;
-  include?: Include;
+  include?: Relations<T>;
 }

--- a/src/common/base/application/service/base-crud.service.ts
+++ b/src/common/base/application/service/base-crud.service.ts
@@ -48,8 +48,8 @@ export class BaseCRUDService<
     return collection;
   }
 
-  async getOneByIdOrFail(id: string): Promise<ResponseDto> {
-    const entity = await this.repository.getOneByIdOrFail(id);
+  async getOneByIdOrFail(id: string, include?: string[]): Promise<ResponseDto> {
+    const entity = await this.repository.getOneByIdOrFail(id, include);
     const responseDto = this.mapper.fromEntityToResponseDto(entity);
 
     return responseDto;

--- a/src/common/base/infrastructure/database/base.repository.ts
+++ b/src/common/base/infrastructure/database/base.repository.ts
@@ -21,14 +21,14 @@ abstract class BaseRepository<T extends IEntity> implements IRepository<T> {
   }
 
   async getAll(options: IGetAllOptions<T>): Promise<ICollection<T>> {
-    const { filter, page, sort, fields } = options || {};
-
+    const { filter, page, sort, fields, include } = options || {};
     const [items, itemCount] = await this.repository.findAndCount({
       where: filter as FindOptionsWhere<T>,
       order: sort as FindOptionsOrder<T>,
       select: fields,
       take: page.size,
       skip: page.offset,
+      relations: include,
     } as FindManyOptions<T>);
 
     return {
@@ -40,14 +40,15 @@ abstract class BaseRepository<T extends IEntity> implements IRepository<T> {
     };
   }
 
-  async getOneById(id: string): Promise<T> {
+  async getOneById(id: string, include?: string[]): Promise<T> {
     return this.repository.findOne({
       where: { id },
+      relations: include,
     } as FindOneOptions<T>);
   }
 
-  async getOneByIdOrFail(id: string): Promise<T> {
-    const entity = await this.getOneById(id);
+  async getOneByIdOrFail(id: string, include?: string[]): Promise<T> {
+    const entity = await this.getOneById(id, include);
 
     if (!entity) {
       throw new EntityNotFoundException(id);

--- a/src/module/course/__test__/course.e2e.spec.ts
+++ b/src/module/course/__test__/course.e2e.spec.ts
@@ -202,6 +202,29 @@ describe('Course Module', () => {
           },
         );
     });
+
+    it('Should allow to include related resources', async () => {
+      await request(app.getHttpServer())
+        .get(`${endpoint}?include[target]=instructor`)
+        .auth(adminToken, { type: 'bearer' })
+        .expect(HttpStatus.OK)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            data: expect.arrayContaining([
+              expect.objectContaining({
+                attributes: expect.objectContaining({
+                  instructor: expect.objectContaining({
+                    firstName: 'admin-name',
+                    lastName: 'admin-surname',
+                    avatarUrl: expect.any(String),
+                  }),
+                }),
+              }),
+            ]),
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
   });
 
   describe('GET - /course/:id', () => {
@@ -259,10 +282,33 @@ describe('Course Module', () => {
           expect(body).toEqual(expectedResponse);
         });
     });
+
+    it('Should allow to include related resources', async () => {
+      const courseId = '22f38dae-00f1-49ff-8f3f-0dd6539af032';
+      await request(app.getHttpServer())
+        .get(`${endpoint}/${courseId}?include[target]=instructor`)
+        .auth(adminToken, { type: 'bearer' })
+        .expect(HttpStatus.OK)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            data: expect.objectContaining({
+              attributes: expect.objectContaining({
+                instructor: expect.objectContaining({
+                  firstName: 'admin-name',
+                  lastName: 'admin-surname',
+                  avatarUrl: expect.any(String),
+                }),
+              }),
+            }),
+          });
+
+          expect(body).toEqual(expectedResponse);
+        });
+    });
   });
 
   describe('POST - /course', () => {
-    it('Should create a new customer', async () => {
+    it('Should create a new course', async () => {
       const createCourseDto = {
         title: 'Introduction to Programming 2',
         description: 'Learn the basics of programming with JavaScript 2',
@@ -294,6 +340,11 @@ describe('Course Module', () => {
                 status: createCourseDto.status,
                 slug: 'introduction-to-programming-2',
                 difficulty: Difficulty.BEGINNER,
+                instructor: expect.objectContaining({
+                  firstName: 'admin-name',
+                  lastName: 'admin-surname',
+                  avatarUrl: expect.any(String),
+                }),
               }),
             }),
             links: expect.arrayContaining([
@@ -497,18 +548,18 @@ describe('Course Module', () => {
     });
 
     it('Should throw an error if course to update is not found', async () => {
-      const nonExistingCustomerId = '22f38dae-00f1-49ff-8f3f-0dd6539af039';
+      const nonExistingCourseId = '22f38dae-00f1-49ff-8f3f-0dd6539af039';
 
       await request(app.getHttpServer())
-        .patch(`${endpoint}/${nonExistingCustomerId}`)
+        .patch(`${endpoint}/${nonExistingCourseId}`)
         .auth(adminToken, { type: 'bearer' })
         .expect(HttpStatus.NOT_FOUND)
         .then(({ body }) => {
           const expectedResponse = expect.objectContaining({
             error: {
-              detail: `Entity with id ${nonExistingCustomerId} not found`,
+              detail: `Entity with id ${nonExistingCourseId} not found`,
               source: {
-                pointer: `${endpoint}/${nonExistingCustomerId}`,
+                pointer: `${endpoint}/${nonExistingCourseId}`,
               },
               status: '404',
               title: 'Entity not found',

--- a/src/module/course/__test__/fixture/Course.yml
+++ b/src/module/course/__test__/fixture/Course.yml
@@ -9,6 +9,7 @@ items:
     status: published
     slug: 'introduction-to-programming'
     difficulty: beginner
+    instructor: '@admin-user'
   course2:
     title: 'Advanced Web Development'
     description: 'Master React, Node.js and modern web architectures'
@@ -17,6 +18,7 @@ items:
     status: archived
     slug: 'advanced-web-development'
     difficulty: advanced
+    instructor: '@admin-user'
   course3:
     title: 'Data Science Fundamentals'
     description: 'Introduction to data analysis and machine learning'
@@ -25,6 +27,7 @@ items:
     status: drafted
     slug: 'data-science-fundamentals'
     difficulty: intermediate
+    instructor: '@admin-user'
   course{4..23}:
     title: '{{commerce.productName}} Course'
     description: '{{lorem.paragraph}}'
@@ -33,3 +36,4 @@ items:
     status: '{{@key % 3 == 0 ? "drafted" : (@key % 3 == 1 ? "published" : "archived")}}'
     slug: '{{lorem.slug}}'
     difficulty: '{{@key % 3 == 0 ? "beginner" : (@key % 3 == 1 ? "intermediate" : "advanced")}}'
+    instructor: '@admin-user'

--- a/src/module/course/__test__/fixture/User.yml
+++ b/src/module/course/__test__/fixture/User.yml
@@ -8,6 +8,7 @@ items:
     externalId: '00000000-0000-0000-0000-00000000000X'
     roles: regular,admin,superAdmin
   admin-user:
+    id: a90108bf-42c6-481f-a63f-4b51fed1300c
     firstName: admin-name
     lastName: admin-surname
     email: 'test_admin@email.co'

--- a/src/module/course/application/dto/course-include.dto.ts
+++ b/src/module/course/application/dto/course-include.dto.ts
@@ -1,0 +1,19 @@
+import { Transform } from 'class-transformer';
+import { IsIn, IsOptional } from 'class-validator';
+
+import { IGetAllOptions } from '@common/base/application/dto/get-all-options.interface';
+import { fromCommaSeparatedToArray } from '@common/base/application/mapper/base.mapper';
+
+import { Course } from '@module/course/domain/course.entity';
+
+type CourseRelations = IGetAllOptions<Course>['include'];
+export class CourseIncludeQueryDto {
+  @IsIn(['instructor'] as CourseRelations, {
+    each: true,
+  })
+  @IsOptional()
+  @Transform((params) => {
+    return fromCommaSeparatedToArray(params.value as string);
+  })
+  target?: CourseRelations;
+}

--- a/src/module/course/application/dto/course-response.dto.ts
+++ b/src/module/course/application/dto/course-response.dto.ts
@@ -2,6 +2,13 @@ import { BaseResponseDto } from '@common/base/application/dto/base.response.dto'
 import { Difficulty } from '@common/base/application/enum/difficulty.enum';
 import { PublishStatus } from '@common/base/application/enum/publish-status.enum';
 
+import { User } from '@module/iam/user/domain/user.entity';
+
+export type CourseResponseInstructor = Pick<
+  User,
+  'firstName' | 'lastName' | 'avatarUrl'
+>;
+
 export class CourseResponseDto extends BaseResponseDto {
   title: string;
   description: string;
@@ -10,6 +17,7 @@ export class CourseResponseDto extends BaseResponseDto {
   status: PublishStatus;
   slug: string;
   difficulty: Difficulty;
+  instructor?: CourseResponseInstructor;
   constructor(
     type: string,
     title: string,
@@ -19,6 +27,7 @@ export class CourseResponseDto extends BaseResponseDto {
     status: PublishStatus,
     slug: string,
     difficulty: Difficulty,
+    instructor?: CourseResponseInstructor,
     id?: string,
   ) {
     super(type, id);
@@ -30,5 +39,8 @@ export class CourseResponseDto extends BaseResponseDto {
     this.status = status;
     this.slug = slug;
     this.difficulty = difficulty;
+    if (instructor) {
+      this.instructor = instructor;
+    }
   }
 }

--- a/src/module/course/application/dto/course.dto.ts
+++ b/src/module/course/application/dto/course.dto.ts
@@ -4,32 +4,36 @@ import { BaseDto } from '@common/base/application/dto/base.dto';
 import { Difficulty } from '@common/base/application/enum/difficulty.enum';
 import { PublishStatus } from '@common/base/application/enum/publish-status.enum';
 
+import { User } from '@module/iam/user/domain/user.entity';
+
 export class CourseDto extends BaseDto {
   @IsOptional()
   @IsString()
-  title: string;
+  title?: string;
 
   @IsOptional()
   @IsString()
-  description: string;
+  description?: string;
 
   @IsOptional()
   @IsNumber()
-  price: number;
+  price?: number;
 
   @IsOptional()
   @IsString()
-  imageUrl: string;
+  imageUrl?: string;
 
   @IsOptional()
   @IsEnum(PublishStatus)
-  status: PublishStatus;
+  status?: PublishStatus;
 
   @IsOptional()
   @IsString()
-  slug: string;
+  slug?: string;
 
   @IsOptional()
   @IsEnum(Difficulty)
-  difficulty: Difficulty;
+  difficulty?: Difficulty;
+
+  instructor?: User;
 }

--- a/src/module/course/application/mapper/course.mapper.ts
+++ b/src/module/course/application/mapper/course.mapper.ts
@@ -1,9 +1,13 @@
 import { IDtoMapper } from '@common/base/application/dto/dto.interface';
 
-import { CourseResponseDto } from '@module/course/application/dto/course-response.dto';
+import {
+  CourseResponseDto,
+  CourseResponseInstructor,
+} from '@module/course/application/dto/course-response.dto';
 import { CreateCourseDto } from '@module/course/application/dto/create-course.dto';
 import { UpdateCourseDto } from '@module/course/application/dto/update-course.dto';
 import { Course } from '@module/course/domain/course.entity';
+import { User } from '@module/iam/user/domain/user.entity';
 
 export class CourseMapper
   implements
@@ -19,6 +23,7 @@ export class CourseMapper
       dto.status,
       dto.slug,
       dto.difficulty,
+      dto.instructor,
     );
   }
 
@@ -36,6 +41,9 @@ export class CourseMapper
   }
 
   fromEntityToResponseDto(entity: Course): CourseResponseDto {
+    const instructor: CourseResponseInstructor = entity.instructor
+      ? this.fromInstructorToCourseResponseInstructor(entity.instructor)
+      : null;
     return new CourseResponseDto(
       Course.getEntityName(),
       entity.title,
@@ -45,7 +53,18 @@ export class CourseMapper
       entity.status,
       entity.slug,
       entity.difficulty,
+      instructor,
       entity.id,
     );
+  }
+
+  private fromInstructorToCourseResponseInstructor(
+    instructor: User,
+  ): CourseResponseInstructor {
+    return {
+      firstName: instructor.firstName,
+      lastName: instructor.lastName,
+      avatarUrl: instructor.avatarUrl,
+    };
   }
 }

--- a/src/module/course/domain/course.entity.ts
+++ b/src/module/course/domain/course.entity.ts
@@ -2,6 +2,8 @@ import { Difficulty } from '@common/base/application/enum/difficulty.enum';
 import { PublishStatus } from '@common/base/application/enum/publish-status.enum';
 import { Base } from '@common/base/domain/base.entity';
 
+import { User } from '@module/iam/user/domain/user.entity';
+
 export class Course extends Base {
   title: string;
   description: string;
@@ -10,6 +12,7 @@ export class Course extends Base {
   status: PublishStatus;
   slug: string;
   difficulty: Difficulty;
+  instructor?: User;
 
   constructor(
     id: string,
@@ -20,6 +23,7 @@ export class Course extends Base {
     status: PublishStatus,
     slug: string,
     difficulty: Difficulty,
+    instructor?: User,
   ) {
     super(id);
     this.title = title;
@@ -29,5 +33,6 @@ export class Course extends Base {
     this.status = status;
     this.slug = slug;
     this.difficulty = difficulty;
+    this.instructor = instructor;
   }
 }

--- a/src/module/course/infrastructure/database/course.schema.ts
+++ b/src/module/course/infrastructure/database/course.schema.ts
@@ -40,4 +40,13 @@ export const CourseSchema = new EntitySchema<Course>({
       nullable: true,
     },
   }),
+  relations: {
+    instructor: {
+      type: 'many-to-one',
+      target: 'User',
+      joinColumn: {
+        name: 'instructor_id',
+      },
+    },
+  },
 });


### PR DESCRIPTION
# Summary

This PR introduces the `instructor` relation to the `Course` entity, along with an update to the `CourseController` to support querying with this relation.

# Details

- Updated the `Course` domain/schema entities with the `instructor` relation.
- Updated the `Course` Dtos with the new property.
- Refactored the `BaseCRUDService` and `BaseRepository` to allow relations on the "get" queries.
- Implemented a `CourseIncludeQueryDto` for validating the query params with valid relation keys.
- Added tests for saving a `Course` with instructors.
- Added tests for querying `Course` with included relations.