### PR TITLE
feat: Add lesson module with CRUD endpoints

### DIFF
--- a/data/migrations/1750184837874-addLessonTable.ts
+++ b/data/migrations/1750184837874-addLessonTable.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddLessonTable1750184837874 implements MigrationInterface {
+    name = 'AddLessonTable1750184837874'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "lesson" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "course_id" uuid NOT NULL, "section_id" uuid NOT NULL, "title" character varying, "description" text, "url" character varying, "lesson_type" character varying, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), "deleted_at" TIMESTAMP, CONSTRAINT "PK_0ef25918f0237e68696dee455bd" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`ALTER TABLE "lesson" ADD CONSTRAINT "FK_a83099885c0ef3112edb9e12fd6" FOREIGN KEY ("section_id") REFERENCES "section"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "lesson" DROP CONSTRAINT "FK_a83099885c0ef3112edb9e12fd6"`);
+        await queryRunner.query(`DROP TABLE "lesson"`);
+    }
+
+}

--- a/src/module/app.module.ts
+++ b/src/module/app.module.ts
@@ -10,6 +10,7 @@ import { SlugService } from '@module/app/application/service/slug.service';
 import { CloudModule } from '@module/cloud/cloud.module';
 import { CourseModule } from '@module/course/course.module';
 import { IamModule } from '@module/iam/iam.module';
+import { LessonModule } from '@module/lesson/lesson.module';
 import { SectionModule } from '@module/section/section.module';
 
 @Global()
@@ -29,6 +30,7 @@ import { SectionModule } from '@module/section/section.module';
     IamModule,
     CourseModule,
     SectionModule,
+    LessonModule,
   ],
   providers: [LinkBuilderService, SlugService],
   exports: [LinkBuilderService, SlugService],

--- a/src/module/cloud/application/constants/image-storage-folders.constants.ts
+++ b/src/module/cloud/application/constants/image-storage-folders.constants.ts
@@ -1,2 +1,4 @@
 export const AVATARS_FOLDER = 'avatars';
-export const COURSES_IMAGES_FOLDER = 'courses/images';
+export const COURSES_FOLDER = 'courses';
+export const SECTION_FOLDER = 'sections';
+export const COURSES_IMAGES_FOLDER = `${COURSES_FOLDER}/images`;

--- a/src/module/lesson/__test__/fixture/Course.yml
+++ b/src/module/lesson/__test__/fixture/Course.yml
@@ -1,0 +1,22 @@
+entity: Course
+items:
+  course1:
+    id: 'c62801a2-0d74-4dd7-a20c-11c25be00a2a'
+    title: 'Introduction to Programming'
+    description: 'Learn the basics of programming with JavaScript'
+    price: 49.99
+    imageUrl: '{{internet.url}}/intro-programming.jpg'
+    status: published
+    slug: 'introduction-to-programming'
+    difficulty: beginner
+    instructor: '@admin-user'
+  course2:
+    id: 'b894ad66-ea0a-4ed3-822b-fea66d3a9e49'
+    title: 'Introduction to Ruby'
+    description: 'Learn the basics of programming with Ruby'
+    price: 49.99
+    imageUrl: '{{internet.url}}/intro-programming.jpg'
+    status: published
+    slug: 'introduction-to-ruby'
+    difficulty: beginner
+    instructor: '@admin-user-2'

--- a/src/module/lesson/__test__/fixture/Section.yml
+++ b/src/module/lesson/__test__/fixture/Section.yml
@@ -1,0 +1,20 @@
+entity: Section
+items:
+  section1:
+    id: '31487427-8f89-4e65-bd09-fb84ab56775b'
+    title: 'Section 1'
+    description: 'Description 1'
+    position: 0
+    course: '@course1'
+  section2:
+    id: 'e231901b-57a6-47c0-b84d-d58ce150a315'
+    title: 'Section 2'
+    description: 'Description 2'
+    position: 1
+    course: '@course1'
+  section3:
+    id: '10950e31-025b-4328-b0c1-e3d7062e5fae'
+    title: 'Section 3'
+    description: 'Description 3'
+    position: 0
+    course: '@course2'

--- a/src/module/lesson/__test__/fixture/User.yml
+++ b/src/module/lesson/__test__/fixture/User.yml
@@ -1,0 +1,32 @@
+entity: User
+items:
+  super-admin-user:
+    firstName: super-admin-name
+    lastName: super-admin-surname
+    email: 'test_super_admin@email.co'
+    avatarUrl: '{{internet.url}}'
+    externalId: '00000000-0000-0000-0000-00000000000X'
+    roles: regular,admin,superAdmin
+  admin-user:
+    id: a90108bf-42c6-481f-a63f-4b51fed1300c
+    firstName: admin-name
+    lastName: admin-surname
+    email: 'test_admin@email.co'
+    avatarUrl: '{{internet.url}}'
+    externalId: '00000000-0000-0000-0000-00000000000Y'
+    roles: regular,admin
+  admin-user-2:
+    id: 9f5e3ef6-b0f5-4795-ab7b-7cf35f9c41e8
+    firstName: second-admin-name
+    lastName: second-admin-surname
+    email: 'second_test_admin@email.co'
+    avatarUrl: '{{internet.url}}'
+    externalId: '00000000-0000-0000-0000-00000000000W'
+    roles: regular,admin
+  regular-user:
+    firstName: regular-name
+    lastName: regular-surname
+    email: 'test_regular@email.co'
+    avatarUrl: '{{internet.url}}'
+    externalId: '00000000-0000-0000-0000-00000000000Z'
+    roles: regular

--- a/src/module/lesson/__test__/lesson.e2e.spec.ts
+++ b/src/module/lesson/__test__/lesson.e2e.spec.ts
@@ -1,0 +1,453 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { HttpStatus } from '@nestjs/common';
+import { NestExpressApplication } from '@nestjs/platform-express';
+import path from 'path';
+import request from 'supertest';
+
+import { loadFixtures } from '@data/util/fixture-loader';
+
+import { SerializedResponseDto } from '@common/base/application/dto/serialized-response.dto';
+import { HttpMethod } from '@common/base/application/enum/http-method.enum';
+
+import { setupApp } from '@config/app.config';
+import { datasourceOptions } from '@config/orm.config';
+
+import { testModuleBootstrapper } from '@test/test.module.bootstrapper';
+import { createAccessToken } from '@test/test.util';
+
+import { CreateLessonDto } from '@module/lesson/application/dto/create-lesson.dto';
+import { LessonResponseDto } from '@module/lesson/application/dto/lesson-response.dto';
+import { UpdateLessonDto } from '@module/lesson/application/dto/update-lesson.dto';
+
+describe('Lesson Module', () => {
+  let app: NestExpressApplication;
+
+  const adminToken = createAccessToken({
+    sub: '00000000-0000-0000-0000-00000000000Y',
+  });
+
+  const fileMock = path.resolve(
+    __dirname,
+    '../../../test/__mocks__/avatar.jpg',
+  );
+
+  beforeAll(async () => {
+    await loadFixtures(`${__dirname}/fixture`, datasourceOptions);
+    const moduleRef = await testModuleBootstrapper();
+    app = moduleRef.createNestApplication({ logger: false });
+    setupApp(app);
+    await app.init();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  const endpoint = '/api/v1/course';
+  const existingIds = {
+    course: {
+      first: 'c62801a2-0d74-4dd7-a20c-11c25be00a2a',
+      second: 'b894ad66-ea0a-4ed3-822b-fea66d3a9e49',
+    },
+    section: {
+      first: '31487427-8f89-4e65-bd09-fb84ab56775b',
+      second: 'e231901b-57a6-47c0-b84d-d58ce150a315',
+      third: '10950e31-025b-4328-b0c1-e3d7062e5fae',
+    },
+  };
+
+  describe('GET - /course/:courseId/section/:sectionId/lesson/:id', () => {
+    it('Should get a lesson by id', async () => {
+      const createLessonDto = {
+        title: 'Lesson 1',
+        description: 'Description 1',
+      } as CreateLessonDto;
+      let lessonId: string;
+
+      await request(app.getHttpServer())
+        .post(
+          `${endpoint}/${existingIds.course.first}/section/${existingIds.section.first}/lesson`,
+        )
+        .auth(adminToken, { type: 'bearer' })
+        .field('title', createLessonDto.title)
+        .field('description', createLessonDto.description)
+        .attach('file', fileMock)
+        .expect(HttpStatus.CREATED)
+        .then(
+          ({ body }: { body: SerializedResponseDto<LessonResponseDto> }) => {
+            lessonId = body.data.id;
+
+            const expectedResponse = expect.objectContaining({
+              data: expect.objectContaining({
+                type: 'lesson',
+                id: expect.any(String),
+                attributes: expect.objectContaining({
+                  courseId: existingIds.course.first,
+                  sectionId: existingIds.section.first,
+                  title: createLessonDto.title,
+                  description: createLessonDto.description,
+                  url: 'test-url',
+                }),
+              }),
+              links: expect.arrayContaining([
+                expect.objectContaining({
+                  href: expect.stringContaining(
+                    `${endpoint}/${existingIds.course.first}/section/${existingIds.section.first}/lesson`,
+                  ),
+                  rel: 'self',
+                  method: HttpMethod.POST,
+                }),
+              ]),
+            });
+
+            expect(body).toEqual(expectedResponse);
+          },
+        );
+
+      return await request(app.getHttpServer())
+        .get(
+          `${endpoint}/${existingIds.course.first}/section/${existingIds.section.first}/lesson/${lessonId}`,
+        )
+        .auth(adminToken, { type: 'bearer' })
+        .expect(HttpStatus.OK)
+        .then(
+          ({ body }: { body: SerializedResponseDto<LessonResponseDto> }) => {
+            const expectedResponse = expect.objectContaining({
+              data: expect.objectContaining({
+                type: 'lesson',
+                id: expect.any(String),
+                attributes: expect.objectContaining({
+                  courseId: existingIds.course.first,
+                  sectionId: existingIds.section.first,
+                  title: createLessonDto.title,
+                  description: createLessonDto.description,
+                  url: 'test-url',
+                }),
+              }),
+              links: expect.arrayContaining([
+                expect.objectContaining({
+                  href: expect.stringContaining(
+                    `${endpoint}/${existingIds.course.first}/section/${existingIds.section.first}/lesson`,
+                  ),
+                  rel: 'self',
+                  method: HttpMethod.GET,
+                }),
+              ]),
+            });
+
+            expect(body).toEqual(expectedResponse);
+          },
+        );
+    });
+
+    it('Should throw an error if the lesson does not exist', async () => {
+      const nonExistingId = '1cfdc342-2a53-4fe7-9e23-31d51b526cd8';
+
+      return await request(app.getHttpServer())
+        .get(
+          `${endpoint}/${existingIds.course.first}/section/${existingIds.section.first}/lesson/${nonExistingId}`,
+        )
+        .auth(adminToken, { type: 'bearer' })
+        .expect(HttpStatus.NOT_FOUND)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `Entity with id ${nonExistingId} not found`,
+              source: {
+                pointer: `${endpoint}/${existingIds.course.first}/section/${existingIds.section.first}/lesson/${nonExistingId}`,
+              },
+              status: HttpStatus.NOT_FOUND.toString(),
+              title: 'Entity not found',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+  });
+
+  describe('POST - /course/:courseId/section/:sectionId/lesson', () => {
+    it('Should create a lesson', async () => {
+      const createLessonDto = {
+        title: 'Lesson 1',
+        description: 'Description 1',
+      } as CreateLessonDto;
+
+      return await request(app.getHttpServer())
+        .post(
+          `${endpoint}/${existingIds.course.first}/section/${existingIds.section.first}/lesson`,
+        )
+        .auth(adminToken, { type: 'bearer' })
+        .field('title', createLessonDto.title)
+        .field('description', createLessonDto.description)
+        .attach('file', fileMock)
+        .expect(HttpStatus.CREATED)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            data: expect.objectContaining({
+              type: 'lesson',
+              id: expect.any(String),
+              attributes: expect.objectContaining({
+                courseId: existingIds.course.first,
+                sectionId: existingIds.section.first,
+                title: createLessonDto.title,
+                description: createLessonDto.description,
+                url: 'test-url',
+              }),
+            }),
+            links: expect.arrayContaining([
+              expect.objectContaining({
+                href: expect.stringContaining(
+                  `${endpoint}/${existingIds.course.first}/section/${existingIds.section.first}/lesson`,
+                ),
+                rel: 'self',
+                method: HttpMethod.POST,
+              }),
+            ]),
+          });
+
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+  });
+
+  describe('PATCH - /course/:courseId/section/:sectionId/lesson/:id', () => {
+    it('Should update a lesson', async () => {
+      const createLessonDto = {
+        title: 'Lesson 1',
+        description: 'Description 1',
+      } as CreateLessonDto;
+      const updateLessonDto = {
+        title: 'Edited',
+      } as UpdateLessonDto;
+      let lessonId: string;
+
+      await request(app.getHttpServer())
+        .post(
+          `${endpoint}/${existingIds.course.first}/section/${existingIds.section.first}/lesson`,
+        )
+        .auth(adminToken, { type: 'bearer' })
+        .field('title', createLessonDto.title)
+        .field('description', createLessonDto.description)
+        .attach('file', fileMock)
+        .expect(HttpStatus.CREATED)
+        .then(
+          ({ body }: { body: SerializedResponseDto<LessonResponseDto> }) => {
+            lessonId = body.data.id;
+
+            const expectedResponse = expect.objectContaining({
+              data: expect.objectContaining({
+                type: 'lesson',
+                id: expect.any(String),
+                attributes: expect.objectContaining({
+                  courseId: existingIds.course.first,
+                  sectionId: existingIds.section.first,
+                  title: createLessonDto.title,
+                  description: createLessonDto.description,
+                  url: 'test-url',
+                }),
+              }),
+              links: expect.arrayContaining([
+                expect.objectContaining({
+                  href: expect.stringContaining(
+                    `${endpoint}/${existingIds.course.first}/section/${existingIds.section.first}/lesson`,
+                  ),
+                  rel: 'self',
+                  method: HttpMethod.POST,
+                }),
+              ]),
+            });
+
+            expect(body).toEqual(expectedResponse);
+          },
+        );
+
+      return await request(app.getHttpServer())
+        .patch(
+          `${endpoint}/${existingIds.course.first}/section/${existingIds.section.first}/lesson/${lessonId}`,
+        )
+        .send(updateLessonDto)
+        .auth(adminToken, { type: 'bearer' })
+        .expect(HttpStatus.OK)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            data: expect.objectContaining({
+              type: 'lesson',
+              id: expect.any(String),
+              attributes: expect.objectContaining({
+                courseId: existingIds.course.first,
+                sectionId: existingIds.section.first,
+                title: updateLessonDto.title,
+                description: createLessonDto.description,
+                url: 'test-url',
+              }),
+            }),
+            links: expect.arrayContaining([
+              expect.objectContaining({
+                href: expect.stringContaining(
+                  `${endpoint}/${existingIds.course.first}/section/${existingIds.section.first}/lesson`,
+                ),
+                rel: 'self',
+                method: HttpMethod.PATCH,
+              }),
+            ]),
+          });
+
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should throw an error if the lesson does not exist', async () => {
+      const nonExistingId = '1cfdc342-2a53-4fe7-9e23-31d51b526cd8';
+      const updateLessonDto = {
+        title: 'Edited',
+      } as UpdateLessonDto;
+
+      return await request(app.getHttpServer())
+        .patch(
+          `${endpoint}/${existingIds.course.first}/section/${existingIds.section.first}/lesson/${nonExistingId}`,
+        )
+        .send(updateLessonDto)
+        .auth(adminToken, { type: 'bearer' })
+        .expect(HttpStatus.NOT_FOUND)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `Entity with id ${nonExistingId} not found`,
+              source: {
+                pointer: `${endpoint}/${existingIds.course.first}/section/${existingIds.section.first}/lesson/${nonExistingId}`,
+              },
+              status: HttpStatus.NOT_FOUND.toString(),
+              title: 'Entity not found',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+  });
+
+  describe('DELETE - /course/:courseId/section/:sectionId/lesson/:id', () => {
+    it('Should delete a lesson', async () => {
+      const createLessonDto = {
+        title: 'Lesson 1',
+        description: 'Description 1',
+      } as CreateLessonDto;
+      let lessonId: string;
+
+      await request(app.getHttpServer())
+        .post(
+          `${endpoint}/${existingIds.course.first}/section/${existingIds.section.first}/lesson`,
+        )
+        .auth(adminToken, { type: 'bearer' })
+        .field('title', createLessonDto.title)
+        .field('description', createLessonDto.description)
+        .attach('file', fileMock)
+        .expect(HttpStatus.CREATED)
+        .then(
+          ({ body }: { body: SerializedResponseDto<LessonResponseDto> }) => {
+            lessonId = body.data.id;
+
+            const expectedResponse = expect.objectContaining({
+              data: expect.objectContaining({
+                type: 'lesson',
+                id: expect.any(String),
+                attributes: expect.objectContaining({
+                  courseId: existingIds.course.first,
+                  sectionId: existingIds.section.first,
+                  title: createLessonDto.title,
+                  description: createLessonDto.description,
+                  url: 'test-url',
+                }),
+              }),
+              links: expect.arrayContaining([
+                expect.objectContaining({
+                  href: expect.stringContaining(
+                    `${endpoint}/${existingIds.course.first}/section/${existingIds.section.first}/lesson`,
+                  ),
+                  rel: 'self',
+                  method: HttpMethod.POST,
+                }),
+              ]),
+            });
+
+            expect(body).toEqual(expectedResponse);
+          },
+        );
+
+      await request(app.getHttpServer())
+        .delete(
+          `${endpoint}/${existingIds.course.first}/section/${existingIds.section.first}/lesson/${lessonId}`,
+        )
+        .auth(adminToken, { type: 'bearer' })
+        .expect(HttpStatus.OK)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            data: expect.objectContaining({
+              type: 'operation',
+              attributes: expect.objectContaining({
+                message: `The lesson with id ${lessonId} has been deleted successfully`,
+                success: true,
+              }),
+            }),
+            links: expect.arrayContaining([
+              expect.objectContaining({
+                href: expect.stringContaining(
+                  `${endpoint}/${existingIds.course.first}/section/${existingIds.section.first}/lesson/${lessonId}`,
+                ),
+                rel: 'self',
+                method: HttpMethod.DELETE,
+              }),
+            ]),
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+
+      await request(app.getHttpServer())
+        .get(
+          `${endpoint}/${existingIds.course.first}/section/${existingIds.section.first}/lesson/${lessonId}`,
+        )
+        .auth(adminToken, { type: 'bearer' })
+        .expect(HttpStatus.NOT_FOUND)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `Entity with id ${lessonId} not found`,
+              source: {
+                pointer: `${endpoint}/${existingIds.course.first}/section/${existingIds.section.first}/lesson/${lessonId}`,
+              },
+              status: HttpStatus.NOT_FOUND.toString(),
+              title: 'Entity not found',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should throw an error if the lesson does not exist', async () => {
+      const nonExistingId = '1cfdc342-2a53-4fe7-9e23-31d51b526cd8';
+
+      return await request(app.getHttpServer())
+        .delete(
+          `${endpoint}/${existingIds.course.first}/section/${existingIds.section.first}/lesson/${nonExistingId}`,
+        )
+        .auth(adminToken, { type: 'bearer' })
+        .expect(HttpStatus.NOT_FOUND)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `Entity with id ${nonExistingId} not found`,
+              source: {
+                pointer: `${endpoint}/${existingIds.course.first}/section/${existingIds.section.first}/lesson/${nonExistingId}`,
+              },
+              status: HttpStatus.NOT_FOUND.toString(),
+              title: 'Entity not found',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+  });
+});

--- a/src/module/lesson/application/dto/create-lesson.dto.ts
+++ b/src/module/lesson/application/dto/create-lesson.dto.ts
@@ -1,0 +1,10 @@
+import { OmitType } from '@nestjs/mapped-types';
+
+import { LessonDto } from '@module/lesson/application/dto/lesson.dto';
+
+export class CreateLessonDtoQuery extends OmitType(LessonDto, [
+  'courseId',
+  'sectionId',
+]) {}
+
+export class CreateLessonDto extends LessonDto {}

--- a/src/module/lesson/application/dto/lesson-response.dto.ts
+++ b/src/module/lesson/application/dto/lesson-response.dto.ts
@@ -1,0 +1,37 @@
+import { BaseResponseDto } from '@common/base/application/dto/base.response.dto';
+
+import { LessonType } from '@module/lesson/domain/lesson.type';
+import { Section } from '@module/section/domain/section.entity';
+
+export class LessonResponseDto extends BaseResponseDto {
+  courseId: string;
+  sectionId: string;
+  title?: string;
+  description?: string;
+  url?: string;
+  lessonType?: LessonType;
+  section?: Section;
+
+  constructor(
+    type: string,
+    courseId: string,
+    sectionId: string,
+    title?: string,
+    description?: string,
+    url?: string,
+    lessonType?: LessonType,
+    id?: string,
+    section?: Section,
+  ) {
+    super(type, id);
+
+    this.courseId = courseId;
+    this.sectionId = sectionId;
+    this.title = title;
+    this.description = description;
+    this.url = url;
+    this.lessonType = lessonType;
+    this.type = type;
+    this.section = section;
+  }
+}

--- a/src/module/lesson/application/dto/lesson.dto.ts
+++ b/src/module/lesson/application/dto/lesson.dto.ts
@@ -1,0 +1,41 @@
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUUID,
+  IsUrl,
+} from 'class-validator';
+
+import { BaseDto } from '@common/base/application/dto/base.dto';
+
+import { LessonType } from '@module/lesson/domain/lesson.type';
+import { Section } from '@module/section/domain/section.entity';
+
+export class LessonDto extends BaseDto {
+  @IsNotEmpty()
+  @IsUUID('4')
+  courseId: string;
+
+  @IsNotEmpty()
+  @IsUUID('4')
+  sectionId: string;
+
+  @IsOptional()
+  @IsString()
+  title?: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsOptional()
+  @IsUrl()
+  url?: string;
+
+  @IsOptional()
+  @IsEnum(LessonType)
+  lessonType?: LessonType;
+
+  section?: Section;
+}

--- a/src/module/lesson/application/dto/update-lesson.dto.ts
+++ b/src/module/lesson/application/dto/update-lesson.dto.ts
@@ -1,0 +1,10 @@
+import { OmitType, PartialType } from '@nestjs/mapped-types';
+
+import { CreateLessonDto } from '@module/lesson/application/dto/create-lesson.dto';
+
+export class UpdateLessonDto extends PartialType(
+  OmitType(CreateLessonDto, ['courseId', 'sectionId']),
+) {
+  courseId?: string;
+  sectionId?: string;
+}

--- a/src/module/lesson/application/mapper/lesson.mapper.ts
+++ b/src/module/lesson/application/mapper/lesson.mapper.ts
@@ -1,0 +1,49 @@
+import { IDtoMapper } from '@common/base/application/dto/dto.interface';
+
+import { CreateLessonDto } from '@module/lesson/application/dto/create-lesson.dto';
+import { LessonResponseDto } from '@module/lesson/application/dto/lesson-response.dto';
+import { UpdateLessonDto } from '@module/lesson/application/dto/update-lesson.dto';
+import { Lesson } from '@module/lesson/domain/lesson.entity';
+
+export class LessonMapper
+  implements
+    IDtoMapper<Lesson, CreateLessonDto, UpdateLessonDto, LessonResponseDto>
+{
+  fromCreateDtoToEntity(dto: CreateLessonDto): Lesson {
+    return new Lesson(
+      dto.id,
+      dto.courseId,
+      dto.sectionId,
+      dto.title,
+      dto.description,
+      dto.url,
+      dto.lessonType,
+    );
+  }
+
+  fromUpdateDtoToEntity(dto: UpdateLessonDto): Lesson {
+    return new Lesson(
+      dto.id,
+      dto.courseId,
+      dto.sectionId,
+      dto.title,
+      dto.description,
+      dto.url,
+      dto.lessonType,
+    );
+  }
+
+  fromEntityToResponseDto(entity: Lesson): LessonResponseDto {
+    return new LessonResponseDto(
+      Lesson.getEntityName(),
+      entity.courseId,
+      entity.sectionId,
+      entity.title,
+      entity.description,
+      entity.url,
+      entity.lessonType,
+      entity.id,
+      entity.section,
+    );
+  }
+}

--- a/src/module/lesson/application/repository/lesson.repository.interface.ts
+++ b/src/module/lesson/application/repository/lesson.repository.interface.ts
@@ -1,0 +1,8 @@
+import BaseRepository from '@common/base/infrastructure/database/base.repository';
+
+import { Lesson } from '@module/lesson/domain/lesson.entity';
+
+export const LESSON_REPOSITORY_KEY = 'lesson_repository';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface ILessonRepository extends BaseRepository<Lesson> {}

--- a/src/module/lesson/application/service/lesson.service.ts
+++ b/src/module/lesson/application/service/lesson.service.ts
@@ -1,0 +1,73 @@
+import { Inject, Injectable } from '@nestjs/common';
+
+import { BaseCRUDService } from '@common/base/application/service/base-crud.service';
+
+import {
+  COURSES_FOLDER,
+  SECTION_FOLDER,
+} from '@module/cloud/application/constants/image-storage-folders.constants';
+import { ImageStorageService } from '@module/cloud/application/service/image-storage.service';
+import { CreateLessonDto } from '@module/lesson/application/dto/create-lesson.dto';
+import { LessonResponseDto } from '@module/lesson/application/dto/lesson-response.dto';
+import { UpdateLessonDto } from '@module/lesson/application/dto/update-lesson.dto';
+import { LessonMapper } from '@module/lesson/application/mapper/lesson.mapper';
+import {
+  ILessonRepository,
+  LESSON_REPOSITORY_KEY,
+} from '@module/lesson/application/repository/lesson.repository.interface';
+import { Lesson } from '@module/lesson/domain/lesson.entity';
+
+@Injectable()
+export class LessonService extends BaseCRUDService<
+  Lesson,
+  CreateLessonDto,
+  UpdateLessonDto,
+  LessonResponseDto
+> {
+  constructor(
+    @Inject(LESSON_REPOSITORY_KEY) lessonRepository: ILessonRepository,
+    private readonly lessonMapper: LessonMapper,
+    private readonly imageStorageService: ImageStorageService,
+  ) {
+    super(lessonRepository, lessonMapper, Lesson.getEntityName());
+  }
+
+  private COURSE_STORAGE_FOLDER = COURSES_FOLDER;
+  private SECTION_STORAGE_FOLDER = SECTION_FOLDER;
+
+  async saveOne(
+    createLessonDto: CreateLessonDto,
+    lessonFile?: Express.Multer.File,
+  ): Promise<LessonResponseDto> {
+    const { sectionId, courseId } = createLessonDto;
+    createLessonDto.url = lessonFile
+      ? await this.imageStorageService.uploadImage(
+          lessonFile,
+          this.buildFileFolder(courseId, sectionId),
+        )
+      : null;
+
+    return super.saveOne(createLessonDto);
+  }
+
+  async updateOne(
+    id: string,
+    UpdateLessonDto: UpdateLessonDto,
+    lessonFile?: Express.Multer.File,
+  ): Promise<LessonResponseDto> {
+    const { courseId, sectionId } = UpdateLessonDto;
+
+    if (lessonFile) {
+      UpdateLessonDto.url = await this.imageStorageService.uploadImage(
+        lessonFile,
+        this.buildFileFolder(courseId, sectionId),
+      );
+    }
+
+    return super.updateOne(id, UpdateLessonDto);
+  }
+
+  private buildFileFolder(courseId: string, sectionId: string): string {
+    return `${this.COURSE_STORAGE_FOLDER}/${courseId}/${this.SECTION_STORAGE_FOLDER}/${sectionId}`;
+  }
+}

--- a/src/module/lesson/domain/lesson.entity.ts
+++ b/src/module/lesson/domain/lesson.entity.ts
@@ -1,0 +1,36 @@
+import { Base } from '@common/base/domain/base.entity';
+
+import { LessonType } from '@module/lesson/domain/lesson.type';
+import { Section } from '@module/section/domain/section.entity';
+
+export class Lesson extends Base {
+  courseId: string;
+  sectionId: string;
+  title?: string;
+  description?: string;
+  url?: string;
+  section?: Section;
+  lessonType?: LessonType;
+
+  get instructorId(): string | undefined {
+    return this.section?.instructorId;
+  }
+
+  constructor(
+    id: string,
+    courseId: string,
+    sectionId: string,
+    title?: string,
+    description?: string,
+    url?: string,
+    lessonType?: LessonType,
+  ) {
+    super(id);
+    this.courseId = courseId;
+    this.sectionId = sectionId;
+    this.title = title;
+    this.description = description;
+    this.url = url;
+    this.lessonType = lessonType;
+  }
+}

--- a/src/module/lesson/domain/lesson.type.ts
+++ b/src/module/lesson/domain/lesson.type.ts
@@ -1,0 +1,4 @@
+export enum LessonType {
+  PDF = 'pdf',
+  VIDEO = 'video',
+}

--- a/src/module/lesson/infrastructure/database/lesson.postgres.repository.ts
+++ b/src/module/lesson/infrastructure/database/lesson.postgres.repository.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import BaseRepository from '@common/base/infrastructure/database/base.repository';
+
+import { ILessonRepository } from '@module/lesson/application/repository/lesson.repository.interface';
+import { Lesson } from '@module/lesson/domain/lesson.entity';
+import { LessonSchema } from '@module/lesson/infrastructure/database/lesson.schema';
+
+@Injectable()
+export class LessonPostgresRepository
+  extends BaseRepository<Lesson>
+  implements ILessonRepository
+{
+  constructor(@InjectRepository(LessonSchema) repository: Repository<Lesson>) {
+    super(repository);
+  }
+}

--- a/src/module/lesson/infrastructure/database/lesson.schema.ts
+++ b/src/module/lesson/infrastructure/database/lesson.schema.ts
@@ -1,0 +1,45 @@
+import { EntitySchema } from 'typeorm';
+
+import { withBaseSchemaColumns } from '@common/base/infrastructure/database/base.schema';
+
+import { Lesson } from '@module/lesson/domain/lesson.entity';
+
+export const LessonSchema = new EntitySchema<Lesson>({
+  name: 'Lesson',
+  target: Lesson,
+  tableName: 'lesson',
+  columns: withBaseSchemaColumns({
+    courseId: {
+      type: 'uuid',
+    },
+    sectionId: {
+      type: 'uuid',
+    },
+    title: {
+      type: String,
+      nullable: true,
+    },
+    description: {
+      type: 'text',
+      nullable: true,
+    },
+    url: {
+      type: String,
+      nullable: true,
+    },
+    lessonType: {
+      type: String,
+      nullable: true,
+    },
+  }),
+  relations: {
+    section: {
+      type: 'many-to-one',
+      target: 'Section',
+      joinColumn: {
+        name: 'section_id',
+      },
+      inverseSide: 'lessons',
+    },
+  },
+});

--- a/src/module/lesson/interface/lesson.controller.ts
+++ b/src/module/lesson/interface/lesson.controller.ts
@@ -1,0 +1,68 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  UploadedFile,
+  UseInterceptors,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+
+import { SuccessOperationResponseDto } from '@common/base/application/dto/success-operation-response.dto';
+
+import { CreateLessonDtoQuery } from '@module/lesson/application/dto/create-lesson.dto';
+import { LessonResponseDto } from '@module/lesson/application/dto/lesson-response.dto';
+import { UpdateLessonDto } from '@module/lesson/application/dto/update-lesson.dto';
+import { LessonService } from '@module/lesson/application/service/lesson.service';
+
+@Controller('course/:courseId/section/:sectionId/lesson')
+@UseInterceptors(FileInterceptor('file'))
+export class LessonController {
+  constructor(private readonly lessonService: LessonService) {}
+
+  @Get(':id')
+  async getOne(
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<LessonResponseDto> {
+    return await this.lessonService.getOneByIdOrFail(id);
+  }
+
+  @Post()
+  async saveOne(
+    @Body() createLessonDto: CreateLessonDtoQuery,
+    @Param('sectionId', ParseUUIDPipe) sectionId: string,
+    @Param('courseId', ParseUUIDPipe) courseId: string,
+    @UploadedFile() file?: Express.Multer.File,
+  ): Promise<LessonResponseDto> {
+    return await this.lessonService.saveOne(
+      { ...createLessonDto, courseId, sectionId },
+      file,
+    );
+  }
+
+  @Patch(':id')
+  async updateOne(
+    @Body() updateLessonDto: UpdateLessonDto,
+    @Param('sectionId', ParseUUIDPipe) sectionId: string,
+    @Param('courseId', ParseUUIDPipe) courseId: string,
+    @Param('id', ParseUUIDPipe) id: string,
+    @UploadedFile() file?: Express.Multer.File,
+  ): Promise<LessonResponseDto> {
+    return await this.lessonService.updateOne(
+      id,
+      { ...updateLessonDto, courseId, sectionId },
+      file,
+    );
+  }
+
+  @Delete(':id')
+  async deleteOne(
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<SuccessOperationResponseDto> {
+    return await this.lessonService.deleteOneByIdOrFail(id);
+  }
+}

--- a/src/module/lesson/interface/lesson.controller.ts
+++ b/src/module/lesson/interface/lesson.controller.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import {
   Body,
   Controller,
@@ -27,6 +28,8 @@ export class LessonController {
   @Get(':id')
   async getOne(
     @Param('id', ParseUUIDPipe) id: string,
+    @Param('courseId', ParseUUIDPipe) _courseId: string,
+    @Param('sectionId', ParseUUIDPipe) _sectionId: string,
   ): Promise<LessonResponseDto> {
     return await this.lessonService.getOneByIdOrFail(id);
   }
@@ -62,6 +65,8 @@ export class LessonController {
   @Delete(':id')
   async deleteOne(
     @Param('id', ParseUUIDPipe) id: string,
+    @Param('courseId', ParseUUIDPipe) _courseId: string,
+    @Param('sectionId', ParseUUIDPipe) _sectionId: string,
   ): Promise<SuccessOperationResponseDto> {
     return await this.lessonService.deleteOneByIdOrFail(id);
   }

--- a/src/module/lesson/lesson.module.ts
+++ b/src/module/lesson/lesson.module.ts
@@ -1,0 +1,21 @@
+import { Module, Provider } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { LessonMapper } from '@module/lesson/application/mapper/lesson.mapper';
+import { LESSON_REPOSITORY_KEY } from '@module/lesson/application/repository/lesson.repository.interface';
+import { LessonService } from '@module/lesson/application/service/lesson.service';
+import { LessonPostgresRepository } from '@module/lesson/infrastructure/database/lesson.postgres.repository';
+import { LessonSchema } from '@module/lesson/infrastructure/database/lesson.schema';
+import { LessonController } from '@module/lesson/interface/lesson.controller';
+
+const lessonRepositoryProvider: Provider = {
+  provide: LESSON_REPOSITORY_KEY,
+  useClass: LessonPostgresRepository,
+};
+
+@Module({
+  imports: [TypeOrmModule.forFeature([LessonSchema])],
+  providers: [LessonService, LessonMapper, lessonRepositoryProvider],
+  controllers: [LessonController],
+})
+export class LessonModule {}


### PR DESCRIPTION
# Summary

This PR introduces a `LessonModule` with CRUD methods.

# Details

- Created the `Lesson` domain/schema entities.
- Implemented a migration for the creation of the `Lesson` table.
- Added DTOs for validating `Lesson` requests/responses.
- Created a `LessonPostgresRepository` that extends the `BaseRepository` for using CRUD methods.
- Added a `LessonMapper` for handling entity/dto transformation.
-  Implemented a `LessonController` with CRUD endpoints.
 