### PR TITLE
refactor: Update one entity flow

### DIFF
--- a/src/common/base/application/dto/dto.interface.ts
+++ b/src/common/base/application/dto/dto.interface.ts
@@ -11,7 +11,7 @@ export interface IDtoMapper<
 > {
   fromEntityToResponseDto(entity: Entity): ResponseDto;
   fromCreateDtoToEntity(dto: CreateDto): Entity;
-  fromUpdateDtoToEntity(dto: UpdateDto): Entity;
+  fromUpdateDtoToEntity(entity: Entity, dto: UpdateDto): Entity;
 }
 
 export interface IResponseDto extends IDto {

--- a/src/common/base/application/service/base-crud.service.ts
+++ b/src/common/base/application/service/base-crud.service.ts
@@ -64,8 +64,9 @@ export class BaseCRUDService<
   }
 
   async updateOne(id: string, updateDto: UpdateDto): Promise<ResponseDto> {
-    const entity = this.mapper.fromUpdateDtoToEntity(updateDto);
-    const updatedEntity = await this.repository.updateOneByIdOrFail(id, entity);
+    const entityToUpdate = await this.repository.getOneByIdOrFail(id);
+    const entity = this.mapper.fromUpdateDtoToEntity(entityToUpdate, updateDto);
+    const updatedEntity = await this.repository.saveOne(entity);
     const responseDto = this.mapper.fromEntityToResponseDto(updatedEntity);
 
     return responseDto;

--- a/src/common/base/infrastructure/database/base.repository.ts
+++ b/src/common/base/infrastructure/database/base.repository.ts
@@ -1,5 +1,4 @@
 import {
-  DeepPartial,
   FindManyOptions,
   FindOneOptions,
   FindOptionsOrder,
@@ -71,22 +70,6 @@ abstract class BaseRepository<T extends IEntity> implements IRepository<T> {
     }
 
     await this.repository.softDelete({ id } as FindOptionsWhere<T>);
-  }
-
-  async updateOneByIdOrFail(
-    id: string,
-    updates: Partial<Omit<T, 'id'>>,
-  ): Promise<T> {
-    const entityToUpdate = await this.repository.preload({
-      ...updates,
-      id,
-    } as DeepPartial<T>);
-
-    if (!entityToUpdate) {
-      throw new EntityNotFoundException(id);
-    }
-
-    return this.repository.save(entityToUpdate);
   }
 }
 

--- a/src/common/base/infrastructure/database/repository.interface.ts
+++ b/src/common/base/infrastructure/database/repository.interface.ts
@@ -8,5 +8,4 @@ export interface IRepository<T extends IEntity> {
   getOneById(id: string): Promise<T>;
   getOneByIdOrFail(id: string): Promise<T>;
   deleteOneByIdOrFail(id: string): Promise<void>;
-  updateOneByIdOrFail(id: string, updates: Partial<Omit<T, 'id'>>): Promise<T>;
 }

--- a/src/module/course/application/mapper/course.mapper.ts
+++ b/src/module/course/application/mapper/course.mapper.ts
@@ -28,17 +28,17 @@ export class CourseMapper
     );
   }
 
-  fromUpdateDtoToEntity(dto: UpdateCourseDto): Course {
+  fromUpdateDtoToEntity(entity: Course, dto: UpdateCourseDto): Course {
     return new Course(
-      dto.id,
-      dto.title,
-      dto.description,
-      dto.price,
-      dto.imageUrl,
-      dto.status,
-      dto.slug,
-      dto.difficulty,
-      dto.instructorId,
+      dto.id ?? entity.id,
+      dto.title ?? entity.title,
+      dto.description ?? entity.description,
+      dto.price ?? entity.price,
+      dto.imageUrl ?? entity.imageUrl,
+      dto.status ?? entity.status,
+      dto.slug ?? entity.slug,
+      dto.difficulty ?? entity.difficulty,
+      dto.instructorId ?? entity.instructorId,
     );
   }
 

--- a/src/module/iam/user/application/mapper/user.mapper.ts
+++ b/src/module/iam/user/application/mapper/user.mapper.ts
@@ -29,10 +29,10 @@ export class UserMapper
   fromUpdateDtoToEntity(dto: UpdateUserDto, currentUser: User): User {
     return new User(
       currentUser.email,
-      dto.firstName,
-      dto.lastName,
+      dto.firstName ?? currentUser.firstName,
+      dto.lastName ?? currentUser.lastName,
       currentUser.roles,
-      dto.avatarUrl,
+      dto.avatarUrl ?? currentUser.avatarUrl,
       currentUser.id,
       currentUser.externalId,
       currentUser.createdAt,

--- a/src/module/lesson/application/mapper/lesson.mapper.ts
+++ b/src/module/lesson/application/mapper/lesson.mapper.ts
@@ -21,15 +21,15 @@ export class LessonMapper
     );
   }
 
-  fromUpdateDtoToEntity(dto: UpdateLessonDto): Lesson {
+  fromUpdateDtoToEntity(entity: Lesson, dto: UpdateLessonDto): Lesson {
     return new Lesson(
-      dto.id,
-      dto.courseId,
-      dto.sectionId,
-      dto.title,
-      dto.description,
-      dto.url,
-      dto.lessonType,
+      dto.id ?? entity.id,
+      dto.courseId ?? entity.courseId,
+      dto.sectionId ?? entity.sectionId,
+      dto.title ?? entity.title,
+      dto.description ?? entity.description,
+      dto.url ?? entity.url,
+      dto.lessonType ?? entity.lessonType,
     );
   }
 

--- a/src/module/section/application/mapper/section.mapper.ts
+++ b/src/module/section/application/mapper/section.mapper.ts
@@ -19,13 +19,13 @@ export class SectionMapper
     );
   }
 
-  fromUpdateDtoToEntity(dto: UpdateSectionDto): Section {
+  fromUpdateDtoToEntity(entity: Section, dto: UpdateSectionDto): Section {
     return new Section(
-      dto.id,
-      dto.courseId,
-      dto.title,
-      dto.description,
-      dto.position,
+      dto.id ?? entity.id,
+      dto.courseId ?? entity.courseId,
+      dto.title ?? entity.title,
+      dto.description ?? entity.description,
+      dto.position ?? entity.position,
     );
   }
 


### PR DESCRIPTION
# Summary

This PR refactores the ´updateOne´ flow to find the entity on the Service, using the repository just for saving the updated entity. This way, the entity mapper can access the existing entity so that the ´new Entity(...)´ can have a fallback value on the not updated properties.