### PR TITLE
refactor: Add instructorId to course entity

### DIFF
--- a/data/migrations/1750087135143-addCourseIdForeignKeyToSectionTable.ts
+++ b/data/migrations/1750087135143-addCourseIdForeignKeyToSectionTable.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddCourseIdForeignKeyToSectionTable1750087135143 implements MigrationInterface {
+    name = 'AddCourseIdForeignKeyToSectionTable1750087135143'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "section" ADD CONSTRAINT "FK_7e12912705e3430a0bd74dad81f" FOREIGN KEY ("course_id") REFERENCES "course"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "section" DROP CONSTRAINT "FK_7e12912705e3430a0bd74dad81f"`);
+    }
+
+}

--- a/data/migrations/1750087496112-addInstructorIdToCourseSchema.ts
+++ b/data/migrations/1750087496112-addInstructorIdToCourseSchema.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddInstructorIdToCourseSchema1750087496112 implements MigrationInterface {
+    name = 'AddInstructorIdToCourseSchema1750087496112'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "course" DROP CONSTRAINT "FK_deca5c9911b3b2100b361060826"`);
+        await queryRunner.query(`ALTER TABLE "course" ALTER COLUMN "instructor_id" SET NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "course" ADD CONSTRAINT "FK_deca5c9911b3b2100b361060826" FOREIGN KEY ("instructor_id") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "course" DROP CONSTRAINT "FK_deca5c9911b3b2100b361060826"`);
+        await queryRunner.query(`ALTER TABLE "course" ALTER COLUMN "instructor_id" DROP NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "course" ADD CONSTRAINT "FK_deca5c9911b3b2100b361060826" FOREIGN KEY ("instructor_id") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+}

--- a/src/module/course/__test__/course.e2e.spec.ts
+++ b/src/module/course/__test__/course.e2e.spec.ts
@@ -77,6 +77,7 @@ describe('Course Module', () => {
                 id: expect.any(String),
                 type: 'course',
                 attributes: expect.objectContaining({
+                  instructorId: expect.any(String),
                   title: expect.any(String),
                   description: expect.any(String),
                   price: expect.any(Number),
@@ -248,6 +249,7 @@ describe('Course Module', () => {
               type: 'course',
               id: courseId,
               attributes: expect.objectContaining({
+                instructorId: expect.any(String),
                 title: 'Introduction to Programming',
                 description: 'Learn the basics of programming with JavaScript',
                 price: 49.99,
@@ -391,6 +393,7 @@ describe('Course Module', () => {
                 type: 'course',
                 id: expect.any(String),
                 attributes: expect.objectContaining({
+                  instructorId: expect.any(String),
                   title: createCourseDto.title,
                   description: createCourseDto.description,
                   price: createCourseDto.price,
@@ -398,11 +401,6 @@ describe('Course Module', () => {
                   status: createCourseDto.status,
                   slug: 'introduction-to-programming-2',
                   difficulty: Difficulty.BEGINNER,
-                  instructor: expect.objectContaining({
-                    firstName: 'admin-name',
-                    lastName: 'admin-surname',
-                    avatarUrl: expect.any(String),
-                  }),
                 }),
               }),
               links: expect.arrayContaining([
@@ -590,11 +588,12 @@ describe('Course Module', () => {
         .then(
           ({ body }: { body: SerializedResponseDto<CourseResponseDto> }) => {
             const { id } = body.data;
-            const expectedResponse = {
+            const expectedResponse = expect.objectContaining({
               data: expect.objectContaining({
                 type: 'course',
                 id: expect.any(String),
                 attributes: expect.objectContaining({
+                  instructorId: expect.any(String),
                   title: createCourseDto.title,
                   description: createCourseDto.description,
                   price: createCourseDto.price,
@@ -626,7 +625,7 @@ describe('Course Module', () => {
                   method: HttpMethod.DELETE,
                 }),
               ]),
-            };
+            });
             expect(body).toEqual(expectedResponse);
             courseId = body.data.id;
           },
@@ -644,11 +643,12 @@ describe('Course Module', () => {
         .expect(HttpStatus.OK)
         .then(
           ({ body }: { body: SerializedResponseDto<CourseResponseDto> }) => {
-            const expectedResponse = {
+            const expectedResponse = expect.objectContaining({
               data: expect.objectContaining({
                 type: 'course',
                 id: expect.any(String),
                 attributes: expect.objectContaining({
+                  instructorId: expect.any(String),
                   title: updateCourseDto.title,
                   description: updateCourseDto.description,
                   price: updateCourseDto.price,
@@ -675,7 +675,7 @@ describe('Course Module', () => {
                   method: HttpMethod.DELETE,
                 }),
               ]),
-            };
+            });
             expect(body).toEqual(expectedResponse);
           },
         );
@@ -755,11 +755,12 @@ describe('Course Module', () => {
         .then(
           ({ body }: { body: SerializedResponseDto<CourseResponseDto> }) => {
             const { id } = body.data;
-            const expectedResponse = {
+            const expectedResponse = expect.objectContaining({
               data: expect.objectContaining({
                 type: 'course',
                 id: expect.any(String),
                 attributes: expect.objectContaining({
+                  instructorId: expect.any(String),
                   title: createCourseDto.title,
                   description: createCourseDto.description,
                   price: createCourseDto.price,
@@ -791,7 +792,7 @@ describe('Course Module', () => {
                   method: HttpMethod.DELETE,
                 }),
               ]),
-            };
+            });
             expect(body).toEqual(expectedResponse);
             courseId = body.data.id;
           },

--- a/src/module/course/application/dto/course-response.dto.ts
+++ b/src/module/course/application/dto/course-response.dto.ts
@@ -10,6 +10,7 @@ export type CourseResponseInstructor = Pick<
 >;
 
 export class CourseResponseDto extends BaseResponseDto {
+  instructorId: string;
   title: string;
   description: string;
   price: number;
@@ -20,6 +21,7 @@ export class CourseResponseDto extends BaseResponseDto {
   instructor?: CourseResponseInstructor;
   constructor(
     type: string,
+    instructorId: string,
     title: string,
     description: string,
     price: number,
@@ -32,6 +34,7 @@ export class CourseResponseDto extends BaseResponseDto {
   ) {
     super(type, id);
 
+    this.instructorId = instructorId;
     this.title = title;
     this.description = description;
     this.price = price;

--- a/src/module/course/application/dto/course.dto.ts
+++ b/src/module/course/application/dto/course.dto.ts
@@ -1,4 +1,11 @@
-import { IsEnum, IsNumber, IsOptional, IsString } from 'class-validator';
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  IsUUID,
+} from 'class-validator';
 
 import { BaseDto } from '@common/base/application/dto/base.dto';
 import { Difficulty } from '@common/base/application/enum/difficulty.enum';
@@ -7,6 +14,10 @@ import { PublishStatus } from '@common/base/application/enum/publish-status.enum
 import { User } from '@module/iam/user/domain/user.entity';
 
 export class CourseDto extends BaseDto {
+  @IsNotEmpty()
+  @IsUUID('4')
+  instructorId: string;
+
   @IsOptional()
   @IsString()
   title?: string;

--- a/src/module/course/application/dto/create-course.dto.ts
+++ b/src/module/course/application/dto/create-course.dto.ts
@@ -1,3 +1,9 @@
+import { OmitType } from '@nestjs/mapped-types';
+
 import { CourseDto } from '@module/course/application/dto/course.dto';
+
+export class CreateCourseRequestDto extends OmitType(CourseDto, [
+  'instructorId',
+]) {}
 
 export class CreateCourseDto extends CourseDto {}

--- a/src/module/course/application/dto/update-course.dto.ts
+++ b/src/module/course/application/dto/update-course.dto.ts
@@ -1,5 +1,9 @@
-import { PartialType } from '@nestjs/mapped-types';
+import { OmitType, PartialType } from '@nestjs/mapped-types';
 
 import { CreateCourseDto } from '@module/course/application/dto/create-course.dto';
 
-export class UpdateCourseDto extends PartialType(CreateCourseDto) {}
+export class UpdateCourseDto extends PartialType(
+  OmitType(CreateCourseDto, ['instructorId']),
+) {
+  instructorId?: string;
+}

--- a/src/module/course/application/mapper/course.mapper.ts
+++ b/src/module/course/application/mapper/course.mapper.ts
@@ -23,6 +23,7 @@ export class CourseMapper
       dto.status,
       dto.slug,
       dto.difficulty,
+      dto.instructorId,
       dto.instructor,
     );
   }
@@ -37,6 +38,7 @@ export class CourseMapper
       dto.status,
       dto.slug,
       dto.difficulty,
+      dto.instructorId,
     );
   }
 
@@ -46,6 +48,7 @@ export class CourseMapper
       : null;
     return new CourseResponseDto(
       Course.getEntityName(),
+      entity.instructorId,
       entity.title,
       entity.description,
       entity.price,

--- a/src/module/course/application/policy/delete-course-policy-handler.ts
+++ b/src/module/course/application/policy/delete-course-policy-handler.ts
@@ -31,9 +31,7 @@ export class DeleteCoursePolicyHandler
   async handle(request: Request): Promise<void> {
     const user = this.getCurrentUser(request);
     const { id } = request.params;
-    const course = await this.courseRepository.getOneByIdOrFail(id, [
-      'instructor',
-    ]);
+    const course = await this.courseRepository.getOneByIdOrFail(id);
 
     const isAllowed = this.authorizationService.isAllowed(
       user,

--- a/src/module/course/application/policy/update-course-policy.handler.ts
+++ b/src/module/course/application/policy/update-course-policy.handler.ts
@@ -31,9 +31,7 @@ export class UpdateCoursePolicyHandler
   async handle(request: Request): Promise<void> {
     const user = this.getCurrentUser(request);
     const { id } = request.params;
-    const course = await this.courseRepository.getOneByIdOrFail(id, [
-      'instructor',
-    ]);
+    const course = await this.courseRepository.getOneByIdOrFail(id);
 
     const isAllowed = this.authorizationService.isAllowed(
       user,

--- a/src/module/course/domain/course.entity.ts
+++ b/src/module/course/domain/course.entity.ts
@@ -12,11 +12,8 @@ export class Course extends Base {
   status: PublishStatus;
   slug: string;
   difficulty: Difficulty;
+  instructorId: string;
   instructor?: User;
-
-  get instructorId(): string | null {
-    return this.instructor?.id || null;
-  }
 
   constructor(
     id: string,
@@ -27,6 +24,7 @@ export class Course extends Base {
     status: PublishStatus,
     slug: string,
     difficulty: Difficulty,
+    instructorId: string,
     instructor?: User,
   ) {
     super(id);
@@ -37,6 +35,7 @@ export class Course extends Base {
     this.status = status;
     this.slug = slug;
     this.difficulty = difficulty;
+    this.instructorId = instructorId;
     this.instructor = instructor;
   }
 }

--- a/src/module/course/infrastructure/database/course.schema.ts
+++ b/src/module/course/infrastructure/database/course.schema.ts
@@ -39,6 +39,9 @@ export const CourseSchema = new EntitySchema<Course>({
       type: String,
       nullable: true,
     },
+    instructorId: {
+      type: 'uuid',
+    },
   }),
   relations: {
     instructor: {

--- a/src/module/course/interface/course.controller.ts
+++ b/src/module/course/interface/course.controller.ts
@@ -26,7 +26,7 @@ import { CourseFilterQueryParamsDto } from '@module/course/application/dto/cours
 import { CourseIncludeQueryDto } from '@module/course/application/dto/course-include.dto';
 import { CourseResponseDto } from '@module/course/application/dto/course-response.dto';
 import { CourseSortQueryParamsDto } from '@module/course/application/dto/course-sort-query-params.dto';
-import { CreateCourseDto } from '@module/course/application/dto/create-course.dto';
+import { CreateCourseRequestDto } from '@module/course/application/dto/create-course.dto';
 import { UpdateCourseDto } from '@module/course/application/dto/update-course.dto';
 import { CreateCoursePolicyHandler } from '@module/course/application/policy/create-course-policy-handler';
 import { DeleteCoursePolicyHandler } from '@module/course/application/policy/delete-course-policy-handler';
@@ -120,12 +120,12 @@ export class CourseController {
   ])
   @Policies(CreateCoursePolicyHandler)
   async saveOne(
-    @Body() createDto: CreateCourseDto,
+    @Body() createDto: CreateCourseRequestDto,
     @CurrentUser() user: User,
     @UploadedFile() image?: Express.Multer.File,
   ): Promise<CourseResponseDto> {
     return await this.courseService.saveOne(
-      { ...createDto, instructor: user },
+      { ...createDto, instructorId: user.id },
       image,
     );
   }


### PR DESCRIPTION
# Summary

This PR updates the `Course` entity to include the `instructorId` as property in order to simplify direct access to the instructor ID without loading the full relation.

# Details

- Updated the `Course` domain/schema entities with `instructorId` property.
- Added the `instructorId` to the CourseDtos.
- Created a custom CreateDto for `saveOne` request to omit the `instructorId` property, as this value is obtained by the `user` property of the request instead of the body.
- Removed "includes" operation from Course Policy Handlers queries because the necessary instructor's id is now a property of the Course entity,   