### PR TITLE
feat: Add lessonType saving based on file

### DIFF
--- a/src/module/lesson/application/dto/create-lesson.dto.ts
+++ b/src/module/lesson/application/dto/create-lesson.dto.ts
@@ -5,6 +5,7 @@ import { LessonDto } from '@module/lesson/application/dto/lesson.dto';
 export class CreateLessonDtoQuery extends OmitType(LessonDto, [
   'courseId',
   'sectionId',
+  'lessonType',
 ]) {}
 
 export class CreateLessonDto extends LessonDto {}


### PR DESCRIPTION
# Summary

This PR changes the `saveOne` and `updateOne` methods from the `Lesson` module in order to create the `lessonType` property based on the file received on the request.

# Details

- Updated the `CreateLessonDtoQuery` to omit `lessonType` as this property will be created based on the received file and not on the request's body.
- Refactored `saveOne` `updateOne` methods to obtain the `LessonType` depending on the received file's mimetype.