### PR TITLE
refactor: Enhance course validation to deny publishing with empty fields

### DIFF
--- a/src/module/course/application/dto/course.dto.ts
+++ b/src/module/course/application/dto/course.dto.ts
@@ -2,7 +2,6 @@ import {
   IsEnum,
   IsNotEmpty,
   IsNumber,
-  IsOptional,
   IsString,
   IsUUID,
   IsUrl,
@@ -10,6 +9,7 @@ import {
   MaxLength,
   Min,
   MinLength,
+  ValidateIf,
 } from 'class-validator';
 
 import { BaseDto } from '@common/base/application/dto/base.dto';
@@ -23,20 +23,20 @@ export class CourseDto extends BaseDto {
   @IsUUID('4')
   instructorId!: string;
 
-  @IsOptional()
+  @ValidateIf((o: CourseDto) => o.status === PublishStatus.published)
   @MinLength(5, { message: 'Title must be at least 5 characters long' })
   @MaxLength(100, { message: 'Title cannot be longer than 100 characters' })
   @IsString()
   title?: string;
 
-  @IsOptional()
+  @ValidateIf((o: CourseDto) => o.status === PublishStatus.published)
   @IsString()
   @MaxLength(2000, {
     message: 'Description cannot be longer than 2000 characters',
   })
   description?: string;
 
-  @IsOptional()
+  @ValidateIf((o: CourseDto) => o.status === PublishStatus.published)
   @IsNumber(
     {
       maxDecimalPlaces: 2,
@@ -47,21 +47,21 @@ export class CourseDto extends BaseDto {
   @Max(10000, { message: 'Price cannot exceed $10,000' })
   price?: number;
 
-  @IsOptional()
+  @ValidateIf((o: CourseDto) => o.status === PublishStatus.published)
   @IsUrl()
   imageUrl?: string;
 
-  @IsOptional()
+  @ValidateIf((o: CourseDto) => o.status === PublishStatus.published)
   @IsEnum(PublishStatus, {
     message: `Status must be one of: ${Object.values(PublishStatus).join(', ')}`,
   })
-  status?: PublishStatus;
+  status?: PublishStatus = PublishStatus.drafted;
 
-  @IsOptional()
+  @ValidateIf((o: CourseDto) => o.status === PublishStatus.published)
   @IsString()
   slug?: string;
 
-  @IsOptional()
+  @ValidateIf((o: CourseDto) => o.status === PublishStatus.published)
   @IsEnum(Difficulty, {
     message: `Difficulty must be one of: ${Object.values(Difficulty).join(', ')}`,
   })

--- a/src/module/course/application/service/course.service.ts
+++ b/src/module/course/application/service/course.service.ts
@@ -65,7 +65,7 @@ export class CourseService extends BaseCRUDService<
       updateDto.status === PublishStatus.published &&
       course.status === PublishStatus.drafted
     ) {
-      this.verifyCourseIsComplete(course);
+      this.verifyCourseIsComplete(course, updateDto);
     }
 
     if (image) {
@@ -105,8 +105,10 @@ export class CourseService extends BaseCRUDService<
     return `${this.fileStorageService.COURSES_FOLDER}/${courseId}/${this.fileStorageService.IMAGES_FOLDER}`;
   }
 
-  private verifyCourseIsComplete(course: Course): void {
-    const missingFields: Array<keyof Course> = [];
+  private verifyCourseIsComplete(
+    course: Course,
+    updateDto: UpdateCourseDto,
+  ): void {
     const requiredFields: Array<keyof Course> = [
       'title',
       'description',
@@ -115,11 +117,9 @@ export class CourseService extends BaseCRUDService<
       'difficulty',
     ];
 
-    for (const field of requiredFields) {
-      if (!course[field]) {
-        missingFields.push(field);
-      }
-    }
+    const missingFields = requiredFields.filter(
+      (field) => course[field] == null && updateDto[field] == null,
+    );
 
     if (missingFields.length) {
       throw new BadRequestException(

--- a/src/module/course/application/service/course.service.ts
+++ b/src/module/course/application/service/course.service.ts
@@ -1,6 +1,7 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 import { v4 as uuidv4 } from 'uuid';
 
+import { PublishStatus } from '@common/base/application/enum/publish-status.enum';
 import { BaseCRUDService } from '@common/base/application/service/base-crud.service';
 
 import { SlugService } from '@module/app/application/service/slug.service';
@@ -56,11 +57,18 @@ export class CourseService extends BaseCRUDService<
     updateDto: UpdateCourseDto,
     image?: Express.Multer.File,
   ): Promise<CourseResponseDto> {
-    if (image) {
-      const course = await (
-        this.repository as ICourseRepository
-      ).getOneByIdOrFail(id);
+    const course = await (
+      this.repository as ICourseRepository
+    ).getOneByIdOrFail(id);
 
+    if (
+      updateDto.status === PublishStatus.published &&
+      course.status === PublishStatus.drafted
+    ) {
+      this.verifyCourseIsComplete(course);
+    }
+
+    if (image) {
       if (course.imageUrl) {
         await this.fileStorageService.deleteFile(course.imageUrl);
       }
@@ -71,7 +79,11 @@ export class CourseService extends BaseCRUDService<
       );
     }
 
-    return super.updateOne(id, updateDto);
+    const courseToUpdate = this.mapper.fromUpdateDtoToEntity(course, updateDto);
+    const updatedEntity = await this.repository.saveOne(courseToUpdate);
+    const responseDto = this.mapper.fromEntityToResponseDto(updatedEntity);
+
+    return responseDto;
   }
 
   private async buildUniqueSlug(title: string): Promise<string> {
@@ -91,5 +103,28 @@ export class CourseService extends BaseCRUDService<
 
   private buildFileFolder(courseId: string): string {
     return `${this.fileStorageService.COURSES_FOLDER}/${courseId}/${this.fileStorageService.IMAGES_FOLDER}`;
+  }
+
+  private verifyCourseIsComplete(course: Course): void {
+    const missingFields: Array<keyof Course> = [];
+    const requiredFields: Array<keyof Course> = [
+      'title',
+      'description',
+      'price',
+      'imageUrl',
+      'difficulty',
+    ];
+
+    for (const field of requiredFields) {
+      if (!course[field]) {
+        missingFields.push(field);
+      }
+    }
+
+    if (missingFields.length) {
+      throw new BadRequestException(
+        `Cannot publish course: missing required fields: ${missingFields.join(', ')}`,
+      );
+    }
   }
 }


### PR DESCRIPTION
# Summary

This PR refactores the `CourseDto` and `updateOne` method to prevent courses publishing with empty fields either on database or in request's body.

# Details

- Updated the `CourseDto` with conditional validation depending on course status.
- Changed the `updateOne` method to verify required fields when trying to publish a drafted course.