### PR TITLE
fix: Correct bug update course bug

### DIFF
--- a/src/module/cloud/application/constants/image-storage-folders.constants.ts
+++ b/src/module/cloud/application/constants/image-storage-folders.constants.ts
@@ -1,4 +1,4 @@
 export const AVATARS_FOLDER = 'avatars';
 export const COURSES_FOLDER = 'courses';
 export const SECTION_FOLDER = 'sections';
-export const COURSES_IMAGES_FOLDER = `${COURSES_FOLDER}/images`;
+export const IMAGES_FOLDER = 'images';

--- a/src/module/course/application/dto/create-course.dto.ts
+++ b/src/module/course/application/dto/create-course.dto.ts
@@ -4,6 +4,7 @@ import { CourseDto } from '@module/course/application/dto/course.dto';
 
 export class CreateCourseRequestDto extends OmitType(CourseDto, [
   'instructorId',
+  'imageUrl',
 ]) {}
 
 export class CreateCourseDto extends CourseDto {}

--- a/src/module/iam/authentication/application/dto/sign-up.dto.ts
+++ b/src/module/iam/authentication/application/dto/sign-up.dto.ts
@@ -1,3 +1,4 @@
+import { OmitType } from '@nestjs/mapped-types';
 import { IsEmail, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 import { IDto } from '@common/base/application/dto/dto.interface';
@@ -23,3 +24,5 @@ export class SignUpDto implements IDto {
   @IsString()
   avatarUrl?: string;
 }
+
+export class SignUpQueryDto extends OmitType(SignUpDto, ['avatarUrl']) {}

--- a/src/module/iam/authentication/interface/authentication.controller.ts
+++ b/src/module/iam/authentication/interface/authentication.controller.ts
@@ -22,7 +22,7 @@ import { RefreshSessionDto } from '@module/iam/authentication/application/dto/re
 import { ResendConfirmationCodeDto } from '@module/iam/authentication/application/dto/resend-confirmation-code.dto';
 import { SignInResponseDto } from '@module/iam/authentication/application/dto/sign-in-response.dto';
 import { SignInDto } from '@module/iam/authentication/application/dto/sign-in.dto';
-import { SignUpDto } from '@module/iam/authentication/application/dto/sign-up.dto';
+import { SignUpQueryDto } from '@module/iam/authentication/application/dto/sign-up.dto';
 import { AuthenticationService } from '@module/iam/authentication/application/service/authentication.service';
 import { AuthType } from '@module/iam/authentication/domain/auth-type.enum';
 import { Auth } from '@module/iam/authentication/infrastructure/decorator/auth.decorator';
@@ -50,7 +50,7 @@ export class AuthenticationController {
     },
   ])
   async handleSignUp(
-    @Body() signUpDto: SignUpDto,
+    @Body() signUpDto: SignUpQueryDto,
     @UploadedFile() avatar?: Express.Multer.File,
   ): Promise<UserResponseDto> {
     return this.authenticationService.handleSignUp(signUpDto, avatar);


### PR DESCRIPTION
# Summary

This PR resolves an issue where course images were inadvertently deleted during course updates when no new image was provided. Additionally, it implements proper DTO validation to prevent file URL injection via query parameters in SignUp/CreateCourse endpoints.

# Details

- Restructured CourseService.updateOne() to maintain existing images when no new file is uploaded, preventing unintended deletions
-  Reorganized image storage using course ID-based directory structure `(/courses/{id}/images/)` for better asset management
- Modified SignUpDto and CreateCourseDto to explicitly exclude file URLs from query parameters, enforcing proper file upload handling through multipart/form-data