### PR TITLE
feat: Add section policies

### DIFF
--- a/src/module/course/course.module.ts
+++ b/src/module/course/course.module.ts
@@ -38,6 +38,7 @@ const policyHandlersProviders = [
     ...policyHandlersProviders,
   ],
   controllers: [CourseController],
+  exports: [courseRepositoryProvider],
 })
 export class CourseModule implements OnModuleInit {
   constructor(private readonly registry: AppSubjectPermissionStorage) {}

--- a/src/module/iam/authorization/infrastructure/casl/type/app-subjects.type.ts
+++ b/src/module/iam/authorization/infrastructure/casl/type/app-subjects.type.ts
@@ -2,7 +2,10 @@ import { InferSubjects } from '@casl/ability';
 
 import { Course } from '@module/course/domain/course.entity';
 import { User } from '@module/iam/user/domain/user.entity';
+import { Section } from '@module/section/domain/section.entity';
 
 export type AppSubjects =
-  | InferSubjects<typeof User | User | typeof Course | Course>
+  | InferSubjects<
+      typeof User | User | typeof Course | Course | typeof Section | Section
+    >
   | 'all';

--- a/src/module/section/__test__/fixture/Course.yml
+++ b/src/module/section/__test__/fixture/Course.yml
@@ -10,3 +10,13 @@ items:
     slug: 'introduction-to-programming'
     difficulty: beginner
     instructor: '@admin-user'
+  course2:
+    id: 'b894ad66-ea0a-4ed3-822b-fea66d3a9e49'
+    title: 'Introduction to Ruby'
+    description: 'Learn the basics of programming with Ruby'
+    price: 49.99
+    imageUrl: '{{internet.url}}/intro-programming.jpg'
+    status: published
+    slug: 'introduction-to-ruby'
+    difficulty: beginner
+    instructor: '@admin-user-2'

--- a/src/module/section/__test__/fixture/User.yml
+++ b/src/module/section/__test__/fixture/User.yml
@@ -15,6 +15,14 @@ items:
     avatarUrl: '{{internet.url}}'
     externalId: '00000000-0000-0000-0000-00000000000Y'
     roles: regular,admin
+  admin-user-2:
+    id: 9f5e3ef6-b0f5-4795-ab7b-7cf35f9c41e8
+    firstName: second-admin-name
+    lastName: second-admin-surname
+    email: 'second_test_admin@email.co'
+    avatarUrl: '{{internet.url}}'
+    externalId: '00000000-0000-0000-0000-00000000000W'
+    roles: regular,admin
   regular-user:
     firstName: regular-name
     lastName: regular-surname

--- a/src/module/section/__test__/section.e2e.spec.ts
+++ b/src/module/section/__test__/section.e2e.spec.ts
@@ -14,6 +14,7 @@ import { datasourceOptions } from '@config/orm.config';
 import { testModuleBootstrapper } from '@test/test.module.bootstrapper';
 import { createAccessToken } from '@test/test.util';
 
+import { AppAction } from '@module/iam/authorization/domain/app.action.enum';
 import { SectionResponseDto } from '@module/section/application/dto/section.response.dto';
 import { UpdateSectionDto } from '@module/section/application/dto/update.section.dto';
 
@@ -24,6 +25,15 @@ describe('Course Module', () => {
 
   const adminToken = createAccessToken({
     sub: '00000000-0000-0000-0000-00000000000Y',
+  });
+  const secondAdminToken = createAccessToken({
+    sub: '00000000-0000-0000-0000-00000000000W',
+  });
+  const regularToken = createAccessToken({
+    sub: '00000000-0000-0000-0000-00000000000Z',
+  });
+  const superAdminToken = createAccessToken({
+    sub: '00000000-0000-0000-0000-00000000000X',
   });
 
   beforeAll(async () => {
@@ -44,8 +54,9 @@ describe('Course Module', () => {
 
   const endpoint = '/api/v1/course';
   const existingCourseId = 'c62801a2-0d74-4dd7-a20c-11c25be00a2a';
+  const secondExistingCourseId = 'b894ad66-ea0a-4ed3-822b-fea66d3a9e49';
 
-  describe('POST - /section', () => {
+  describe('POST - /course/:courseId/section', () => {
     it('Should create a section', async () => {
       const createSectionDto = {
         title: 'Section 1',
@@ -98,9 +109,105 @@ describe('Course Module', () => {
           },
         );
     });
+
+    it('Should deny access to regular users', async () => {
+      const createSectionDto = {
+        title: 'Section 1',
+        description: 'Description 1',
+        position: 0,
+      } as CreateSectionDto;
+
+      await request(app.getHttpServer())
+        .post(`${endpoint}/${existingCourseId}/section`)
+        .auth(regularToken, { type: 'bearer' })
+        .send(createSectionDto)
+        .expect(HttpStatus.FORBIDDEN)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `You are not allowed to ${AppAction.Create.toUpperCase()} this resource`,
+              source: {
+                pointer: `${endpoint}/${existingCourseId}/section`,
+              },
+              status: HttpStatus.FORBIDDEN.toString(),
+              title: 'Forbidden',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should throw an error if the course does not exist', async () => {
+      const nonExistingCourseId = '1c9c3688-64b3-4bf0-8481-bd8aa16ce134';
+      const createSectionDto = {
+        title: 'Section 1',
+        description: 'Description 1',
+        position: 0,
+      } as CreateSectionDto;
+
+      await request(app.getHttpServer())
+        .post(`${endpoint}/${nonExistingCourseId}/section`)
+        .auth(adminToken, { type: 'bearer' })
+        .send(createSectionDto)
+        .expect(HttpStatus.NOT_FOUND)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `Entity with id ${nonExistingCourseId} not found`,
+              source: {
+                pointer: `${endpoint}/${nonExistingCourseId}/section`,
+              },
+              status: HttpStatus.NOT_FOUND.toString(),
+              title: 'Entity not found',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should deny access to non instructors admins', async () => {
+      const createSectionDto = {
+        title: 'Section 1',
+        description: 'Description 1',
+        position: 0,
+      } as CreateSectionDto;
+
+      await request(app.getHttpServer())
+        .post(`${endpoint}/${existingCourseId}/section`)
+        .auth(secondAdminToken, { type: 'bearer' })
+        .send(createSectionDto)
+        .expect(HttpStatus.FORBIDDEN)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `You are not allowed to ${AppAction.Create.toUpperCase()} this resource`,
+              source: {
+                pointer: `${endpoint}/${existingCourseId}/section`,
+              },
+              status: HttpStatus.FORBIDDEN.toString(),
+              title: 'Forbidden',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should grant access to non instructor super admins', async () => {
+      const createSectionDto = {
+        title: 'Section 1',
+        description: 'Description 1',
+        position: 0,
+      } as CreateSectionDto;
+
+      await request(app.getHttpServer())
+        .post(`${endpoint}/${existingCourseId}/section`)
+        .auth(superAdminToken, { type: 'bearer' })
+        .send(createSectionDto)
+        .expect(HttpStatus.CREATED);
+    });
   });
 
-  describe('PATCH - /section/:id', () => {
+  describe('PATCH - /course/:courseId/section/:id', () => {
     it('Should update section', async () => {
       const updateSectionDto = {
         title: 'Updated',
@@ -215,10 +322,306 @@ describe('Course Module', () => {
           expect(body).toEqual(expectedResponse);
         });
     });
+
+    it('Should throw an error if the section does not belong to the course', async () => {
+      const updateSectionDto = {
+        title: 'Updated',
+      } as UpdateSectionDto;
+      const createSectionDto = {
+        title: 'Section 1',
+        description: 'Description 1',
+        position: 0,
+      } as CreateSectionDto;
+      let sectionId: string;
+
+      await request(app.getHttpServer())
+        .post(`${endpoint}/${existingCourseId}/section`)
+        .auth(adminToken, { type: 'bearer' })
+        .send(createSectionDto)
+        .expect(HttpStatus.CREATED)
+        .then(
+          ({ body }: { body: SerializedResponseDto<SectionResponseDto> }) => {
+            sectionId = body.data.id;
+
+            const expectedResponse = expect.objectContaining({
+              data: expect.objectContaining({
+                attributes: expect.objectContaining({
+                  title: createSectionDto.title,
+                  description: createSectionDto.description,
+                  position: createSectionDto.position,
+                  courseId: existingCourseId,
+                }),
+              }),
+              links: expect.arrayContaining([
+                expect.objectContaining({
+                  href: expect.stringContaining(
+                    `${endpoint}/${existingCourseId}/section`,
+                  ),
+                  rel: 'self',
+                  method: HttpMethod.POST,
+                }),
+                expect.objectContaining({
+                  rel: 'update-section',
+                  method: HttpMethod.PATCH,
+                  href: expect.stringContaining(
+                    `${endpoint}/${existingCourseId}/section/${sectionId}`,
+                  ),
+                }),
+                expect.objectContaining({
+                  rel: 'delete-section',
+                  method: HttpMethod.DELETE,
+                  href: expect.stringContaining(
+                    `${endpoint}/${existingCourseId}/section/${sectionId}`,
+                  ),
+                }),
+              ]),
+            });
+            expect(body).toEqual(expectedResponse);
+          },
+        );
+
+      await request(app.getHttpServer())
+        .patch(`${endpoint}/${secondExistingCourseId}/section/${sectionId}`)
+        .auth(adminToken, { type: 'bearer' })
+        .send(updateSectionDto)
+        .expect(HttpStatus.BAD_REQUEST)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `The section with id ${sectionId} does not belong to the course with id ${secondExistingCourseId}`,
+              source: {
+                pointer: `${endpoint}/${secondExistingCourseId}/section/${sectionId}`,
+              },
+              status: '400',
+              title: 'Bad request',
+            },
+          });
+
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should deny access to regular users', async () => {
+      const updateSectionDto = {
+        title: 'Updated',
+      } as UpdateSectionDto;
+      const createSectionDto = {
+        title: 'Section 1',
+        description: 'Description 1',
+        position: 0,
+      } as CreateSectionDto;
+      let sectionId: string;
+
+      await request(app.getHttpServer())
+        .post(`${endpoint}/${existingCourseId}/section`)
+        .auth(adminToken, { type: 'bearer' })
+        .send(createSectionDto)
+        .expect(HttpStatus.CREATED)
+        .then(
+          ({ body }: { body: SerializedResponseDto<SectionResponseDto> }) => {
+            sectionId = body.data.id;
+
+            const expectedResponse = expect.objectContaining({
+              data: expect.objectContaining({
+                attributes: expect.objectContaining({
+                  title: createSectionDto.title,
+                  description: createSectionDto.description,
+                  position: createSectionDto.position,
+                  courseId: existingCourseId,
+                }),
+              }),
+              links: expect.arrayContaining([
+                expect.objectContaining({
+                  href: expect.stringContaining(
+                    `${endpoint}/${existingCourseId}/section`,
+                  ),
+                  rel: 'self',
+                  method: HttpMethod.POST,
+                }),
+                expect.objectContaining({
+                  rel: 'update-section',
+                  method: HttpMethod.PATCH,
+                  href: expect.stringContaining(
+                    `${endpoint}/${existingCourseId}/section/${sectionId}`,
+                  ),
+                }),
+                expect.objectContaining({
+                  rel: 'delete-section',
+                  method: HttpMethod.DELETE,
+                  href: expect.stringContaining(
+                    `${endpoint}/${existingCourseId}/section/${sectionId}`,
+                  ),
+                }),
+              ]),
+            });
+            expect(body).toEqual(expectedResponse);
+          },
+        );
+
+      await request(app.getHttpServer())
+        .patch(`${endpoint}/${existingCourseId}/section/${sectionId}`)
+        .auth(regularToken, { type: 'bearer' })
+        .send(updateSectionDto)
+        .expect(HttpStatus.FORBIDDEN)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `You are not allowed to ${AppAction.Update.toUpperCase()} this resource`,
+              source: {
+                pointer: `${endpoint}/${existingCourseId}/section/${sectionId}`,
+              },
+              status: HttpStatus.FORBIDDEN.toString(),
+              title: 'Forbidden',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should deny access to non instructors admins', async () => {
+      const updateSectionDto = {
+        title: 'Updated',
+      } as UpdateSectionDto;
+      const createSectionDto = {
+        title: 'Section 1',
+        description: 'Description 1',
+        position: 0,
+      } as CreateSectionDto;
+      let sectionId: string;
+
+      await request(app.getHttpServer())
+        .post(`${endpoint}/${existingCourseId}/section`)
+        .auth(adminToken, { type: 'bearer' })
+        .send(createSectionDto)
+        .expect(HttpStatus.CREATED)
+        .then(
+          ({ body }: { body: SerializedResponseDto<SectionResponseDto> }) => {
+            sectionId = body.data.id;
+
+            const expectedResponse = expect.objectContaining({
+              data: expect.objectContaining({
+                attributes: expect.objectContaining({
+                  title: createSectionDto.title,
+                  description: createSectionDto.description,
+                  position: createSectionDto.position,
+                  courseId: existingCourseId,
+                }),
+              }),
+              links: expect.arrayContaining([
+                expect.objectContaining({
+                  href: expect.stringContaining(
+                    `${endpoint}/${existingCourseId}/section`,
+                  ),
+                  rel: 'self',
+                  method: HttpMethod.POST,
+                }),
+                expect.objectContaining({
+                  rel: 'update-section',
+                  method: HttpMethod.PATCH,
+                  href: expect.stringContaining(
+                    `${endpoint}/${existingCourseId}/section/${sectionId}`,
+                  ),
+                }),
+                expect.objectContaining({
+                  rel: 'delete-section',
+                  method: HttpMethod.DELETE,
+                  href: expect.stringContaining(
+                    `${endpoint}/${existingCourseId}/section/${sectionId}`,
+                  ),
+                }),
+              ]),
+            });
+            expect(body).toEqual(expectedResponse);
+          },
+        );
+
+      await request(app.getHttpServer())
+        .patch(`${endpoint}/${existingCourseId}/section/${sectionId}`)
+        .auth(secondAdminToken, { type: 'bearer' })
+        .send(updateSectionDto)
+        .expect(HttpStatus.FORBIDDEN)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `You are not allowed to ${AppAction.Update.toUpperCase()} this resource`,
+              source: {
+                pointer: `${endpoint}/${existingCourseId}/section/${sectionId}`,
+              },
+              status: HttpStatus.FORBIDDEN.toString(),
+              title: 'Forbidden',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should grant access to non instructor super admins', async () => {
+      const updateSectionDto = {
+        title: 'Updated',
+      } as UpdateSectionDto;
+      const createSectionDto = {
+        title: 'Section 1',
+        description: 'Description 1',
+        position: 0,
+      } as CreateSectionDto;
+      let sectionId: string;
+
+      await request(app.getHttpServer())
+        .post(`${endpoint}/${existingCourseId}/section`)
+        .auth(adminToken, { type: 'bearer' })
+        .send(createSectionDto)
+        .expect(HttpStatus.CREATED)
+        .then(
+          ({ body }: { body: SerializedResponseDto<SectionResponseDto> }) => {
+            sectionId = body.data.id;
+
+            const expectedResponse = expect.objectContaining({
+              data: expect.objectContaining({
+                attributes: expect.objectContaining({
+                  title: createSectionDto.title,
+                  description: createSectionDto.description,
+                  position: createSectionDto.position,
+                  courseId: existingCourseId,
+                }),
+              }),
+              links: expect.arrayContaining([
+                expect.objectContaining({
+                  href: expect.stringContaining(
+                    `${endpoint}/${existingCourseId}/section`,
+                  ),
+                  rel: 'self',
+                  method: HttpMethod.POST,
+                }),
+                expect.objectContaining({
+                  rel: 'update-section',
+                  method: HttpMethod.PATCH,
+                  href: expect.stringContaining(
+                    `${endpoint}/${existingCourseId}/section/${sectionId}`,
+                  ),
+                }),
+                expect.objectContaining({
+                  rel: 'delete-section',
+                  method: HttpMethod.DELETE,
+                  href: expect.stringContaining(
+                    `${endpoint}/${existingCourseId}/section/${sectionId}`,
+                  ),
+                }),
+              ]),
+            });
+            expect(body).toEqual(expectedResponse);
+          },
+        );
+
+      await request(app.getHttpServer())
+        .patch(`${endpoint}/${existingCourseId}/section/${sectionId}`)
+        .auth(superAdminToken, { type: 'bearer' })
+        .send(updateSectionDto)
+        .expect(HttpStatus.OK);
+    });
   });
 
-  describe('DELETE - /section/:id', () => {
-    it('Should delete section', async () => {
+  describe('DELETE - /course/:courseId/section/:id', () => {
+    it('Should delete a section', async () => {
       const createSectionDto = {
         title: 'Section 1',
         description: 'Description 1',
@@ -348,6 +751,286 @@ describe('Course Module', () => {
           });
           expect(body).toEqual(expectedResponse);
         });
+    });
+
+    it('Should throw an error if the section does not belong to the course', async () => {
+      const createSectionDto = {
+        title: 'Section 1',
+        description: 'Description 1',
+        position: 0,
+      } as CreateSectionDto;
+      let sectionId: string;
+
+      await request(app.getHttpServer())
+        .post(`${endpoint}/${existingCourseId}/section`)
+        .auth(adminToken, { type: 'bearer' })
+        .send(createSectionDto)
+        .expect(HttpStatus.CREATED)
+        .then(
+          ({ body }: { body: SerializedResponseDto<SectionResponseDto> }) => {
+            sectionId = body.data.id;
+
+            const expectedResponse = expect.objectContaining({
+              data: expect.objectContaining({
+                attributes: expect.objectContaining({
+                  title: createSectionDto.title,
+                  description: createSectionDto.description,
+                  position: createSectionDto.position,
+                  courseId: existingCourseId,
+                }),
+              }),
+              links: expect.arrayContaining([
+                expect.objectContaining({
+                  href: expect.stringContaining(
+                    `${endpoint}/${existingCourseId}/section`,
+                  ),
+                  rel: 'self',
+                  method: HttpMethod.POST,
+                }),
+                expect.objectContaining({
+                  rel: 'update-section',
+                  method: HttpMethod.PATCH,
+                  href: expect.stringContaining(
+                    `${endpoint}/${existingCourseId}/section/${sectionId}`,
+                  ),
+                }),
+                expect.objectContaining({
+                  rel: 'delete-section',
+                  method: HttpMethod.DELETE,
+                  href: expect.stringContaining(
+                    `${endpoint}/${existingCourseId}/section/${sectionId}`,
+                  ),
+                }),
+              ]),
+            });
+            expect(body).toEqual(expectedResponse);
+          },
+        );
+
+      await request(app.getHttpServer())
+        .delete(`${endpoint}/${secondExistingCourseId}/section/${sectionId}`)
+        .auth(adminToken, { type: 'bearer' })
+        .expect(HttpStatus.BAD_REQUEST)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `The section with id ${sectionId} does not belong to the course with id ${secondExistingCourseId}`,
+              source: {
+                pointer: `${endpoint}/${secondExistingCourseId}/section/${sectionId}`,
+              },
+              status: '400',
+              title: 'Bad request',
+            },
+          });
+
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should deny access to regular users', async () => {
+      const createSectionDto = {
+        title: 'Section 1',
+        description: 'Description 1',
+        position: 0,
+      } as CreateSectionDto;
+      let sectionId: string;
+
+      await request(app.getHttpServer())
+        .post(`${endpoint}/${existingCourseId}/section`)
+        .auth(adminToken, { type: 'bearer' })
+        .send(createSectionDto)
+        .expect(HttpStatus.CREATED)
+        .then(
+          ({ body }: { body: SerializedResponseDto<SectionResponseDto> }) => {
+            sectionId = body.data.id;
+
+            const expectedResponse = expect.objectContaining({
+              data: expect.objectContaining({
+                attributes: expect.objectContaining({
+                  title: createSectionDto.title,
+                  description: createSectionDto.description,
+                  position: createSectionDto.position,
+                  courseId: existingCourseId,
+                }),
+              }),
+              links: expect.arrayContaining([
+                expect.objectContaining({
+                  href: expect.stringContaining(
+                    `${endpoint}/${existingCourseId}/section`,
+                  ),
+                  rel: 'self',
+                  method: HttpMethod.POST,
+                }),
+                expect.objectContaining({
+                  rel: 'update-section',
+                  method: HttpMethod.PATCH,
+                  href: expect.stringContaining(
+                    `${endpoint}/${existingCourseId}/section/${sectionId}`,
+                  ),
+                }),
+                expect.objectContaining({
+                  rel: 'delete-section',
+                  method: HttpMethod.DELETE,
+                  href: expect.stringContaining(
+                    `${endpoint}/${existingCourseId}/section/${sectionId}`,
+                  ),
+                }),
+              ]),
+            });
+            expect(body).toEqual(expectedResponse);
+          },
+        );
+
+      await request(app.getHttpServer())
+        .delete(`${endpoint}/${existingCourseId}/section/${sectionId}`)
+        .auth(regularToken, { type: 'bearer' })
+        .expect(HttpStatus.FORBIDDEN)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `You are not allowed to ${AppAction.Delete.toUpperCase()} this resource`,
+              source: {
+                pointer: `${endpoint}/${existingCourseId}/section/${sectionId}`,
+              },
+              status: HttpStatus.FORBIDDEN.toString(),
+              title: 'Forbidden',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should deny access to non instructors admins', async () => {
+      const createSectionDto = {
+        title: 'Section 1',
+        description: 'Description 1',
+        position: 0,
+      } as CreateSectionDto;
+      let sectionId: string;
+
+      await request(app.getHttpServer())
+        .post(`${endpoint}/${existingCourseId}/section`)
+        .auth(adminToken, { type: 'bearer' })
+        .send(createSectionDto)
+        .expect(HttpStatus.CREATED)
+        .then(
+          ({ body }: { body: SerializedResponseDto<SectionResponseDto> }) => {
+            sectionId = body.data.id;
+
+            const expectedResponse = expect.objectContaining({
+              data: expect.objectContaining({
+                attributes: expect.objectContaining({
+                  title: createSectionDto.title,
+                  description: createSectionDto.description,
+                  position: createSectionDto.position,
+                  courseId: existingCourseId,
+                }),
+              }),
+              links: expect.arrayContaining([
+                expect.objectContaining({
+                  href: expect.stringContaining(
+                    `${endpoint}/${existingCourseId}/section`,
+                  ),
+                  rel: 'self',
+                  method: HttpMethod.POST,
+                }),
+                expect.objectContaining({
+                  rel: 'update-section',
+                  method: HttpMethod.PATCH,
+                  href: expect.stringContaining(
+                    `${endpoint}/${existingCourseId}/section/${sectionId}`,
+                  ),
+                }),
+                expect.objectContaining({
+                  rel: 'delete-section',
+                  method: HttpMethod.DELETE,
+                  href: expect.stringContaining(
+                    `${endpoint}/${existingCourseId}/section/${sectionId}`,
+                  ),
+                }),
+              ]),
+            });
+            expect(body).toEqual(expectedResponse);
+          },
+        );
+
+      await request(app.getHttpServer())
+        .delete(`${endpoint}/${existingCourseId}/section/${sectionId}`)
+        .auth(secondAdminToken, { type: 'bearer' })
+        .expect(HttpStatus.FORBIDDEN)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `You are not allowed to ${AppAction.Delete.toUpperCase()} this resource`,
+              source: {
+                pointer: `${endpoint}/${existingCourseId}/section/${sectionId}`,
+              },
+              status: HttpStatus.FORBIDDEN.toString(),
+              title: 'Forbidden',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should grant access to non instructor super admins', async () => {
+      const createSectionDto = {
+        title: 'Section 1',
+        description: 'Description 1',
+        position: 0,
+      } as CreateSectionDto;
+      let sectionId: string;
+
+      await request(app.getHttpServer())
+        .post(`${endpoint}/${existingCourseId}/section`)
+        .auth(adminToken, { type: 'bearer' })
+        .send(createSectionDto)
+        .expect(HttpStatus.CREATED)
+        .then(
+          ({ body }: { body: SerializedResponseDto<SectionResponseDto> }) => {
+            sectionId = body.data.id;
+
+            const expectedResponse = expect.objectContaining({
+              data: expect.objectContaining({
+                attributes: expect.objectContaining({
+                  title: createSectionDto.title,
+                  description: createSectionDto.description,
+                  position: createSectionDto.position,
+                  courseId: existingCourseId,
+                }),
+              }),
+              links: expect.arrayContaining([
+                expect.objectContaining({
+                  href: expect.stringContaining(
+                    `${endpoint}/${existingCourseId}/section`,
+                  ),
+                  rel: 'self',
+                  method: HttpMethod.POST,
+                }),
+                expect.objectContaining({
+                  rel: 'update-section',
+                  method: HttpMethod.PATCH,
+                  href: expect.stringContaining(
+                    `${endpoint}/${existingCourseId}/section/${sectionId}`,
+                  ),
+                }),
+                expect.objectContaining({
+                  rel: 'delete-section',
+                  method: HttpMethod.DELETE,
+                  href: expect.stringContaining(
+                    `${endpoint}/${existingCourseId}/section/${sectionId}`,
+                  ),
+                }),
+              ]),
+            });
+            expect(body).toEqual(expectedResponse);
+          },
+        );
+
+      await request(app.getHttpServer())
+        .delete(`${endpoint}/${existingCourseId}/section/${sectionId}`)
+        .auth(superAdminToken, { type: 'bearer' })
+        .expect(HttpStatus.OK);
     });
   });
 });

--- a/src/module/section/application/dto/create.section.dto.ts
+++ b/src/module/section/application/dto/create.section.dto.ts
@@ -1,3 +1,7 @@
+import { OmitType } from '@nestjs/mapped-types';
+
 import { SectionDto } from '@module/section/application/dto/section.dto';
+
+export class CreateSectionDtoQuery extends OmitType(SectionDto, ['courseId']) {}
 
 export class CreateSectionDto extends SectionDto {}

--- a/src/module/section/application/dto/update.section.dto.ts
+++ b/src/module/section/application/dto/update.section.dto.ts
@@ -1,5 +1,9 @@
-import { PartialType } from '@nestjs/mapped-types';
+import { OmitType, PartialType } from '@nestjs/mapped-types';
 
 import { CreateSectionDto } from '@module/section/application/dto/create.section.dto';
 
-export class UpdateSectionDto extends PartialType(CreateSectionDto) {}
+export class UpdateSectionDto extends PartialType(
+  OmitType(CreateSectionDto, ['courseId']),
+) {
+  courseId?: string;
+}

--- a/src/module/section/application/policy/create-section-policy.handler.ts
+++ b/src/module/section/application/policy/create-section-policy.handler.ts
@@ -1,0 +1,57 @@
+import { ForbiddenException, Inject, Injectable } from '@nestjs/common';
+import { Request } from 'express';
+
+import {
+  COURSE_REPOSITORY_KEY,
+  ICourseRepository,
+} from '@module/course/application/repository/repository.interface';
+import { BasePolicyHandler } from '@module/iam/authorization/application/policy/base-policy.handler';
+import { AuthorizationService } from '@module/iam/authorization/application/service/authorization.service';
+import { AppRole } from '@module/iam/authorization/domain/app-role.enum';
+import { AppAction } from '@module/iam/authorization/domain/app.action.enum';
+import { IPolicyHandler } from '@module/iam/authorization/infrastructure/policy/handler/policy-handler.interface';
+import { PolicyHandlerStorage } from '@module/iam/authorization/infrastructure/policy/storage/policies-handler.storage';
+import { Section } from '@module/section/domain/section.entity';
+
+@Injectable()
+export class CreateSectionPolicyHandler
+  extends BasePolicyHandler
+  implements IPolicyHandler
+{
+  private readonly action = AppAction.Create;
+
+  constructor(
+    private readonly policyHandlerStorage: PolicyHandlerStorage,
+    private readonly authorizationService: AuthorizationService,
+    @Inject(COURSE_REPOSITORY_KEY)
+    private readonly courseRepository: ICourseRepository,
+  ) {
+    super();
+    this.policyHandlerStorage.add(CreateSectionPolicyHandler, this);
+  }
+
+  async handle(request: Request): Promise<void> {
+    const { courseId } = request.params;
+    const course = await this.courseRepository.getOneByIdOrFail(courseId);
+    const user = this.getCurrentUser(request);
+    const userIsSuperAdmin = user.roles.includes(AppRole.SuperAdmin);
+
+    if (course.instructorId !== user.id && !userIsSuperAdmin) {
+      throw new ForbiddenException(
+        `You are not allowed to ${this.action.toUpperCase()} this resource`,
+      );
+    }
+
+    const isAllowed = this.authorizationService.isAllowed(
+      user,
+      this.action,
+      Section,
+    );
+
+    if (!isAllowed) {
+      throw new ForbiddenException(
+        `You are not allowed to ${this.action.toUpperCase()} this resource`,
+      );
+    }
+  }
+}

--- a/src/module/section/application/policy/delete-section-policy.handler.ts
+++ b/src/module/section/application/policy/delete-section-policy.handler.ts
@@ -1,0 +1,60 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Inject,
+  Injectable,
+} from '@nestjs/common';
+import { Request } from 'express';
+
+import { BasePolicyHandler } from '@module/iam/authorization/application/policy/base-policy.handler';
+import { AuthorizationService } from '@module/iam/authorization/application/service/authorization.service';
+import { AppAction } from '@module/iam/authorization/domain/app.action.enum';
+import { IPolicyHandler } from '@module/iam/authorization/infrastructure/policy/handler/policy-handler.interface';
+import { PolicyHandlerStorage } from '@module/iam/authorization/infrastructure/policy/storage/policies-handler.storage';
+import {
+  ISectionRepository,
+  SECTION_REPOSITORY_KEY,
+} from '@module/section/application/repository/section.repository.interface';
+
+@Injectable()
+export class DeleteSectionPolicyHandler
+  extends BasePolicyHandler
+  implements IPolicyHandler
+{
+  private readonly action = AppAction.Delete;
+
+  constructor(
+    private readonly policyHandlerStorage: PolicyHandlerStorage,
+    private readonly authorizationService: AuthorizationService,
+    @Inject(SECTION_REPOSITORY_KEY)
+    private readonly sectionRepository: ISectionRepository,
+  ) {
+    super();
+    this.policyHandlerStorage.add(DeleteSectionPolicyHandler, this);
+  }
+
+  async handle(request: Request): Promise<void> {
+    const { courseId, id: sectionId } = request.params;
+    const section = await this.sectionRepository.getOneByIdOrFail(sectionId, [
+      'course',
+    ]);
+    if (section.courseId !== courseId) {
+      throw new BadRequestException(
+        `The section with id ${sectionId} does not belong to the course with id ${courseId}`,
+      );
+    }
+
+    const user = this.getCurrentUser(request);
+    const isAllowed = this.authorizationService.isAllowed(
+      user,
+      this.action,
+      section,
+    );
+
+    if (!isAllowed) {
+      throw new ForbiddenException(
+        `You are not allowed to ${this.action.toUpperCase()} this resource`,
+      );
+    }
+  }
+}

--- a/src/module/section/application/policy/update-section-policy.handler.ts
+++ b/src/module/section/application/policy/update-section-policy.handler.ts
@@ -1,0 +1,61 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Inject,
+  Injectable,
+} from '@nestjs/common';
+import { Request } from 'express';
+
+import { BasePolicyHandler } from '@module/iam/authorization/application/policy/base-policy.handler';
+import { AuthorizationService } from '@module/iam/authorization/application/service/authorization.service';
+import { AppAction } from '@module/iam/authorization/domain/app.action.enum';
+import { IPolicyHandler } from '@module/iam/authorization/infrastructure/policy/handler/policy-handler.interface';
+import { PolicyHandlerStorage } from '@module/iam/authorization/infrastructure/policy/storage/policies-handler.storage';
+import {
+  ISectionRepository,
+  SECTION_REPOSITORY_KEY,
+} from '@module/section/application/repository/section.repository.interface';
+
+@Injectable()
+export class UpdateSectionPolicyHandler
+  extends BasePolicyHandler
+  implements IPolicyHandler
+{
+  private readonly action = AppAction.Update;
+
+  constructor(
+    private readonly policyHandlerStorage: PolicyHandlerStorage,
+    private readonly authorizationService: AuthorizationService,
+    @Inject(SECTION_REPOSITORY_KEY)
+    private readonly sectionRepository: ISectionRepository,
+  ) {
+    super();
+    this.policyHandlerStorage.add(UpdateSectionPolicyHandler, this);
+  }
+
+  async handle(request: Request): Promise<void> {
+    const { courseId, id: sectionId } = request.params;
+    const section = await this.sectionRepository.getOneByIdOrFail(sectionId, [
+      'course',
+    ]);
+
+    if (section.courseId !== courseId) {
+      throw new BadRequestException(
+        `The section with id ${sectionId} does not belong to the course with id ${courseId}`,
+      );
+    }
+
+    const user = this.getCurrentUser(request);
+    const isAllowed = this.authorizationService.isAllowed(
+      user,
+      this.action,
+      section,
+    );
+
+    if (!isAllowed) {
+      throw new ForbiddenException(
+        `You are not allowed to ${this.action.toUpperCase()} this resource`,
+      );
+    }
+  }
+}

--- a/src/module/section/domain/section.entity.ts
+++ b/src/module/section/domain/section.entity.ts
@@ -9,6 +9,10 @@ export class Section extends Base {
   position: number;
   course?: Course;
 
+  get instructorId(): string | undefined {
+    return this.course?.instructorId;
+  }
+
   constructor(
     id: string,
     courseId: string,

--- a/src/module/section/domain/section.permissions.ts
+++ b/src/module/section/domain/section.permissions.ts
@@ -1,0 +1,16 @@
+import { AppRole } from '@module/iam/authorization/domain/app-role.enum';
+import { AppAction } from '@module/iam/authorization/domain/app.action.enum';
+import { IPermissionsDefinition } from '@module/iam/authorization/infrastructure/policy/type/permissions-definition.interface';
+import { Section } from '@module/section/domain/section.entity';
+
+export const sectionPermissions: IPermissionsDefinition = {
+  [AppRole.Regular](_, { cannot }) {
+    cannot(AppAction.Manage, Section);
+  },
+  [AppRole.Admin](user, { can }) {
+    can(AppAction.Manage, Section, { instructorId: user.id });
+  },
+  [AppRole.SuperAdmin](_, { can }) {
+    can(AppAction.Manage, Section);
+  },
+};

--- a/src/module/section/infrastructure/database/section.schema.ts
+++ b/src/module/section/infrastructure/database/section.schema.ts
@@ -26,7 +26,7 @@ export const SectionSchema = new EntitySchema<Section>({
     },
   }),
   relations: {
-    courseId: {
+    course: {
       type: 'many-to-one',
       target: 'Course',
       joinColumn: {

--- a/src/module/section/interface/section.controller.ts
+++ b/src/module/section/interface/section.controller.ts
@@ -16,7 +16,7 @@ import { SectionResponseDto } from '@module/section/application/dto/section.resp
 import { UpdateSectionDto } from '@module/section/application/dto/update.section.dto';
 import { SectionService } from '@module/section/application/service/section.service';
 
-import { CreateSectionDto } from '../application/dto/create.section.dto';
+import { CreateSectionDtoQuery } from '../application/dto/create.section.dto';
 
 @Controller('course/:courseId/section')
 export class SectionController {
@@ -35,8 +35,8 @@ export class SectionController {
       rel: 'delete-section',
     },
   ])
-  saveOneSection(
-    @Body() createSectionDto: Omit<CreateSectionDto, 'courseId'>,
+  saveOne(
+    @Body() createSectionDto: CreateSectionDtoQuery,
     @Param('courseId', ParseUUIDPipe) courseId: string,
   ): Promise<SectionResponseDto> {
     return this.sectionService.saveOne({ ...createSectionDto, courseId });

--- a/src/module/section/interface/section.controller.ts
+++ b/src/module/section/interface/section.controller.ts
@@ -18,6 +18,7 @@ import { PoliciesGuard } from '@module/iam/authorization/infrastructure/policy/g
 import { SectionResponseDto } from '@module/section/application/dto/section.response.dto';
 import { UpdateSectionDto } from '@module/section/application/dto/update.section.dto';
 import { CreateSectionPolicyHandler } from '@module/section/application/policy/create-section-policy.handler';
+import { UpdateSectionPolicyHandler } from '@module/section/application/policy/update-section-policy.handler';
 import { SectionService } from '@module/section/application/service/section.service';
 
 import { CreateSectionDtoQuery } from '../application/dto/create.section.dto';
@@ -49,6 +50,7 @@ export class SectionController {
   }
 
   @Patch(':id')
+  @Policies(UpdateSectionPolicyHandler)
   @Hypermedia([
     {
       method: HttpMethod.POST,

--- a/src/module/section/interface/section.controller.ts
+++ b/src/module/section/interface/section.controller.ts
@@ -6,23 +6,29 @@ import {
   ParseUUIDPipe,
   Patch,
   Post,
+  UseGuards,
 } from '@nestjs/common';
 
 import { Hypermedia } from '@common/base/application/decorator/hypermedia.decorator';
 import { SuccessOperationResponseDto } from '@common/base/application/dto/success-operation-response.dto';
 import { HttpMethod } from '@common/base/application/enum/http-method.enum';
 
+import { Policies } from '@module/iam/authorization/infrastructure/policy/decorator/policy.decorator';
+import { PoliciesGuard } from '@module/iam/authorization/infrastructure/policy/guard/policy.guard';
 import { SectionResponseDto } from '@module/section/application/dto/section.response.dto';
 import { UpdateSectionDto } from '@module/section/application/dto/update.section.dto';
+import { CreateSectionPolicyHandler } from '@module/section/application/policy/create-section-policy.handler';
 import { SectionService } from '@module/section/application/service/section.service';
 
 import { CreateSectionDtoQuery } from '../application/dto/create.section.dto';
 
 @Controller('course/:courseId/section')
+@UseGuards(PoliciesGuard)
 export class SectionController {
   constructor(private readonly sectionService: SectionService) {}
 
   @Post()
+  @Policies(CreateSectionPolicyHandler)
   @Hypermedia([
     {
       endpoint: '/course/:courseId/section/:id',

--- a/src/module/section/interface/section.controller.ts
+++ b/src/module/section/interface/section.controller.ts
@@ -18,6 +18,7 @@ import { PoliciesGuard } from '@module/iam/authorization/infrastructure/policy/g
 import { SectionResponseDto } from '@module/section/application/dto/section.response.dto';
 import { UpdateSectionDto } from '@module/section/application/dto/update.section.dto';
 import { CreateSectionPolicyHandler } from '@module/section/application/policy/create-section-policy.handler';
+import { DeleteSectionPolicyHandler } from '@module/section/application/policy/delete-section-policy.handler';
 import { UpdateSectionPolicyHandler } from '@module/section/application/policy/update-section-policy.handler';
 import { SectionService } from '@module/section/application/service/section.service';
 
@@ -71,6 +72,7 @@ export class SectionController {
   }
 
   @Delete(':id')
+  @Policies(DeleteSectionPolicyHandler)
   async deleteOneByIdOrFail(
     @Param('id', ParseUUIDPipe) id: string,
   ): Promise<SuccessOperationResponseDto> {

--- a/src/module/section/section.module.ts
+++ b/src/module/section/section.module.ts
@@ -1,8 +1,11 @@
 import { Module, OnModuleInit, Provider } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { CourseModule } from '@module/course/course.module';
+import { AuthorizationModule } from '@module/iam/authorization/authorization.module';
 import { AppSubjectPermissionStorage } from '@module/iam/authorization/infrastructure/casl/storage/app-subject-permissions-storage';
 import { SectionMapper } from '@module/section/application/mapper/section.mapper';
+import { CreateSectionPolicyHandler } from '@module/section/application/policy/create-section-policy.handler';
 import { SECTION_REPOSITORY_KEY } from '@module/section/application/repository/section.repository.interface';
 import { SectionService } from '@module/section/application/service/section.service';
 import { Section } from '@module/section/domain/section.entity';
@@ -15,9 +18,21 @@ export const sectionRepositoryProvider: Provider = {
   provide: SECTION_REPOSITORY_KEY,
   useClass: SectionPostgresRepository,
 };
+
+const policyHandlersProviders = [CreateSectionPolicyHandler];
+
 @Module({
-  imports: [TypeOrmModule.forFeature([SectionSchema])],
-  providers: [SectionService, sectionRepositoryProvider, SectionMapper],
+  imports: [
+    TypeOrmModule.forFeature([SectionSchema]),
+    AuthorizationModule.forFeature(),
+  ],
+  providers: [
+    CourseModule,
+    SectionService,
+    sectionRepositoryProvider,
+    SectionMapper,
+    ...policyHandlersProviders,
+  ],
   controllers: [SectionController],
   exports: [SectionService, sectionRepositoryProvider],
 })

--- a/src/module/section/section.module.ts
+++ b/src/module/section/section.module.ts
@@ -1,9 +1,12 @@
-import { Module, Provider } from '@nestjs/common';
+import { Module, OnModuleInit, Provider } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { AppSubjectPermissionStorage } from '@module/iam/authorization/infrastructure/casl/storage/app-subject-permissions-storage';
 import { SectionMapper } from '@module/section/application/mapper/section.mapper';
 import { SECTION_REPOSITORY_KEY } from '@module/section/application/repository/section.repository.interface';
 import { SectionService } from '@module/section/application/service/section.service';
+import { Section } from '@module/section/domain/section.entity';
+import { sectionPermissions } from '@module/section/domain/section.permissions';
 import { SectionPostgresRepository } from '@module/section/infrastructure/database/section.postgres.repository';
 import { SectionSchema } from '@module/section/infrastructure/database/section.schema';
 import { SectionController } from '@module/section/interface/section.controller';
@@ -18,4 +21,10 @@ export const sectionRepositoryProvider: Provider = {
   controllers: [SectionController],
   exports: [SectionService, sectionRepositoryProvider],
 })
-export class SectionModule {}
+export class SectionModule implements OnModuleInit {
+  constructor(private readonly registry: AppSubjectPermissionStorage) {}
+
+  onModuleInit(): void {
+    this.registry.set(Section, sectionPermissions);
+  }
+}

--- a/src/module/section/section.module.ts
+++ b/src/module/section/section.module.ts
@@ -31,6 +31,7 @@ const policyHandlersProviders = [
   imports: [
     TypeOrmModule.forFeature([SectionSchema]),
     AuthorizationModule.forFeature(),
+    CourseModule,
   ],
   providers: [
     CourseModule,

--- a/src/module/section/section.module.ts
+++ b/src/module/section/section.module.ts
@@ -6,6 +6,7 @@ import { AuthorizationModule } from '@module/iam/authorization/authorization.mod
 import { AppSubjectPermissionStorage } from '@module/iam/authorization/infrastructure/casl/storage/app-subject-permissions-storage';
 import { SectionMapper } from '@module/section/application/mapper/section.mapper';
 import { CreateSectionPolicyHandler } from '@module/section/application/policy/create-section-policy.handler';
+import { UpdateSectionPolicyHandler } from '@module/section/application/policy/update-section-policy.handler';
 import { SECTION_REPOSITORY_KEY } from '@module/section/application/repository/section.repository.interface';
 import { SectionService } from '@module/section/application/service/section.service';
 import { Section } from '@module/section/domain/section.entity';
@@ -19,7 +20,10 @@ export const sectionRepositoryProvider: Provider = {
   useClass: SectionPostgresRepository,
 };
 
-const policyHandlersProviders = [CreateSectionPolicyHandler];
+const policyHandlersProviders = [
+  CreateSectionPolicyHandler,
+  UpdateSectionPolicyHandler,
+];
 
 @Module({
   imports: [

--- a/src/module/section/section.module.ts
+++ b/src/module/section/section.module.ts
@@ -6,6 +6,7 @@ import { AuthorizationModule } from '@module/iam/authorization/authorization.mod
 import { AppSubjectPermissionStorage } from '@module/iam/authorization/infrastructure/casl/storage/app-subject-permissions-storage';
 import { SectionMapper } from '@module/section/application/mapper/section.mapper';
 import { CreateSectionPolicyHandler } from '@module/section/application/policy/create-section-policy.handler';
+import { DeleteSectionPolicyHandler } from '@module/section/application/policy/delete-section-policy.handler';
 import { UpdateSectionPolicyHandler } from '@module/section/application/policy/update-section-policy.handler';
 import { SECTION_REPOSITORY_KEY } from '@module/section/application/repository/section.repository.interface';
 import { SectionService } from '@module/section/application/service/section.service';
@@ -23,6 +24,7 @@ export const sectionRepositoryProvider: Provider = {
 const policyHandlersProviders = [
   CreateSectionPolicyHandler,
   UpdateSectionPolicyHandler,
+  DeleteSectionPolicyHandler,
 ];
 
 @Module({


### PR DESCRIPTION
# Summary

This PR introduces section policies for `Create`, `Update` and `Delete` actions.

# Details

- Defined the `sectionPermissions` for `regular`, `admin` and `superAdmin` users.
- Updated the `Create` and `Update` Section Dto to omit IDs from request.
- Added the `instructorId` property to `Section` entity to be able to validate the user's request.
- Created the `Create`, `Update` and `Delete` policy handlers for handling `saveOne`, `updateOne` and `deleteOne` requests authorization.
- Updated the Section tests to verify authorization based on the user roles of the request.