### PR TITLE
feat: Add course policies for authorization

### DIFF
--- a/src/module/course/__test__/course.e2e.spec.ts
+++ b/src/module/course/__test__/course.e2e.spec.ts
@@ -701,5 +701,45 @@ describe('Course Module', () => {
           },
         );
     });
+
+    it('Should throw an error if course to delete is not found', async () => {
+      const nonExistingCourseId = '22f38dae-00f1-49ff-8f3f-0dd6539af039';
+
+      await request(app.getHttpServer())
+        .delete(`${endpoint}/${nonExistingCourseId}`)
+        .auth(adminToken, { type: 'bearer' })
+        .expect(HttpStatus.NOT_FOUND)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `Entity with id ${nonExistingCourseId} not found`,
+              source: {
+                pointer: `${endpoint}/${nonExistingCourseId}`,
+              },
+              status: '404',
+              title: 'Entity not found',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should deny access to regular users', async () => {
+      const existingCourseId = '22f38dae-00f1-49ff-8f3f-0dd6539af032';
+
+      await request(app.getHttpServer())
+        .delete(`${endpoint}/${existingCourseId}`)
+        .auth(regularToken, { type: 'bearer' })
+        .expect(HttpStatus.FORBIDDEN);
+    });
+
+    it('Should deny access to non instructors admins', async () => {
+      const existingCourseId = '22f38dae-00f1-49ff-8f3f-0dd6539af032';
+
+      await request(app.getHttpServer())
+        .del(`${endpoint}/${existingCourseId}`)
+        .auth(secondAdminToken, { type: 'bearer' })
+        .expect(HttpStatus.FORBIDDEN);
+    });
   });
 });

--- a/src/module/course/__test__/course.e2e.spec.ts
+++ b/src/module/course/__test__/course.e2e.spec.ts
@@ -37,6 +37,11 @@ describe('Course Module', () => {
   const adminToken = createAccessToken({
     sub: '00000000-0000-0000-0000-00000000000Y',
   });
+
+  const secondAdminToken = createAccessToken({
+    sub: '00000000-0000-0000-0000-00000000000W',
+  });
+
   const regularToken = createAccessToken({
     sub: '00000000-0000-0000-0000-00000000000Z',
   });
@@ -586,6 +591,32 @@ describe('Course Module', () => {
           });
           expect(body).toEqual(expectedResponse);
         });
+    });
+
+    it('Should deny access to regular users', async () => {
+      const existingCourseId = '22f38dae-00f1-49ff-8f3f-0dd6539af032';
+      const updateCourseDto = {
+        title: 'Introduction to Programming 2',
+      } as UpdateCourseDto;
+
+      await request(app.getHttpServer())
+        .patch(`${endpoint}/${existingCourseId}`)
+        .auth(regularToken, { type: 'bearer' })
+        .send(updateCourseDto)
+        .expect(HttpStatus.FORBIDDEN);
+    });
+
+    it('Should deny access to non instructors admins', async () => {
+      const existingCourseId = '22f38dae-00f1-49ff-8f3f-0dd6539af032';
+      const updateCourseDto = {
+        title: 'Introduction to Programming 2',
+      } as UpdateCourseDto;
+
+      await request(app.getHttpServer())
+        .patch(`${endpoint}/${existingCourseId}`)
+        .auth(secondAdminToken, { type: 'bearer' })
+        .send(updateCourseDto)
+        .expect(HttpStatus.FORBIDDEN);
     });
   });
 

--- a/src/module/course/__test__/course.e2e.spec.ts
+++ b/src/module/course/__test__/course.e2e.spec.ts
@@ -37,6 +37,9 @@ describe('Course Module', () => {
   const adminToken = createAccessToken({
     sub: '00000000-0000-0000-0000-00000000000Y',
   });
+  const regularToken = createAccessToken({
+    sub: '00000000-0000-0000-0000-00000000000Z',
+  });
 
   beforeAll(async () => {
     await loadFixtures(`${__dirname}/fixture`, datasourceOptions);
@@ -446,6 +449,22 @@ describe('Course Module', () => {
           };
           expect(body).toEqual(expectedResponse);
         });
+    });
+
+    it('Should deny access to regular users', async () => {
+      const createCourseDto = {
+        title: 'Introduction to Programming 2',
+        description: 'Learn the basics of programming with JavaScript 2',
+        price: 49.99,
+        status: PublishStatus.drafted,
+        difficulty: Difficulty.BEGINNER,
+      } as CreateCourseDto;
+
+      await request(app.getHttpServer())
+        .post(endpoint)
+        .auth(regularToken, { type: 'bearer' })
+        .send(createCourseDto)
+        .expect(HttpStatus.FORBIDDEN);
     });
   });
 

--- a/src/module/course/__test__/fixture/User.yml
+++ b/src/module/course/__test__/fixture/User.yml
@@ -15,6 +15,13 @@ items:
     avatarUrl: '{{internet.url}}'
     externalId: '00000000-0000-0000-0000-00000000000Y'
     roles: regular,admin
+  regular-user:
+    firstName: regular-name
+    lastName: regular-surname
+    email: 'test_regular@email.co'
+    avatarUrl: '{{internet.url}}'
+    externalId: '00000000-0000-0000-0000-00000000000Z'
+    roles: regular
   user{2..23}:
     firstName: '{{person.firstName}}'
     lastName: '{{person.lastName}}'

--- a/src/module/course/__test__/fixture/User.yml
+++ b/src/module/course/__test__/fixture/User.yml
@@ -15,6 +15,14 @@ items:
     avatarUrl: '{{internet.url}}'
     externalId: '00000000-0000-0000-0000-00000000000Y'
     roles: regular,admin
+  admin-user-2:
+    id: 8aba0c66-c142-469b-928a-f347752fd665
+    firstName: admin-2-name
+    lastName: admin-2-surname
+    email: 'test_admin_2@email.co'
+    avatarUrl: '{{internet.url}}'
+    externalId: '00000000-0000-0000-0000-00000000000W'
+    roles: regular,admin
   regular-user:
     firstName: regular-name
     lastName: regular-surname

--- a/src/module/course/application/policy/create-course-policy-handler.ts
+++ b/src/module/course/application/policy/create-course-policy-handler.ts
@@ -1,0 +1,41 @@
+import { ForbiddenException, Injectable } from '@nestjs/common';
+import { Request } from 'express';
+
+import { Course } from '@module/course/domain/course.entity';
+import { BasePolicyHandler } from '@module/iam/authorization/application/policy/base-policy.handler';
+import { AuthorizationService } from '@module/iam/authorization/application/service/authorization.service';
+import { AppAction } from '@module/iam/authorization/domain/app.action.enum';
+import { IPolicyHandler } from '@module/iam/authorization/infrastructure/policy/handler/policy-handler.interface';
+import { PolicyHandlerStorage } from '@module/iam/authorization/infrastructure/policy/storage/policies-handler.storage';
+
+@Injectable()
+export class CreateCoursePolicyHandler
+  extends BasePolicyHandler
+  implements IPolicyHandler
+{
+  private readonly action = AppAction.Create;
+
+  constructor(
+    private readonly policyHandlerStorage: PolicyHandlerStorage,
+    private readonly authorizationService: AuthorizationService,
+  ) {
+    super();
+    this.policyHandlerStorage.add(CreateCoursePolicyHandler, this);
+  }
+
+  handle(request: Request): Promise<void> | void {
+    const user = this.getCurrentUser(request);
+
+    const isAllowed = this.authorizationService.isAllowed(
+      user,
+      this.action,
+      Course,
+    );
+
+    if (!isAllowed) {
+      throw new ForbiddenException(
+        `You are not allowed to ${this.action.toUpperCase()} this resource`,
+      );
+    }
+  }
+}

--- a/src/module/course/application/policy/delete-course-policy-handler.ts
+++ b/src/module/course/application/policy/delete-course-policy-handler.ts
@@ -1,0 +1,50 @@
+import { ForbiddenException, Inject, Injectable } from '@nestjs/common';
+import { Request } from 'express';
+
+import {
+  COURSE_REPOSITORY_KEY,
+  ICourseRepository,
+} from '@module/course/application/repository/repository.interface';
+import { BasePolicyHandler } from '@module/iam/authorization/application/policy/base-policy.handler';
+import { AuthorizationService } from '@module/iam/authorization/application/service/authorization.service';
+import { AppAction } from '@module/iam/authorization/domain/app.action.enum';
+import { IPolicyHandler } from '@module/iam/authorization/infrastructure/policy/handler/policy-handler.interface';
+import { PolicyHandlerStorage } from '@module/iam/authorization/infrastructure/policy/storage/policies-handler.storage';
+
+@Injectable()
+export class DeleteCoursePolicyHandler
+  extends BasePolicyHandler
+  implements IPolicyHandler
+{
+  private readonly action = AppAction.Delete;
+
+  constructor(
+    private readonly policyHandlerStorage: PolicyHandlerStorage,
+    @Inject(COURSE_REPOSITORY_KEY)
+    private readonly courseRepository: ICourseRepository,
+    private readonly authorizationService: AuthorizationService,
+  ) {
+    super();
+    this.policyHandlerStorage.add(DeleteCoursePolicyHandler, this);
+  }
+
+  async handle(request: Request): Promise<void> {
+    const user = this.getCurrentUser(request);
+    const { id } = request.params;
+    const course = await this.courseRepository.getOneByIdOrFail(id, [
+      'instructor',
+    ]);
+
+    const isAllowed = this.authorizationService.isAllowed(
+      user,
+      this.action,
+      course,
+    );
+
+    if (!isAllowed) {
+      throw new ForbiddenException(
+        `You are not allowed to ${this.action.toUpperCase()} this resource`,
+      );
+    }
+  }
+}

--- a/src/module/course/application/policy/update-course-policy.handler.ts
+++ b/src/module/course/application/policy/update-course-policy.handler.ts
@@ -1,0 +1,50 @@
+import { ForbiddenException, Inject, Injectable } from '@nestjs/common';
+import { Request } from 'express';
+
+import {
+  COURSE_REPOSITORY_KEY,
+  ICourseRepository,
+} from '@module/course/application/repository/repository.interface';
+import { BasePolicyHandler } from '@module/iam/authorization/application/policy/base-policy.handler';
+import { AuthorizationService } from '@module/iam/authorization/application/service/authorization.service';
+import { AppAction } from '@module/iam/authorization/domain/app.action.enum';
+import { IPolicyHandler } from '@module/iam/authorization/infrastructure/policy/handler/policy-handler.interface';
+import { PolicyHandlerStorage } from '@module/iam/authorization/infrastructure/policy/storage/policies-handler.storage';
+
+@Injectable()
+export class UpdateCoursePolicyHandler
+  extends BasePolicyHandler
+  implements IPolicyHandler
+{
+  private readonly action = AppAction.Update;
+
+  constructor(
+    private readonly policyHandlerStorage: PolicyHandlerStorage,
+    @Inject(COURSE_REPOSITORY_KEY)
+    private readonly courseRepository: ICourseRepository,
+    private readonly authorizationService: AuthorizationService,
+  ) {
+    super();
+    this.policyHandlerStorage.add(UpdateCoursePolicyHandler, this);
+  }
+
+  async handle(request: Request): Promise<void> {
+    const user = this.getCurrentUser(request);
+    const { id } = request.params;
+    const course = await this.courseRepository.getOneByIdOrFail(id, [
+      'instructor',
+    ]);
+
+    const isAllowed = this.authorizationService.isAllowed(
+      user,
+      this.action,
+      course,
+    );
+
+    if (!isAllowed) {
+      throw new ForbiddenException(
+        `You are not allowed to ${this.action.toUpperCase()} this resource`,
+      );
+    }
+  }
+}

--- a/src/module/course/course.module.ts
+++ b/src/module/course/course.module.ts
@@ -2,20 +2,39 @@ import { Module, Provider } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { CourseMapper } from '@module/course/application/mapper/course.mapper';
+import { CreateCoursePolicyHandler } from '@module/course/application/policy/create-course-policy-handler';
+import { DeleteCoursePolicyHandler } from '@module/course/application/policy/delete-course-policy-handler';
+import { UpdateCoursePolicyHandler } from '@module/course/application/policy/update-course-policy.handler';
 import { COURSE_REPOSITORY_KEY } from '@module/course/application/repository/repository.interface';
 import { CourseService } from '@module/course/application/service/course.service';
+import { coursePermissions } from '@module/course/domain/course.permissions';
 import { CoursePostgresRepository } from '@module/course/infrastructure/database/course.postrges.repository';
 import { CourseSchema } from '@module/course/infrastructure/database/course.schema';
 import { CourseController } from '@module/course/interface/course.controller';
+import { AuthorizationModule } from '@module/iam/authorization/authorization.module';
 
 const courseRepositoryProvider: Provider = {
   provide: COURSE_REPOSITORY_KEY,
   useClass: CoursePostgresRepository,
 };
 
+const policyHandlersProviders = [
+  CreateCoursePolicyHandler,
+  UpdateCoursePolicyHandler,
+  DeleteCoursePolicyHandler,
+];
+
 @Module({
-  imports: [TypeOrmModule.forFeature([CourseSchema])],
-  providers: [CourseService, courseRepositoryProvider, CourseMapper],
+  imports: [
+    TypeOrmModule.forFeature([CourseSchema]),
+    AuthorizationModule.forFeature({ permissions: coursePermissions }),
+  ],
+  providers: [
+    CourseService,
+    courseRepositoryProvider,
+    CourseMapper,
+    ...policyHandlersProviders,
+  ],
   controllers: [CourseController],
 })
 export class CourseModule {}

--- a/src/module/course/domain/course.entity.ts
+++ b/src/module/course/domain/course.entity.ts
@@ -14,6 +14,10 @@ export class Course extends Base {
   difficulty: Difficulty;
   instructor?: User;
 
+  get instructorId(): string | null {
+    return this.instructor?.id || null;
+  }
+
   constructor(
     id: string,
     title: string,

--- a/src/module/course/domain/course.permissions.ts
+++ b/src/module/course/domain/course.permissions.ts
@@ -1,0 +1,19 @@
+import { Course } from '@module/course/domain/course.entity';
+import { AppRole } from '@module/iam/authorization/domain/app-role.enum';
+import { AppAction } from '@module/iam/authorization/domain/app.action.enum';
+import { IPermissionsDefinition } from '@module/iam/authorization/infrastructure/policy/type/permissions-definition.interface';
+
+export const coursePermissions: IPermissionsDefinition = {
+  [AppRole.Regular](_, { can }) {
+    can(AppAction.Read, Course);
+  },
+  [AppRole.Admin](user, { can }) {
+    can([AppAction.Read, AppAction.Create], Course);
+    can([AppAction.Update, AppAction.Delete], Course, {
+      instructorId: user.id,
+    });
+  },
+  [AppRole.SuperAdmin](_, { can }) {
+    can(AppAction.Manage, Course);
+  },
+};

--- a/src/module/course/interface/course.controller.ts
+++ b/src/module/course/interface/course.controller.ts
@@ -27,6 +27,7 @@ import { CourseSortQueryParamsDto } from '@module/course/application/dto/course-
 import { CreateCourseDto } from '@module/course/application/dto/create-course.dto';
 import { UpdateCourseDto } from '@module/course/application/dto/update-course.dto';
 import { CreateCoursePolicyHandler } from '@module/course/application/policy/create-course-policy-handler';
+import { DeleteCoursePolicyHandler } from '@module/course/application/policy/delete-course-policy-handler';
 import { UpdateCoursePolicyHandler } from '@module/course/application/policy/update-course-policy.handler';
 import { CourseService } from '@module/course/application/service/course.service';
 import { CurrentUser } from '@module/iam/authentication/infrastructure/decorator/current-user.decorator';
@@ -89,6 +90,7 @@ export class CourseController {
   }
 
   @Delete(':id')
+  @Policies(DeleteCoursePolicyHandler)
   async deleteOneByIdOrFail(
     @Param('id', ParseUUIDPipe) id: string,
   ): Promise<SuccessOperationResponseDto> {

--- a/src/module/course/interface/course.controller.ts
+++ b/src/module/course/interface/course.controller.ts
@@ -27,6 +27,7 @@ import { CourseSortQueryParamsDto } from '@module/course/application/dto/course-
 import { CreateCourseDto } from '@module/course/application/dto/create-course.dto';
 import { UpdateCourseDto } from '@module/course/application/dto/update-course.dto';
 import { CreateCoursePolicyHandler } from '@module/course/application/policy/create-course-policy-handler';
+import { UpdateCoursePolicyHandler } from '@module/course/application/policy/update-course-policy.handler';
 import { CourseService } from '@module/course/application/service/course.service';
 import { CurrentUser } from '@module/iam/authentication/infrastructure/decorator/current-user.decorator';
 import { Policies } from '@module/iam/authorization/infrastructure/policy/decorator/policy.decorator';
@@ -78,6 +79,7 @@ export class CourseController {
   }
 
   @Patch(':id')
+  @Policies(UpdateCoursePolicyHandler)
   async updateOne(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() updateDto: UpdateCourseDto,

--- a/src/module/course/interface/course.controller.ts
+++ b/src/module/course/interface/course.controller.ts
@@ -9,6 +9,7 @@ import {
   Post,
   Query,
   UploadedFile,
+  UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
@@ -25,11 +26,15 @@ import { CourseResponseDto } from '@module/course/application/dto/course-respons
 import { CourseSortQueryParamsDto } from '@module/course/application/dto/course-sort-query-params.dto';
 import { CreateCourseDto } from '@module/course/application/dto/create-course.dto';
 import { UpdateCourseDto } from '@module/course/application/dto/update-course.dto';
+import { CreateCoursePolicyHandler } from '@module/course/application/policy/create-course-policy-handler';
 import { CourseService } from '@module/course/application/service/course.service';
 import { CurrentUser } from '@module/iam/authentication/infrastructure/decorator/current-user.decorator';
+import { Policies } from '@module/iam/authorization/infrastructure/policy/decorator/policy.decorator';
+import { PoliciesGuard } from '@module/iam/authorization/infrastructure/policy/guard/policy.guard';
 import { User } from '@module/iam/user/domain/user.entity';
 
 @UseInterceptors(FileInterceptor('image', ImageOptionsFactory.create('image')))
+@UseGuards(PoliciesGuard)
 @Controller('course')
 export class CourseController {
   constructor(private readonly courseService: CourseService) {}
@@ -60,6 +65,7 @@ export class CourseController {
   }
 
   @Post()
+  @Policies(CreateCoursePolicyHandler)
   async saveOne(
     @Body() createDto: CreateCourseDto,
     @CurrentUser() user: User,

--- a/src/module/iam/authorization/application/policy/base-policy.handler.ts
+++ b/src/module/iam/authorization/application/policy/base-policy.handler.ts
@@ -1,0 +1,10 @@
+import { Request } from 'express';
+
+import { REQUEST_USER_KEY } from '@module/iam/authentication/infrastructure/decorator/current-user.decorator';
+import { User } from '@module/iam/user/domain/user.entity';
+
+export class BasePolicyHandler {
+  protected getCurrentUser(request: Request): User {
+    return request[REQUEST_USER_KEY] as User;
+  }
+}

--- a/src/module/iam/authorization/infrastructure/casl/type/app-subjects.type.ts
+++ b/src/module/iam/authorization/infrastructure/casl/type/app-subjects.type.ts
@@ -1,5 +1,8 @@
 import { InferSubjects } from '@casl/ability';
 
+import { Course } from '@module/course/domain/course.entity';
 import { User } from '@module/iam/user/domain/user.entity';
 
-export type AppSubjects = InferSubjects<typeof User | User> | 'all';
+export type AppSubjects =
+  | InferSubjects<typeof User | User | typeof Course | Course>
+  | 'all';

--- a/src/module/iam/authorization/infrastructure/policy/guard/policy.guard.ts
+++ b/src/module/iam/authorization/infrastructure/policy/guard/policy.guard.ts
@@ -2,6 +2,7 @@ import {
   CanActivate,
   ExecutionContext,
   ForbiddenException,
+  HttpException,
   Injectable,
   Type,
 } from '@nestjs/common';
@@ -29,6 +30,9 @@ export class PoliciesGuard implements CanActivate {
           return handler.handle(this.getContextRequest(context));
         }),
       ).catch((error) => {
+        if (error instanceof HttpException) {
+          throw error;
+        }
         throw new ForbiddenException((error as Error).message);
       });
     }

--- a/src/module/iam/user/application/policy/read-user-policy.handler.ts
+++ b/src/module/iam/user/application/policy/read-user-policy.handler.ts
@@ -1,7 +1,7 @@
 import { ForbiddenException, Injectable } from '@nestjs/common';
 import { Request } from 'express';
 
-import { REQUEST_USER_KEY } from '@module/iam/authentication/infrastructure/decorator/current-user.decorator';
+import { BasePolicyHandler } from '@module/iam/authorization/application/policy/base-policy.handler';
 import { AuthorizationService } from '@module/iam/authorization/application/service/authorization.service';
 import { AppAction } from '@module/iam/authorization/domain/app.action.enum';
 import { IPolicyHandler } from '@module/iam/authorization/infrastructure/policy/handler/policy-handler.interface';
@@ -9,19 +9,22 @@ import { PolicyHandlerStorage } from '@module/iam/authorization/infrastructure/p
 import { User } from '@module/iam/user/domain/user.entity';
 
 @Injectable()
-export class ReadUserPolicyHandler implements IPolicyHandler {
+export class ReadUserPolicyHandler
+  extends BasePolicyHandler
+  implements IPolicyHandler
+{
   private readonly action = AppAction.Read;
 
   constructor(
     private readonly policyHandlerStorage: PolicyHandlerStorage,
     private readonly authorizationService: AuthorizationService,
   ) {
+    super();
     this.policyHandlerStorage.add(ReadUserPolicyHandler, this);
   }
 
   handle(request: Request): void {
     const currentUser = this.getCurrentUser(request);
-
     const isAllowed = this.authorizationService.isAllowed(
       currentUser,
       this.action,
@@ -33,9 +36,5 @@ export class ReadUserPolicyHandler implements IPolicyHandler {
         `You are not allowed to ${this.action.toUpperCase()} this resource`,
       );
     }
-  }
-
-  private getCurrentUser(request: Request): User {
-    return request[REQUEST_USER_KEY] as User;
   }
 }


### PR DESCRIPTION
# Summary

This PR introduces policies  `create`, `update` and `delete` Course actions.

# Details

- Created a `BasePolicyHandler` with a protected method to obtain the user from the current request.
- Implemented `create`, `update` and `delete` policy handler in order to protect routes from regular or non-instructors.
- Refactored policy guard to throw `HttpExceptions` errors to preserve errors like `EntityNotFoundException`.