### PR TITLE
refactor: Improve response adapter with role based hateoas

### DIFF
--- a/src/common/base/application/decorator/hypermedia.decorator.ts
+++ b/src/common/base/application/decorator/hypermedia.decorator.ts
@@ -2,8 +2,13 @@ import { CustomDecorator, SetMetadata } from '@nestjs/common';
 
 import { ILink } from '@common/base/application/dto/serialized-response.interface';
 
+import { AppAction } from '@module/iam/authorization/domain/app.action.enum';
+import { AppSubjects } from '@module/iam/authorization/infrastructure/casl/type/app-subjects.type';
+
 export interface ILinkMetadata extends Omit<ILink, 'href'> {
   endpoint: string;
+  action?: AppAction;
+  subject?: AppSubjects;
 }
 
 export const HYPERMEDIA_KEY = 'HYPERMEDIA_KEY';

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -6,6 +6,7 @@ import { NestExpressApplication } from '@nestjs/platform-express';
 import { ResponseFormatterInterceptor } from '@module/app/application/interceptor/response-formatter.interceptor';
 import { LinkBuilderService } from '@module/app/application/service/link-builder.service';
 import { AppExceptionFilter } from '@module/app/infrastructure/nestjs/app-exception.filter';
+import { AuthorizationService } from '@module/iam/authorization/application/service/authorization.service';
 
 export const setupApp = (app: NestExpressApplication): void => {
   app.enableVersioning({
@@ -21,6 +22,7 @@ export const setupApp = (app: NestExpressApplication): void => {
       app.get(Reflector),
       app.get(LinkBuilderService),
       app.get(ConfigService),
+      app.get(AuthorizationService),
     ),
   );
 

--- a/src/module/course/course.module.ts
+++ b/src/module/course/course.module.ts
@@ -1,4 +1,4 @@
-import { Module, Provider } from '@nestjs/common';
+import { Module, OnModuleInit, Provider } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { CourseMapper } from '@module/course/application/mapper/course.mapper';
@@ -7,11 +7,13 @@ import { DeleteCoursePolicyHandler } from '@module/course/application/policy/del
 import { UpdateCoursePolicyHandler } from '@module/course/application/policy/update-course-policy.handler';
 import { COURSE_REPOSITORY_KEY } from '@module/course/application/repository/repository.interface';
 import { CourseService } from '@module/course/application/service/course.service';
+import { Course } from '@module/course/domain/course.entity';
 import { coursePermissions } from '@module/course/domain/course.permissions';
 import { CoursePostgresRepository } from '@module/course/infrastructure/database/course.postrges.repository';
 import { CourseSchema } from '@module/course/infrastructure/database/course.schema';
 import { CourseController } from '@module/course/interface/course.controller';
 import { AuthorizationModule } from '@module/iam/authorization/authorization.module';
+import { AppSubjectPermissionStorage } from '@module/iam/authorization/infrastructure/casl/storage/app-subject-permissions-storage';
 
 const courseRepositoryProvider: Provider = {
   provide: COURSE_REPOSITORY_KEY,
@@ -27,7 +29,7 @@ const policyHandlersProviders = [
 @Module({
   imports: [
     TypeOrmModule.forFeature([CourseSchema]),
-    AuthorizationModule.forFeature({ permissions: coursePermissions }),
+    AuthorizationModule.forFeature(),
   ],
   providers: [
     CourseService,
@@ -37,4 +39,10 @@ const policyHandlersProviders = [
   ],
   controllers: [CourseController],
 })
-export class CourseModule {}
+export class CourseModule implements OnModuleInit {
+  constructor(private readonly registry: AppSubjectPermissionStorage) {}
+
+  onModuleInit(): void {
+    this.registry.set(Course, coursePermissions);
+  }
+}

--- a/src/module/iam/authorization/application/service/authorization.service.ts
+++ b/src/module/iam/authorization/application/service/authorization.service.ts
@@ -18,7 +18,7 @@ export class AuthorizationService {
       return false;
     }
 
-    const userAbility = this.abilityFactory.createForUser(user);
+    const userAbility = this.abilityFactory.createForUser(user, subject);
     return userAbility.can(action, subject);
   }
 }

--- a/src/module/iam/authorization/authorization.constants.ts
+++ b/src/module/iam/authorization/authorization.constants.ts
@@ -1,1 +1,0 @@
-export const PERMISSIONS_FOR_FEATURE_KEY = 'permissions_for_feature';

--- a/src/module/iam/authorization/authorization.module.ts
+++ b/src/module/iam/authorization/authorization.module.ts
@@ -1,8 +1,8 @@
 import { DynamicModule, Module } from '@nestjs/common';
 
 import { AuthorizationService } from '@module/iam/authorization/application/service/authorization.service';
-import { PERMISSIONS_FOR_FEATURE_KEY } from '@module/iam/authorization/authorization.constants';
 import { CaslAbilityFactory } from '@module/iam/authorization/infrastructure/casl/factory/casl-ability.factory';
+import { AppSubjectPermissionStorage } from '@module/iam/authorization/infrastructure/casl/storage/app-subject-permissions-storage';
 import { PoliciesGuard } from '@module/iam/authorization/infrastructure/policy/guard/policy.guard';
 import { PolicyHandlerStorage } from '@module/iam/authorization/infrastructure/policy/storage/policies-handler.storage';
 import { IPermissionsDefinition } from '@module/iam/authorization/infrastructure/policy/type/permissions-definition.interface';
@@ -17,33 +17,16 @@ export class AuthorizationModule {
     return {
       module: AuthorizationModule,
       global: true,
-      providers: [PolicyHandlerStorage],
-      exports: [PolicyHandlerStorage],
+      providers: [PolicyHandlerStorage, AppSubjectPermissionStorage],
+      exports: [PolicyHandlerStorage, AppSubjectPermissionStorage],
     };
   }
 
-  static forFeature(
-    options: IAuthorizationModuleForFeatureOptions,
-  ): DynamicModule {
-    const permissionsProvider = {
-      provide: PERMISSIONS_FOR_FEATURE_KEY,
-      useValue: options.permissions,
-    };
-
+  static forFeature(): DynamicModule {
     return {
       module: AuthorizationModule,
-      providers: [
-        AuthorizationService,
-        CaslAbilityFactory,
-        PoliciesGuard,
-        permissionsProvider,
-      ],
-      exports: [
-        AuthorizationService,
-        CaslAbilityFactory,
-        PoliciesGuard,
-        permissionsProvider,
-      ],
+      providers: [AuthorizationService, CaslAbilityFactory, PoliciesGuard],
+      exports: [AuthorizationService, CaslAbilityFactory, PoliciesGuard],
     };
   }
 }

--- a/src/module/iam/authorization/infrastructure/casl/storage/app-subject-permissions-storage.ts
+++ b/src/module/iam/authorization/infrastructure/casl/storage/app-subject-permissions-storage.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+
+import { AppSubjects } from '@module/iam/authorization/infrastructure/casl/type/app-subjects.type';
+import { IPermissionsDefinition } from '@module/iam/authorization/infrastructure/policy/type/permissions-definition.interface';
+
+@Injectable()
+export class AppSubjectPermissionStorage {
+  private readonly permissionsMap = new Map<
+    AppSubjects,
+    IPermissionsDefinition
+  >();
+
+  set(subject: AppSubjects, permissions: IPermissionsDefinition): void {
+    this.permissionsMap.set(subject, permissions);
+  }
+
+  getPermissions(subject: AppSubjects): IPermissionsDefinition | null {
+    return this.permissionsMap.get(subject) ?? null;
+  }
+}

--- a/src/module/iam/user/interface/user.controller.ts
+++ b/src/module/iam/user/interface/user.controller.ts
@@ -1,9 +1,12 @@
 import { Body, Controller, Get, Patch, Query, UseGuards } from '@nestjs/common';
 
+import { Hypermedia } from '@common/base/application/decorator/hypermedia.decorator';
 import { CollectionDto } from '@common/base/application/dto/collection.dto';
 import { PageQueryParamsDto } from '@common/base/application/dto/page-query-params';
+import { HttpMethod } from '@common/base/application/enum/http-method.enum';
 
 import { CurrentUser } from '@module/iam/authentication/infrastructure/decorator/current-user.decorator';
+import { AppAction } from '@module/iam/authorization/domain/app.action.enum';
 import { Policies } from '@module/iam/authorization/infrastructure/policy/decorator/policy.decorator';
 import { PoliciesGuard } from '@module/iam/authorization/infrastructure/policy/guard/policy.guard';
 import { UpdateUserDto } from '@module/iam/user/application/dto/update-user.dto';
@@ -15,8 +18,8 @@ import { ReadUserPolicyHandler } from '@module/iam/user/application/policy/read-
 import { UserService } from '@module/iam/user/application/service/user.service';
 import { User } from '@module/iam/user/domain/user.entity';
 
-@UseGuards(PoliciesGuard)
 @Controller('user')
+@UseGuards(PoliciesGuard)
 export class UserController {
   constructor(private readonly userService: UserService) {}
 
@@ -37,11 +40,32 @@ export class UserController {
   }
 
   @Get('me')
+  @Hypermedia([
+    {
+      endpoint: '/user/me',
+      method: HttpMethod.PATCH,
+      rel: 'update-me',
+    },
+    {
+      endpoint: '/user',
+      method: HttpMethod.GET,
+      rel: 'get-all',
+      action: AppAction.Read,
+      subject: User,
+    },
+  ])
   getMe(@CurrentUser() user: User): UserResponseDto {
     return this.userService.getMe(user);
   }
 
   @Patch('me')
+  @Hypermedia([
+    {
+      endpoint: '/user/me',
+      method: HttpMethod.GET,
+      rel: 'get-me',
+    },
+  ])
   async updateMe(
     @CurrentUser() user: User,
     @Body() updateUserDto: UpdateUserDto,

--- a/src/module/iam/user/user.module.ts
+++ b/src/module/iam/user/user.module.ts
@@ -1,11 +1,13 @@
-import { Module, Provider } from '@nestjs/common';
+import { Module, OnModuleInit, Provider } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { AuthorizationModule } from '@module/iam/authorization/authorization.module';
+import { AppSubjectPermissionStorage } from '@module/iam/authorization/infrastructure/casl/storage/app-subject-permissions-storage';
 import { UserMapper } from '@module/iam/user/application/mapper/user.mapper';
 import { ReadUserPolicyHandler } from '@module/iam/user/application/policy/read-user-policy.handler';
 import { USER_REPOSITORY_KEY } from '@module/iam/user/application/repository/user.repository.interface';
 import { UserService } from '@module/iam/user/application/service/user.service';
+import { User } from '@module/iam/user/domain/user.entity';
 import { userPermissions } from '@module/iam/user/domain/user.permission';
 import { UserPostgresRepository } from '@module/iam/user/infrastructure/database/user.postgres.repository';
 import { UserSchema } from '@module/iam/user/infrastructure/database/user.schema';
@@ -21,7 +23,7 @@ const userRepositoryProvider: Provider = {
 @Module({
   imports: [
     TypeOrmModule.forFeature([UserSchema]),
-    AuthorizationModule.forFeature({ permissions: userPermissions }),
+    AuthorizationModule.forFeature(),
   ],
   controllers: [UserController],
   providers: [
@@ -32,4 +34,10 @@ const userRepositoryProvider: Provider = {
   ],
   exports: [userRepositoryProvider, UserMapper],
 })
-export class UserModule {}
+export class UserModule implements OnModuleInit {
+  constructor(private readonly registry: AppSubjectPermissionStorage) {}
+
+  onModuleInit(): void {
+    this.registry.set(User, userPermissions);
+  }
+}


### PR DESCRIPTION
# Summary

This PR refactors the hypermedia link generation mechanism to filter available endpoints based on the current user's permissions.

# Details

- Introduced a centralized `AppSubjectPermissionStorage` service to register and retrieve permission definitions per domain entity (`AppSubject`).
- Updated the UserModule and CourseModule to register their corresponding permissions (userPermissions and coursePermissions) during module initialization using AppSubjectPermissionStorage.
- This new approach enables the AuthorizationService to determine permissions for any subject type, which is particularly useful in global contexts like the `ResponseFormatterInterceptor`.
- Previously, permissions were passed via `AuthorizationModule.forFeature(...)`, this does not work in global components like interceptors that could not access module-specific instances.
- Updated the `ResponseFormatterInterceptor` to filter the hypermedia links received using the `AuthorizationService`.
- Refactored the `CaslAbilityFactory` to build abilities by the received `AppSubjct`.
- Added role base hypermedia links to the user controller. 