### PR TITLE
refactor: Enhance response interceptor including entityId on hypermedia links

### DIFF
--- a/src/module/app/application/interceptor/response-formatter.interceptor.ts
+++ b/src/module/app/application/interceptor/response-formatter.interceptor.ts
@@ -118,7 +118,7 @@ export class ResponseFormatterInterceptor implements NestInterceptor {
       currentRequestMethod,
       baseAppUrl,
       linksMetadata,
-      responseDto.id,
+      responseDto,
     );
     const serializedResponseData =
       this.buildSerializedResponseData(responseDto);

--- a/src/module/app/application/service/link-builder.service.interface.ts
+++ b/src/module/app/application/service/link-builder.service.interface.ts
@@ -1,4 +1,5 @@
 import { ILinkMetadata } from '@common/base/application/decorator/hypermedia.decorator';
+import { BaseResponseDto } from '@common/base/application/dto/base.response.dto';
 import { IPagingCollectionData } from '@common/base/application/dto/collection.interface';
 import {
   ICollectionLinks,
@@ -12,7 +13,7 @@ export interface ILinkBuilderService {
     currentRequestMethod: HttpMethod,
     baseAppUrl: string,
     linksMetadata: ILinkMetadata[],
-    id: string,
+    responseDto: BaseResponseDto,
   ): ILink[];
   buildCollectionLinks(
     currentRequestUrl: string,


### PR DESCRIPTION
# Summary

This PR refactores the `ResponseFormatterInterceptor` to replace the `:entityId` params from endpoint with the real entity id.

# Details

- Updated the `ResponseFormatterInterceptor` for using a regex to replce the `:entityId` paraam with the real entity id.