### PR TITLE
refactor: Normalize db primary keys constraints

### DIFF
--- a/data/migrations/1749578077208-normalizePrimaryKeyConstraints.ts
+++ b/data/migrations/1749578077208-normalizePrimaryKeyConstraints.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class NormalizePrimaryKeyConstraints1749578077208 implements MigrationInterface {
+    name = 'NormalizePrimaryKeyConstraints1749578077208'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "course" DROP CONSTRAINT "FK_deca5c9911b3b2100b361060826"`);
+        await queryRunner.query(`ALTER TABLE "user" DROP CONSTRAINT "UQ_cace4a159ff9f2512dd42373760"`);
+        await queryRunner.query(`ALTER TABLE "course" DROP CONSTRAINT "UQ_bf95180dd756fd204fb01ce4916"`);
+        await queryRunner.query(`ALTER TABLE "course" ADD CONSTRAINT "FK_deca5c9911b3b2100b361060826" FOREIGN KEY ("instructor_id") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "course" DROP CONSTRAINT "FK_deca5c9911b3b2100b361060826"`);
+        await queryRunner.query(`ALTER TABLE "course" ADD CONSTRAINT "UQ_bf95180dd756fd204fb01ce4916" UNIQUE ("id")`);
+        await queryRunner.query(`ALTER TABLE "user" ADD CONSTRAINT "UQ_cace4a159ff9f2512dd42373760" UNIQUE ("id")`);
+        await queryRunner.query(`ALTER TABLE "course" ADD CONSTRAINT "FK_deca5c9911b3b2100b361060826" FOREIGN KEY ("instructor_id") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "typeorm": "ts-node -r tsconfig-paths/register ./typeorm.custom-cli.ts",
     "migration:create": "cross-var npm run typeorm -- migration:create ./data/migrations/$npm_config_name",
     "migration:run": "npm run typeorm -- migration:run -d ./src/config/orm.config.ts",
+    "schema:diff": "npm run typeorm -- schema:log -d ./src/config/orm.config.ts",
     "migration:generate": "cross-var npm run typeorm -- migration:generate -d ./src/config/orm.config.ts ./data/migrations/$npm_config_name",
     "cognito:prepare": "cross-env ./data/scripts/create_user_pool.sh",
     "s3:prepare": "cross-env ./data/scripts/create_s3_bucket.sh",

--- a/src/common/base/infrastructure/database/base.schema.ts
+++ b/src/common/base/infrastructure/database/base.schema.ts
@@ -10,7 +10,7 @@ export function withBaseSchemaColumns<Entity extends object>(
   >,
 ): EntitySchemaColumns<Entity> {
   return {
-    id: { type: 'uuid', primary: true, generated: 'uuid', unique: true },
+    id: { type: 'uuid', primary: true, generated: 'uuid' },
     ...columns,
     createdAt: { type: Date, createDate: true },
     updatedAt: { type: Date, updateDate: true },


### PR DESCRIPTION
# Summary

This PR refactors the `withBaseSchemaColumns` utility and includes a migration to normalize primary key constraints across the database.

# Details

- Removed the redundant `unique: true` from the `id` field in the `withBaseSchemaColumns` function.
    - Primary keys are inherently unique, so the explicit `unique: true` was unnecessary and caused duplicated constraints.
- Added a TypeORM migration to drop existing redundant unique constraints.
