### PR TITLE
feat: Add lesson permissions for handling request's authorizations

### DIFF
--- a/src/common/base/application/factory/file-options.factory.ts
+++ b/src/common/base/application/factory/file-options.factory.ts
@@ -30,7 +30,7 @@ export class FileOptionsFactory implements MulterOptions {
     const maxFileSize =
       Math.max(
         ...formats.map((format) => MAX_FILE_SIZES[format as FileFormat]),
-      ) + 1;
+      ) + 5;
 
     return {
       limits: {

--- a/src/module/course/__test__/course.e2e.spec.ts
+++ b/src/module/course/__test__/course.e2e.spec.ts
@@ -567,7 +567,7 @@ describe('Course Module', () => {
         status: PublishStatus.drafted,
         difficulty: Difficulty.BEGINNER,
       } as CreateCourseDto;
-      const oversizedImageMock = createLargeMockFile('image.svg', 30);
+      const oversizedImageMock = createLargeMockFile('image.svg', 5.1);
 
       await request(app.getHttpServer())
         .post(endpoint)

--- a/src/module/iam/authorization/infrastructure/casl/type/app-subjects.type.ts
+++ b/src/module/iam/authorization/infrastructure/casl/type/app-subjects.type.ts
@@ -2,10 +2,18 @@ import { InferSubjects } from '@casl/ability';
 
 import { Course } from '@module/course/domain/course.entity';
 import { User } from '@module/iam/user/domain/user.entity';
+import { Lesson } from '@module/lesson/domain/lesson.entity';
 import { Section } from '@module/section/domain/section.entity';
 
 export type AppSubjects =
   | InferSubjects<
-      typeof User | User | typeof Course | Course | typeof Section | Section
+      | typeof User
+      | User
+      | typeof Course
+      | Course
+      | typeof Section
+      | Section
+      | typeof Lesson
+      | Lesson
     >
   | 'all';

--- a/src/module/lesson/__test__/fixture/Lesson.yml
+++ b/src/module/lesson/__test__/fixture/Lesson.yml
@@ -1,0 +1,11 @@
+entity: Lesson
+items:
+  lesson1:
+    id: '23de5a50-aa82-45f1-996e-7e6730852631'
+    title: 'Introduction to JavaScript'
+    description: 'Learn the basics of programming with JavaScript'
+    courseId: 'c62801a2-0d74-4dd7-a20c-11c25be00a2a'
+    sectionId: '31487427-8f89-4e65-bd09-fb84ab56775b'
+    url: '{{internet.url}}/intro-programming.pdf'
+    lessonType: pdf
+    section: '@section1'

--- a/src/module/lesson/__test__/lesson.e2e.spec.ts
+++ b/src/module/lesson/__test__/lesson.e2e.spec.ts
@@ -798,5 +798,246 @@ describe('Lesson Module', () => {
           expect(body).toEqual(expectedResponse);
         });
     });
+
+    it('Should deny access to regular users', async () => {
+      const createLessonDto = {
+        title: 'Lesson 1',
+        description: 'Description 1',
+      } as CreateLessonDto;
+      let lessonId: string = '';
+
+      await request(app.getHttpServer())
+        .post(
+          `${endpoint}/${existingIds.course.first}/section/${existingIds.section.first}/lesson`,
+        )
+        .auth(adminToken, { type: 'bearer' })
+        .field('title', createLessonDto.title as string)
+        .field('description', createLessonDto.description as string)
+        .attach('file', fileMock)
+        .expect(HttpStatus.CREATED)
+        .then(
+          ({ body }: { body: SerializedResponseDto<LessonResponseDto> }) => {
+            lessonId = body.data.id as string;
+
+            const expectedResponse = expect.objectContaining({
+              data: expect.objectContaining({
+                type: 'lesson',
+                id: expect.any(String),
+                attributes: expect.objectContaining({
+                  courseId: existingIds.course.first,
+                  sectionId: existingIds.section.first,
+                  title: createLessonDto.title,
+                  description: createLessonDto.description,
+                  url: 'test-url',
+                }),
+              }),
+              links: expect.arrayContaining([
+                expect.objectContaining({
+                  href: expect.stringContaining(
+                    `${endpoint}/${existingIds.course.first}/section/${existingIds.section.first}/lesson`,
+                  ),
+                  rel: 'self',
+                  method: HttpMethod.POST,
+                }),
+              ]),
+            });
+
+            expect(body).toEqual(expectedResponse);
+          },
+        );
+
+      return await request(app.getHttpServer())
+        .delete(
+          `${endpoint}/${existingIds.course.first}/section/${existingIds.section.first}/lesson/${lessonId}`,
+        )
+        .auth(regularToken, { type: 'bearer' })
+        .expect(HttpStatus.FORBIDDEN)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `You are not allowed to ${AppAction.Delete.toUpperCase()} this resource`,
+              source: {
+                pointer: `${endpoint}/${existingIds.course.first}/section/${existingIds.section.first}/lesson/${lessonId}`,
+              },
+              status: HttpStatus.FORBIDDEN.toString(),
+              title: 'Forbidden',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should deny access to non instructors admins', async () => {
+      const createLessonDto = {
+        title: 'Lesson 1',
+        description: 'Description 1',
+      } as CreateLessonDto;
+      let lessonId: string = '';
+
+      await request(app.getHttpServer())
+        .post(
+          `${endpoint}/${existingIds.course.first}/section/${existingIds.section.first}/lesson`,
+        )
+        .auth(adminToken, { type: 'bearer' })
+        .field('title', createLessonDto.title as string)
+        .field('description', createLessonDto.description as string)
+        .attach('file', fileMock)
+        .expect(HttpStatus.CREATED)
+        .then(
+          ({ body }: { body: SerializedResponseDto<LessonResponseDto> }) => {
+            lessonId = body.data.id as string;
+
+            const expectedResponse = expect.objectContaining({
+              data: expect.objectContaining({
+                type: 'lesson',
+                id: expect.any(String),
+                attributes: expect.objectContaining({
+                  courseId: existingIds.course.first,
+                  sectionId: existingIds.section.first,
+                  title: createLessonDto.title,
+                  description: createLessonDto.description,
+                  url: 'test-url',
+                }),
+              }),
+              links: expect.arrayContaining([
+                expect.objectContaining({
+                  href: expect.stringContaining(
+                    `${endpoint}/${existingIds.course.first}/section/${existingIds.section.first}/lesson`,
+                  ),
+                  rel: 'self',
+                  method: HttpMethod.POST,
+                }),
+              ]),
+            });
+
+            expect(body).toEqual(expectedResponse);
+          },
+        );
+
+      return await request(app.getHttpServer())
+        .delete(
+          `${endpoint}/${existingIds.course.first}/section/${existingIds.section.first}/lesson/${lessonId}`,
+        )
+        .auth(secondAdminToken, { type: 'bearer' })
+        .expect(HttpStatus.FORBIDDEN)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `You are not allowed to ${AppAction.Delete.toUpperCase()} this resource`,
+              source: {
+                pointer: `${endpoint}/${existingIds.course.first}/section/${existingIds.section.first}/lesson/${lessonId}`,
+              },
+              status: HttpStatus.FORBIDDEN.toString(),
+              title: 'Forbidden',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should grant access to super admins', async () => {
+      const createLessonDto = {
+        title: 'Lesson 1',
+        description: 'Description 1',
+      } as CreateLessonDto;
+      let lessonId: string = '';
+
+      await request(app.getHttpServer())
+        .post(
+          `${endpoint}/${existingIds.course.first}/section/${existingIds.section.first}/lesson`,
+        )
+        .auth(adminToken, { type: 'bearer' })
+        .field('title', createLessonDto.title as string)
+        .field('description', createLessonDto.description as string)
+        .attach('file', fileMock)
+        .expect(HttpStatus.CREATED)
+        .then(
+          ({ body }: { body: SerializedResponseDto<LessonResponseDto> }) => {
+            lessonId = body.data.id as string;
+
+            const expectedResponse = expect.objectContaining({
+              data: expect.objectContaining({
+                type: 'lesson',
+                id: expect.any(String),
+                attributes: expect.objectContaining({
+                  courseId: existingIds.course.first,
+                  sectionId: existingIds.section.first,
+                  title: createLessonDto.title,
+                  description: createLessonDto.description,
+                  url: 'test-url',
+                }),
+              }),
+              links: expect.arrayContaining([
+                expect.objectContaining({
+                  href: expect.stringContaining(
+                    `${endpoint}/${existingIds.course.first}/section/${existingIds.section.first}/lesson`,
+                  ),
+                  rel: 'self',
+                  method: HttpMethod.POST,
+                }),
+              ]),
+            });
+
+            expect(body).toEqual(expectedResponse);
+          },
+        );
+
+      return await request(app.getHttpServer())
+        .delete(
+          `${endpoint}/${existingIds.course.first}/section/${existingIds.section.first}/lesson/${lessonId}`,
+        )
+        .auth(superAdminToken, { type: 'bearer' })
+        .expect(HttpStatus.OK)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            data: expect.any(Object),
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should throw an error if the lesson does not belong to the section', async () => {
+      return await request(app.getHttpServer())
+        .delete(
+          `${endpoint}/${existingIds.course.first}/section/${existingIds.section.third}/lesson/${existingIds.lesson.first}`,
+        )
+        .auth(adminToken, { type: 'bearer' })
+        .expect(HttpStatus.BAD_REQUEST)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `The lesson with id ${existingIds.lesson.first} does not belong to the section with id ${existingIds.section.third}`,
+              source: {
+                pointer: `${endpoint}/${existingIds.course.first}/section/${existingIds.section.third}/lesson/${existingIds.lesson.first}`,
+              },
+              status: HttpStatus.BAD_REQUEST.toString(),
+              title: 'Bad request',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should throw an error if the section does not belong to the course', async () => {
+      return await request(app.getHttpServer())
+        .delete(
+          `${endpoint}/${existingIds.course.second}/section/${existingIds.section.first}/lesson/${existingIds.lesson.first}`,
+        )
+        .auth(adminToken, { type: 'bearer' })
+        .expect(HttpStatus.BAD_REQUEST)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `The section with id ${existingIds.section.first} does not belong to the course with id ${existingIds.course.second}`,
+              source: {
+                pointer: `${endpoint}/${existingIds.course.second}/section/${existingIds.section.first}/lesson/${existingIds.lesson.first}`,
+              },
+              status: HttpStatus.BAD_REQUEST.toString(),
+              title: 'Bad request',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
   });
 });

--- a/src/module/lesson/application/policy/create-lesson-policy.handler.ts
+++ b/src/module/lesson/application/policy/create-lesson-policy.handler.ts
@@ -1,0 +1,67 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Inject,
+} from '@nestjs/common';
+import { Request } from 'express';
+
+import { BasePolicyHandler } from '@module/iam/authorization/application/policy/base-policy.handler';
+import { AuthorizationService } from '@module/iam/authorization/application/service/authorization.service';
+import { AppRole } from '@module/iam/authorization/domain/app-role.enum';
+import { AppAction } from '@module/iam/authorization/domain/app.action.enum';
+import { IPolicyHandler } from '@module/iam/authorization/infrastructure/policy/handler/policy-handler.interface';
+import { PolicyHandlerStorage } from '@module/iam/authorization/infrastructure/policy/storage/policies-handler.storage';
+import { Lesson } from '@module/lesson/domain/lesson.entity';
+import {
+  ISectionRepository,
+  SECTION_REPOSITORY_KEY,
+} from '@module/section/application/repository/section.repository.interface';
+
+export class CreateLessonPolicyHandler
+  extends BasePolicyHandler
+  implements IPolicyHandler
+{
+  private readonly action = AppAction.Create;
+  constructor(
+    private readonly policyHandlerStorage: PolicyHandlerStorage,
+    private readonly authorizationService: AuthorizationService,
+    @Inject(SECTION_REPOSITORY_KEY)
+    private readonly sectionRepository: ISectionRepository,
+  ) {
+    super();
+    this.policyHandlerStorage.add(CreateLessonPolicyHandler, this);
+  }
+
+  async handle(request: Request): Promise<void> {
+    const { courseId, sectionId } = request.params;
+    const section = await this.sectionRepository.getOneByIdOrFail(sectionId, [
+      'course',
+    ]);
+    const user = this.getCurrentUser(request);
+    const userIsSuperAdmin = user.roles.includes(AppRole.SuperAdmin);
+
+    if (section.courseId !== courseId) {
+      throw new BadRequestException(
+        `The section with id ${sectionId} does not belong to the course with id ${courseId}`,
+      );
+    }
+
+    if (section.instructorId !== user.id && !userIsSuperAdmin) {
+      throw new ForbiddenException(
+        `You are not allowed to ${this.action.toUpperCase()} this resource`,
+      );
+    }
+
+    const isAllowed = this.authorizationService.isAllowed(
+      user,
+      this.action,
+      Lesson,
+    );
+
+    if (!isAllowed) {
+      throw new ForbiddenException(
+        `You are not allowed to ${this.action.toUpperCase()} this resource`,
+      );
+    }
+  }
+}

--- a/src/module/lesson/application/policy/delete-lession-policy.handler.ts
+++ b/src/module/lesson/application/policy/delete-lession-policy.handler.ts
@@ -1,0 +1,75 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Inject,
+} from '@nestjs/common';
+import { Request } from 'express';
+
+import { BasePolicyHandler } from '@module/iam/authorization/application/policy/base-policy.handler';
+import { AuthorizationService } from '@module/iam/authorization/application/service/authorization.service';
+import { AppRole } from '@module/iam/authorization/domain/app-role.enum';
+import { AppAction } from '@module/iam/authorization/domain/app.action.enum';
+import { IPolicyHandler } from '@module/iam/authorization/infrastructure/policy/handler/policy-handler.interface';
+import { PolicyHandlerStorage } from '@module/iam/authorization/infrastructure/policy/storage/policies-handler.storage';
+import {
+  ILessonRepository,
+  LESSON_REPOSITORY_KEY,
+} from '@module/lesson/application/repository/lesson.repository.interface';
+import { Lesson } from '@module/lesson/domain/lesson.entity';
+
+export class DeleteLessonPolicyHandler
+  extends BasePolicyHandler
+  implements IPolicyHandler
+{
+  private readonly action = AppAction.Delete;
+  constructor(
+    private readonly policyHandlerStorage: PolicyHandlerStorage,
+    private readonly authorizationService: AuthorizationService,
+    @Inject(LESSON_REPOSITORY_KEY)
+    private readonly lessonRepository: ILessonRepository,
+  ) {
+    super();
+    this.policyHandlerStorage.add(DeleteLessonPolicyHandler, this);
+  }
+
+  async handle(request: Request): Promise<void> {
+    const { courseId, sectionId, id: lessonId } = request.params;
+    const lesson = await this.lessonRepository.getOneByIdOrFail(lessonId, [
+      'section',
+      'section.course' as keyof Lesson,
+    ]);
+
+    if (lesson.sectionId !== sectionId) {
+      throw new BadRequestException(
+        `The lesson with id ${lessonId} does not belong to the section with id ${sectionId}`,
+      );
+    }
+
+    if (lesson.section?.courseId !== courseId) {
+      throw new BadRequestException(
+        `The section with id ${sectionId} does not belong to the course with id ${courseId}`,
+      );
+    }
+
+    const user = this.getCurrentUser(request);
+    const userIsSuperAdmin = user.roles.includes(AppRole.SuperAdmin);
+
+    if (lesson.instructorId !== user.id && !userIsSuperAdmin) {
+      throw new ForbiddenException(
+        `You are not allowed to ${this.action.toUpperCase()} this resource`,
+      );
+    }
+
+    const isAllowed = this.authorizationService.isAllowed(
+      user,
+      this.action,
+      lesson,
+    );
+
+    if (!isAllowed) {
+      throw new ForbiddenException(
+        `You are not allowed to ${this.action.toUpperCase()} this resource`,
+      );
+    }
+  }
+}

--- a/src/module/lesson/application/policy/update-lesson-policy.handler.ts
+++ b/src/module/lesson/application/policy/update-lesson-policy.handler.ts
@@ -1,0 +1,67 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Inject,
+} from '@nestjs/common';
+import { Request } from 'express';
+
+import { BasePolicyHandler } from '@module/iam/authorization/application/policy/base-policy.handler';
+import { AuthorizationService } from '@module/iam/authorization/application/service/authorization.service';
+import { AppAction } from '@module/iam/authorization/domain/app.action.enum';
+import { IPolicyHandler } from '@module/iam/authorization/infrastructure/policy/handler/policy-handler.interface';
+import { PolicyHandlerStorage } from '@module/iam/authorization/infrastructure/policy/storage/policies-handler.storage';
+import {
+  ILessonRepository,
+  LESSON_REPOSITORY_KEY,
+} from '@module/lesson/application/repository/lesson.repository.interface';
+import { Lesson } from '@module/lesson/domain/lesson.entity';
+
+export class UpdateLessonPolicyHandler
+  extends BasePolicyHandler
+  implements IPolicyHandler
+{
+  private readonly action = AppAction.Update;
+  constructor(
+    private readonly policyHandlerStorage: PolicyHandlerStorage,
+    private readonly authorizationService: AuthorizationService,
+    @Inject(LESSON_REPOSITORY_KEY)
+    private readonly lessonRepository: ILessonRepository,
+  ) {
+    super();
+    this.policyHandlerStorage.add(UpdateLessonPolicyHandler, this);
+  }
+
+  async handle(request: Request): Promise<void> {
+    const { courseId, sectionId, id: lessonId } = request.params;
+    const lesson = await this.lessonRepository.getOneByIdOrFail(lessonId, [
+      'section',
+      'section.course' as keyof Lesson,
+    ]);
+
+    if (lesson.sectionId !== sectionId) {
+      throw new BadRequestException(
+        `The lesson with id ${lessonId} does not belong to the section with id ${sectionId}`,
+      );
+    }
+
+    if (lesson.section?.courseId !== courseId) {
+      throw new BadRequestException(
+        `The section with id ${sectionId} does not belong to the course with id ${courseId}`,
+      );
+    }
+
+    const user = this.getCurrentUser(request);
+
+    const isAllowed = this.authorizationService.isAllowed(
+      user,
+      this.action,
+      lesson,
+    );
+
+    if (!isAllowed) {
+      throw new ForbiddenException(
+        `You are not allowed to ${this.action.toUpperCase()} this resource`,
+      );
+    }
+  }
+}

--- a/src/module/lesson/domain/lesson.permissions.ts
+++ b/src/module/lesson/domain/lesson.permissions.ts
@@ -1,0 +1,18 @@
+import { AppRole } from '@module/iam/authorization/domain/app-role.enum';
+import { AppAction } from '@module/iam/authorization/domain/app.action.enum';
+import { IPermissionsDefinition } from '@module/iam/authorization/infrastructure/policy/type/permissions-definition.interface';
+import { Lesson } from '@module/lesson/domain/lesson.entity';
+
+export const lessonPermissions: IPermissionsDefinition = {
+  [AppRole.Regular](_, { cannot }) {
+    cannot(AppAction.Manage, Lesson);
+  },
+  [AppRole.Admin](user, { can }) {
+    can(AppAction.Manage, Lesson, {
+      instructorId: user.id,
+    });
+  },
+  [AppRole.SuperAdmin](_, { can }) {
+    can(AppAction.Manage, Lesson);
+  },
+};

--- a/src/module/lesson/interface/lesson.controller.ts
+++ b/src/module/lesson/interface/lesson.controller.ts
@@ -24,6 +24,7 @@ import { CreateLessonDtoQuery } from '@module/lesson/application/dto/create-less
 import { LessonResponseDto } from '@module/lesson/application/dto/lesson-response.dto';
 import { UpdateLessonDto } from '@module/lesson/application/dto/update-lesson.dto';
 import { CreateLessonPolicyHandler } from '@module/lesson/application/policy/create-lesson-policy.handler';
+import { UpdateLessonPolicyHandler } from '@module/lesson/application/policy/update-lesson-policy.handler';
 import { LessonService } from '@module/lesson/application/service/lesson.service';
 
 @Controller('course/:courseId/section/:sectionId/lesson')
@@ -61,6 +62,7 @@ export class LessonController {
   }
 
   @Patch(':id')
+  @Policies(UpdateLessonPolicyHandler)
   async updateOne(
     @Body() updateLessonDto: UpdateLessonDto,
     @Param('sectionId', ParseUUIDPipe) sectionId: string,

--- a/src/module/lesson/interface/lesson.controller.ts
+++ b/src/module/lesson/interface/lesson.controller.ts
@@ -24,6 +24,7 @@ import { CreateLessonDtoQuery } from '@module/lesson/application/dto/create-less
 import { LessonResponseDto } from '@module/lesson/application/dto/lesson-response.dto';
 import { UpdateLessonDto } from '@module/lesson/application/dto/update-lesson.dto';
 import { CreateLessonPolicyHandler } from '@module/lesson/application/policy/create-lesson-policy.handler';
+import { DeleteLessonPolicyHandler } from '@module/lesson/application/policy/delete-lession-policy.handler';
 import { UpdateLessonPolicyHandler } from '@module/lesson/application/policy/update-lesson-policy.handler';
 import { LessonService } from '@module/lesson/application/service/lesson.service';
 
@@ -78,6 +79,7 @@ export class LessonController {
   }
 
   @Delete(':id')
+  @Policies(DeleteLessonPolicyHandler)
   async deleteOne(
     @Param('id', ParseUUIDPipe) id: string,
     @Param('courseId', ParseUUIDPipe) _courseId: string,

--- a/src/module/lesson/interface/lesson.controller.ts
+++ b/src/module/lesson/interface/lesson.controller.ts
@@ -9,6 +9,7 @@ import {
   Patch,
   Post,
   UploadedFile,
+  UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
@@ -17,12 +18,16 @@ import { SuccessOperationResponseDto } from '@common/base/application/dto/succes
 import { FileFormat } from '@common/base/application/enum/file-format.enum';
 import { FileOptionsFactory } from '@common/base/application/factory/file-options.factory';
 
+import { Policies } from '@module/iam/authorization/infrastructure/policy/decorator/policy.decorator';
+import { PoliciesGuard } from '@module/iam/authorization/infrastructure/policy/guard/policy.guard';
 import { CreateLessonDtoQuery } from '@module/lesson/application/dto/create-lesson.dto';
 import { LessonResponseDto } from '@module/lesson/application/dto/lesson-response.dto';
 import { UpdateLessonDto } from '@module/lesson/application/dto/update-lesson.dto';
+import { CreateLessonPolicyHandler } from '@module/lesson/application/policy/create-lesson-policy.handler';
 import { LessonService } from '@module/lesson/application/service/lesson.service';
 
 @Controller('course/:courseId/section/:sectionId/lesson')
+@UseGuards(PoliciesGuard)
 @UseInterceptors(
   FileInterceptor(
     'file',
@@ -42,6 +47,7 @@ export class LessonController {
   }
 
   @Post()
+  @Policies(CreateLessonPolicyHandler)
   async saveOne(
     @Body() createLessonDto: CreateLessonDtoQuery,
     @Param('sectionId', ParseUUIDPipe) sectionId: string,

--- a/src/module/lesson/lesson.module.ts
+++ b/src/module/lesson/lesson.module.ts
@@ -1,9 +1,12 @@
-import { Module, Provider } from '@nestjs/common';
+import { Module, OnModuleInit, Provider } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { AppSubjectPermissionStorage } from '@module/iam/authorization/infrastructure/casl/storage/app-subject-permissions-storage';
 import { LessonMapper } from '@module/lesson/application/mapper/lesson.mapper';
 import { LESSON_REPOSITORY_KEY } from '@module/lesson/application/repository/lesson.repository.interface';
 import { LessonService } from '@module/lesson/application/service/lesson.service';
+import { Lesson } from '@module/lesson/domain/lesson.entity';
+import { lessonPermissions } from '@module/lesson/domain/lesson.permissions';
 import { LessonPostgresRepository } from '@module/lesson/infrastructure/database/lesson.postgres.repository';
 import { LessonSchema } from '@module/lesson/infrastructure/database/lesson.schema';
 import { LessonController } from '@module/lesson/interface/lesson.controller';
@@ -18,4 +21,10 @@ const lessonRepositoryProvider: Provider = {
   providers: [LessonService, LessonMapper, lessonRepositoryProvider],
   controllers: [LessonController],
 })
-export class LessonModule {}
+export class LessonModule implements OnModuleInit {
+  constructor(private readonly registry: AppSubjectPermissionStorage) {}
+
+  onModuleInit(): void {
+    this.registry.set(Lesson, lessonPermissions);
+  }
+}

--- a/src/module/lesson/lesson.module.ts
+++ b/src/module/lesson/lesson.module.ts
@@ -5,6 +5,7 @@ import { AuthorizationModule } from '@module/iam/authorization/authorization.mod
 import { AppSubjectPermissionStorage } from '@module/iam/authorization/infrastructure/casl/storage/app-subject-permissions-storage';
 import { LessonMapper } from '@module/lesson/application/mapper/lesson.mapper';
 import { CreateLessonPolicyHandler } from '@module/lesson/application/policy/create-lesson-policy.handler';
+import { UpdateLessonPolicyHandler } from '@module/lesson/application/policy/update-lesson-policy.handler';
 import { LESSON_REPOSITORY_KEY } from '@module/lesson/application/repository/lesson.repository.interface';
 import { LessonService } from '@module/lesson/application/service/lesson.service';
 import { Lesson } from '@module/lesson/domain/lesson.entity';
@@ -12,13 +13,17 @@ import { lessonPermissions } from '@module/lesson/domain/lesson.permissions';
 import { LessonPostgresRepository } from '@module/lesson/infrastructure/database/lesson.postgres.repository';
 import { LessonSchema } from '@module/lesson/infrastructure/database/lesson.schema';
 import { LessonController } from '@module/lesson/interface/lesson.controller';
+import { SectionModule } from '@module/section/section.module';
 
 const lessonRepositoryProvider: Provider = {
   provide: LESSON_REPOSITORY_KEY,
   useClass: LessonPostgresRepository,
 };
 
-const policyHandlersProvider = [CreateLessonPolicyHandler];
+const policyHandlersProvider = [
+  CreateLessonPolicyHandler,
+  UpdateLessonPolicyHandler,
+];
 
 @Module({
   imports: [

--- a/src/module/lesson/lesson.module.ts
+++ b/src/module/lesson/lesson.module.ts
@@ -5,6 +5,7 @@ import { AuthorizationModule } from '@module/iam/authorization/authorization.mod
 import { AppSubjectPermissionStorage } from '@module/iam/authorization/infrastructure/casl/storage/app-subject-permissions-storage';
 import { LessonMapper } from '@module/lesson/application/mapper/lesson.mapper';
 import { CreateLessonPolicyHandler } from '@module/lesson/application/policy/create-lesson-policy.handler';
+import { DeleteLessonPolicyHandler } from '@module/lesson/application/policy/delete-lession-policy.handler';
 import { UpdateLessonPolicyHandler } from '@module/lesson/application/policy/update-lesson-policy.handler';
 import { LESSON_REPOSITORY_KEY } from '@module/lesson/application/repository/lesson.repository.interface';
 import { LessonService } from '@module/lesson/application/service/lesson.service';
@@ -23,6 +24,7 @@ const lessonRepositoryProvider: Provider = {
 const policyHandlersProvider = [
   CreateLessonPolicyHandler,
   UpdateLessonPolicyHandler,
+  DeleteLessonPolicyHandler,
 ];
 
 @Module({

--- a/src/module/lesson/lesson.module.ts
+++ b/src/module/lesson/lesson.module.ts
@@ -1,8 +1,10 @@
 import { Module, OnModuleInit, Provider } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { AuthorizationModule } from '@module/iam/authorization/authorization.module';
 import { AppSubjectPermissionStorage } from '@module/iam/authorization/infrastructure/casl/storage/app-subject-permissions-storage';
 import { LessonMapper } from '@module/lesson/application/mapper/lesson.mapper';
+import { CreateLessonPolicyHandler } from '@module/lesson/application/policy/create-lesson-policy.handler';
 import { LESSON_REPOSITORY_KEY } from '@module/lesson/application/repository/lesson.repository.interface';
 import { LessonService } from '@module/lesson/application/service/lesson.service';
 import { Lesson } from '@module/lesson/domain/lesson.entity';
@@ -16,9 +18,20 @@ const lessonRepositoryProvider: Provider = {
   useClass: LessonPostgresRepository,
 };
 
+const policyHandlersProvider = [CreateLessonPolicyHandler];
+
 @Module({
-  imports: [TypeOrmModule.forFeature([LessonSchema])],
-  providers: [LessonService, LessonMapper, lessonRepositoryProvider],
+  imports: [
+    TypeOrmModule.forFeature([LessonSchema]),
+    AuthorizationModule.forFeature(),
+    SectionModule,
+  ],
+  providers: [
+    LessonService,
+    LessonMapper,
+    lessonRepositoryProvider,
+    ...policyHandlersProvider,
+  ],
   controllers: [LessonController],
 })
 export class LessonModule implements OnModuleInit {

--- a/src/module/section/section.module.ts
+++ b/src/module/section/section.module.ts
@@ -41,7 +41,7 @@ const policyHandlersProviders = [
     ...policyHandlersProviders,
   ],
   controllers: [SectionController],
-  exports: [SectionService, sectionRepositoryProvider],
+  exports: [sectionRepositoryProvider],
 })
 export class SectionModule implements OnModuleInit {
   constructor(private readonly registry: AppSubjectPermissionStorage) {}


### PR DESCRIPTION
# Summary

This PR introduces `create`, `update` and `delete` policy handlers to validate user's request based on its roles.

# Details

- Created the `CreateLessonPolicyHandler` for handling `saveOne`'s method validation in order to prevent unauthorized users to save lessons.
- Added the `UpdatedLessonPolicyHandler` for handling `updateOne`'s method validation in order to prevent unauthorized users to update lessons.
- Implemented the `DeleteLessonPolicyHandler` for handling `updateOne`'s method validation in order to prevent unauthorized users to delete lessons.