### PR TITLE
fix: Prevent errors on duplicate course titles

### DIFF
--- a/src/module/course/infrastructure/database/course.postrges.repository.ts
+++ b/src/module/course/infrastructure/database/course.postrges.repository.ts
@@ -18,12 +18,12 @@ export class CoursePostgresRepository
   }
 
   async getSlugsStartingWith(slug: string): Promise<string[]> {
-    const results: { course_slug: string }[] = await this.repository
+    const results: { slug: string }[] = await this.repository
       .createQueryBuilder('course')
-      .select('course.slug')
+      .select('course.slug', 'slug')
       .where('course.slug LIKE :slug', { slug: `${slug}%` })
       .getRawMany();
 
-    return results.map((r) => r.course_slug);
+    return results.map((r) => r.slug);
   }
 }


### PR DESCRIPTION
# Summary

This PR fixes a bug that caused errors when trying to create many courses with the same title.
