### PR TITLE
feat: Add deleteFile method to FileStorageService

### DIFF
--- a/src/module/cloud/application/interface/file-storage-provider.interface.ts
+++ b/src/module/cloud/application/interface/file-storage-provider.interface.ts
@@ -3,4 +3,5 @@ export const FILE_STORAGE_PROVIDER_SERVICE_KEY =
 
 export interface IFileStorageProvider {
   uploadFile(file: Express.Multer.File, folder: string): Promise<string>;
+  deleteFile(fileUrl: string): Promise<void>;
 }

--- a/src/module/cloud/application/service/file-storage.service.ts
+++ b/src/module/cloud/application/service/file-storage.service.ts
@@ -15,4 +15,8 @@ export class FileStorageService {
   uploadFile(file: Express.Multer.File, folder: string): Promise<string> {
     return this.fileStorageProvider.uploadFile(file, folder);
   }
+
+  deleteFile(fileUrl: string): Promise<void> {
+    return this.fileStorageProvider.deleteFile(fileUrl);
+  }
 }

--- a/src/module/course/application/service/course.service.ts
+++ b/src/module/course/application/service/course.service.ts
@@ -73,6 +73,11 @@ export class CourseService extends BaseCRUDService<
     image?: Express.Multer.File,
   ): Promise<CourseResponseDto> {
     if (image) {
+      const course = await (
+        this.repository as ICourseRepository
+      ).getOneByIdOrFail(id);
+
+      await this.fileStorageService.deleteFile(course.imageUrl);
       updateDto.imageUrl = await this.fileStorageService.uploadFile(
         image,
         this.buildFileFolder(id),

--- a/src/module/lesson/__test__/lesson.e2e.spec.ts
+++ b/src/module/lesson/__test__/lesson.e2e.spec.ts
@@ -269,7 +269,8 @@ describe('Lesson Module', () => {
         .patch(
           `${endpoint}/${existingIds.course.first}/section/${existingIds.section.first}/lesson/${lessonId}`,
         )
-        .send(updateLessonDto)
+        .field('title', updateLessonDto.title)
+        .attach('file', fileMock)
         .auth(adminToken, { type: 'bearer' })
         .expect(HttpStatus.OK)
         .then(({ body }) => {

--- a/src/module/lesson/application/service/lesson.service.ts
+++ b/src/module/lesson/application/service/lesson.service.ts
@@ -58,6 +58,10 @@ export class LessonService extends BaseCRUDService<
     const { courseId, sectionId } = UpdateLessonDto;
 
     if (lessonFile) {
+      const lesson = await (
+        this.repository as ILessonRepository
+      ).getOneByIdOrFail(id);
+      await this.fileStorageService.deleteFile(lesson.url);
       UpdateLessonDto.url = await this.fileStorageService.uploadFile(
         lessonFile,
         this.buildFileFolder(courseId, sectionId),

--- a/src/test/test.module.bootstrapper.ts
+++ b/src/test/test.module.bootstrapper.ts
@@ -16,6 +16,7 @@ export const identityProviderServiceMock = {
 
 export const fileStorageProviderServiceMock = {
   uploadFile: jest.fn(() => Promise.resolve('test-url')),
+  deleteFile: jest.fn(() => Promise.resolve()),
 };
 
 export const testModuleBootstrapper = (): Promise<TestingModule> => {


### PR DESCRIPTION
# Summary

This PR introduces the `deleteFile` method to the `FileStorageService` and `AmazonS3Service`.

# Details

- Updated the generic `IFileStorageProvider` with deleteFile method.
- Created a `deleteFile` method on the `AmazonS3Service` that deletes a file by a received fileUrl.
- Enhanced the `updateOne` methods to delete old files while replacing them. 