### PR TITLE
feat: Add payment method module with CRUD routes

### DIFF
--- a/data/migrations/1751303908600-addPaymentMethodTable.ts
+++ b/data/migrations/1751303908600-addPaymentMethodTable.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddPaymentMethodTable1751303908600 implements MigrationInterface {
+    name = 'AddPaymentMethodTable1751303908600'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "payment_method" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "name" character varying(20) NOT NULL, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), "deleted_at" TIMESTAMP, CONSTRAINT "UQ_6101666760258a840e115e1bb11" UNIQUE ("name"), CONSTRAINT "PK_7744c2b2dd932c9cf42f2b9bc3a" PRIMARY KEY ("id"))`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE "payment_method"`);
+    }
+
+}

--- a/src/common/base/infrastructure/exception/entity-already-excists.exception.ts
+++ b/src/common/base/infrastructure/exception/entity-already-excists.exception.ts
@@ -1,0 +1,9 @@
+import { ConflictException } from '@nestjs/common';
+
+class EntityAlreadyExistsException extends ConflictException {
+  constructor(key: string, value: string) {
+    super(`Entity with ${key} '${value}' already exists`);
+  }
+}
+
+export default EntityAlreadyExistsException;

--- a/src/common/transformers/string.transformer.ts
+++ b/src/common/transformers/string.transformer.ts
@@ -1,0 +1,28 @@
+export class StringTransformer {
+  static toKebabCase(string: string): string {
+    if (!string || typeof string !== 'string') return '';
+
+    return string
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .replace(/([a-z])([A-Z])/g, '$1-$2')
+      .replace(/[^a-zA-Z0-9\s-]/g, '')
+      .toLowerCase()
+      .replace(/[\s-]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+  }
+
+  static toSeparatedWords(input: string): string {
+    if (!input || typeof input !== 'string') return '';
+
+    return input
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .replace(/([a-z])([A-Z])/g, '$1 $2')
+      .replace(/[_-]/g, ' ')
+      .replace(/[^a-zA-Z0-9\s]/g, '')
+      .toLowerCase()
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+}

--- a/src/module/app.module.ts
+++ b/src/module/app.module.ts
@@ -11,6 +11,7 @@ import { CloudModule } from '@module/cloud/cloud.module';
 import { CourseModule } from '@module/course/course.module';
 import { IamModule } from '@module/iam/iam.module';
 import { LessonModule } from '@module/lesson/lesson.module';
+import { PaymentMethodModule } from '@module/payment-method/payment-method.module';
 import { SectionModule } from '@module/section/section.module';
 
 @Global()
@@ -31,6 +32,7 @@ import { SectionModule } from '@module/section/section.module';
     CourseModule,
     SectionModule,
     LessonModule,
+    PaymentMethodModule,
   ],
   providers: [LinkBuilderService, SlugService],
   exports: [LinkBuilderService, SlugService],

--- a/src/module/payment-method/__test__/fixture/PaymentMethod.yml
+++ b/src/module/payment-method/__test__/fixture/PaymentMethod.yml
@@ -1,0 +1,9 @@
+entity: PaymentMethod
+items:
+  payment-method1:
+    id: '361cb833-1f51-4b21-b5e9-1089c5d09b09'
+    name: 'Stellar'
+  payment-method2:
+    name: '{{person.firstName}}'
+  payment-method{3..23}:
+    name: '{{person.firstName}}'

--- a/src/module/payment-method/__test__/fixture/User.yml
+++ b/src/module/payment-method/__test__/fixture/User.yml
@@ -1,0 +1,24 @@
+entity: User
+items:
+  super-admin-user:
+    firstName: super-admin-name
+    lastName: super-admin-surname
+    email: 'test_super_admin@email.co'
+    avatarUrl: '{{internet.url}}'
+    externalId: '00000000-0000-0000-0000-00000000000X'
+    roles: regular,admin,superAdmin
+  admin-user:
+    id: a90108bf-42c6-481f-a63f-4b51fed1300c
+    firstName: admin-name
+    lastName: admin-surname
+    email: 'test_admin@email.co'
+    avatarUrl: '{{internet.url}}'
+    externalId: '00000000-0000-0000-0000-00000000000Y'
+    roles: regular,admin
+  regular-user:
+    firstName: regular-name
+    lastName: regular-surname
+    email: 'test_regular@email.co'
+    avatarUrl: '{{internet.url}}'
+    externalId: '00000000-0000-0000-0000-00000000000Z'
+    roles: regular

--- a/src/module/payment-method/__test__/payment-method.e2e.spec.ts
+++ b/src/module/payment-method/__test__/payment-method.e2e.spec.ts
@@ -1,0 +1,541 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { HttpStatus } from '@nestjs/common';
+import { NestExpressApplication } from '@nestjs/platform-express';
+import request from 'supertest';
+
+import { loadFixtures } from '@data/util/fixture-loader';
+
+import {
+  SerializedResponseDto,
+  SerializedResponseDtoCollection,
+} from '@common/base/application/dto/serialized-response.dto';
+import { SuccessOperationResponseDto } from '@common/base/application/dto/success-operation-response.dto';
+import { HttpMethod } from '@common/base/application/enum/http-method.enum';
+
+import { setupApp } from '@config/app.config';
+import { datasourceOptions } from '@config/orm.config';
+
+import { testModuleBootstrapper } from '@test/test.module.bootstrapper';
+import { createAccessToken } from '@test/test.util';
+
+import { CreatePaymentMethodDto } from '@module/payment-method/application/dto/create-payment-method.dto';
+import { PaymentMethodResponseDto } from '@module/payment-method/application/dto/payment-method-response.dto';
+import { PaymentMethodDto } from '@module/payment-method/application/dto/payment-method.dto';
+import { UpdatePaymentMethodDto } from '@module/payment-method/application/dto/update-payment-method.dto';
+
+describe('PaymentMethod Module', () => {
+  let app: NestExpressApplication;
+
+  const regularToken = createAccessToken({
+    sub: '00000000-0000-0000-0000-00000000000Z',
+  });
+  const superAdminToken = createAccessToken({
+    sub: '00000000-0000-0000-0000-00000000000Z',
+  });
+
+  beforeAll(async () => {
+    await loadFixtures(`${__dirname}/fixture`, datasourceOptions);
+    const moduleRef = await testModuleBootstrapper();
+    app = moduleRef.createNestApplication({ logger: false });
+    setupApp(app);
+    await app.init();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  const endpoint = '/api/v1/payment-method';
+
+  describe('GET - /payment-method', () => {
+    it('Should return paginated payment methods', async () => {
+      return await request(app.getHttpServer())
+        .get(endpoint)
+        .auth(regularToken, { type: 'bearer' })
+        .expect(HttpStatus.OK)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            data: expect.arrayContaining([
+              expect.objectContaining({
+                id: expect.any(String),
+                type: 'payment-method',
+                attributes: expect.objectContaining({
+                  name: expect.any(String),
+                }),
+              }),
+            ]),
+            links: expect.arrayContaining([
+              expect.objectContaining({
+                rel: 'self',
+                href: expect.any(String),
+                method: HttpMethod.GET,
+              }),
+              expect.objectContaining({
+                rel: 'first',
+                href: expect.any(String),
+                method: HttpMethod.GET,
+              }),
+              expect.objectContaining({
+                rel: 'last',
+                href: expect.any(String),
+                method: HttpMethod.GET,
+              }),
+              expect.objectContaining({
+                rel: 'next',
+                href: expect.any(String),
+                method: HttpMethod.GET,
+              }),
+            ]),
+            meta: expect.objectContaining({
+              pageNumber: expect.any(Number),
+              pageSize: expect.any(Number),
+              pageCount: expect.any(Number),
+              itemCount: expect.any(Number),
+            }),
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should allow to filter by attributes', async () => {
+      const name = 'Stellar';
+      return request(app.getHttpServer())
+        .get(`${endpoint}?filter[name]=${name}`)
+        .auth(regularToken, { type: 'bearer' })
+        .expect(HttpStatus.OK)
+        .then(
+          ({
+            body,
+          }: {
+            body: SerializedResponseDtoCollection<PaymentMethodResponseDto>;
+          }) => {
+            const expectedResponse = expect.objectContaining({
+              data: expect.arrayContaining([
+                expect.objectContaining({
+                  attributes: expect.objectContaining({
+                    name,
+                  }),
+                }),
+              ]),
+            });
+            expect(body).toEqual(expectedResponse);
+            expect(body.data).toHaveLength(1);
+          },
+        );
+    });
+
+    it('Should allow to sort by attributes', async () => {
+      const firstPaymentMethod = { name: '' } as PaymentMethodDto;
+      const lastPaymentMethod = { name: '' } as PaymentMethodDto;
+      let pageCount: number = 0;
+
+      await request(app.getHttpServer())
+        .get(`${endpoint}?sort[name]=DESC&page[size]=10`)
+        .auth(regularToken, { type: 'bearer' })
+        .expect(HttpStatus.OK)
+        .then(
+          ({
+            body,
+          }: {
+            body: SerializedResponseDtoCollection<PaymentMethodResponseDto>;
+          }) => {
+            firstPaymentMethod.name = body.data[0].attributes.name;
+            pageCount = body.meta.pageCount;
+          },
+        );
+
+      await request(app.getHttpServer())
+        .get(
+          `${endpoint}?page[size]=10&sort[name]=ASC&page[number]=${pageCount}`,
+        )
+        .auth(regularToken, { type: 'bearer' })
+        .expect(HttpStatus.OK)
+        .then(
+          ({
+            body,
+          }: {
+            body: SerializedResponseDtoCollection<PaymentMethodResponseDto>;
+          }) => {
+            const resources = body.data;
+            lastPaymentMethod.name =
+              resources[resources.length - 1].attributes.name;
+            expect(lastPaymentMethod.name).toBe(firstPaymentMethod.name);
+          },
+        );
+    });
+
+    it('Should allow to select specific attributes', async () => {
+      const attributes = ['name'] as (keyof PaymentMethodDto)[];
+
+      await request(app.getHttpServer())
+        .get(`${endpoint}?page[size]=10&fields[target]=${attributes.join(',')}`)
+        .auth(regularToken, { type: 'bearer' })
+        .expect(HttpStatus.OK)
+        .then(
+          ({
+            body,
+          }: {
+            body: SerializedResponseDtoCollection<PaymentMethodResponseDto>;
+          }) => {
+            const resourceAttributes = body.data[0].attributes;
+            expect(Object.keys(resourceAttributes).length).toBe(
+              attributes.length,
+            );
+            expect(resourceAttributes).toEqual({
+              name: expect.any(String),
+            });
+          },
+        );
+    });
+  });
+
+  describe('GET - /payment-method/:id', () => {
+    it('Should return a payment method by its id', async () => {
+      const paymentMethodId = '361cb833-1f51-4b21-b5e9-1089c5d09b09';
+      await request(app.getHttpServer())
+        .get(`${endpoint}/${paymentMethodId}`)
+        .auth(regularToken, { type: 'bearer' })
+        .expect(HttpStatus.OK)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            data: expect.objectContaining({
+              type: 'payment-method',
+              id: paymentMethodId,
+              attributes: expect.objectContaining({
+                name: 'Stellar',
+              }),
+            }),
+            links: expect.arrayContaining([
+              expect.objectContaining({
+                rel: 'self',
+                href: expect.stringContaining(`${endpoint}/${paymentMethodId}`),
+                method: HttpMethod.GET,
+              }),
+            ]),
+          });
+
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should throw an error if payment method is not found', async () => {
+      const nonExistingPaymentMethodId = '22f38dae-00f1-49ff-8f3f-0dd6539af039';
+      await request(app.getHttpServer())
+        .get(`${endpoint}/${nonExistingPaymentMethodId}`)
+        .auth(regularToken, { type: 'bearer' })
+        .expect(HttpStatus.NOT_FOUND)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `Entity with id ${nonExistingPaymentMethodId} not found`,
+              source: {
+                pointer: `${endpoint}/${nonExistingPaymentMethodId}`,
+              },
+              status: HttpStatus.NOT_FOUND.toString(),
+              title: 'Entity not found',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+  });
+
+  describe('POST - /payment-method', () => {
+    it('Should create a new payment method', async () => {
+      const createPaymentMethod = {
+        name: 'Mercado Pago',
+      } as CreatePaymentMethodDto;
+
+      await request(app.getHttpServer())
+        .post(endpoint)
+        .auth(superAdminToken, { type: 'bearer' })
+        .send(createPaymentMethod)
+        .expect(HttpStatus.CREATED)
+        .then(
+          ({
+            body,
+          }: {
+            body: SerializedResponseDto<PaymentMethodResponseDto>;
+          }) => {
+            const expectedResponse = {
+              data: expect.objectContaining({
+                type: 'payment-method',
+                id: expect.any(String),
+                attributes: expect.objectContaining({
+                  name: createPaymentMethod.name,
+                }),
+              }),
+              links: expect.arrayContaining([
+                expect.objectContaining({
+                  href: expect.stringContaining(endpoint),
+                  rel: 'self',
+                  method: HttpMethod.POST,
+                }),
+              ]),
+            };
+            expect(body).toEqual(expectedResponse);
+          },
+        );
+    });
+
+    it('Should throw an error when the payment method name already exists', async () => {
+      const createPaymentMethod = {
+        name: 'Debit Card',
+      } as CreatePaymentMethodDto;
+
+      await request(app.getHttpServer())
+        .post(endpoint)
+        .auth(superAdminToken, { type: 'bearer' })
+        .send(createPaymentMethod)
+        .expect(HttpStatus.CREATED)
+        .then(
+          ({
+            body,
+          }: {
+            body: SerializedResponseDto<PaymentMethodResponseDto>;
+          }) => {
+            const expectedResponse = {
+              data: expect.objectContaining({
+                type: 'payment-method',
+                id: expect.any(String),
+                attributes: expect.objectContaining({
+                  name: createPaymentMethod.name,
+                }),
+              }),
+              links: expect.arrayContaining([
+                expect.objectContaining({
+                  href: expect.stringContaining(endpoint),
+                  rel: 'self',
+                  method: HttpMethod.POST,
+                }),
+              ]),
+            };
+            expect(body).toEqual(expectedResponse);
+          },
+        );
+
+      return await request(app.getHttpServer())
+        .post(endpoint)
+        .auth(superAdminToken, { type: 'bearer' })
+        .send(createPaymentMethod)
+        .expect(HttpStatus.CONFLICT)
+        .then(
+          ({
+            body,
+          }: {
+            body: SerializedResponseDto<PaymentMethodResponseDto>;
+          }) => {
+            const expectedResponse = expect.objectContaining({
+              error: {
+                detail: `Entity with name '${createPaymentMethod.name}' already exists`,
+                source: {
+                  pointer: endpoint,
+                },
+                status: HttpStatus.CONFLICT.toString(),
+                title: 'Entity already exists',
+              },
+            });
+            expect(body).toEqual(expectedResponse);
+          },
+        );
+    });
+  });
+
+  describe('PATCH - /payment-method/:id', () => {
+    it('Should update an existing payment method', async () => {
+      const createPaymentMethod = {
+        name: 'Stripe',
+      } as CreatePaymentMethodDto;
+
+      const updatePaymentMethod = {
+        name: 'credit-card',
+      } as UpdatePaymentMethodDto;
+
+      let paymentMethodId: string = '';
+
+      await request(app.getHttpServer())
+        .post(endpoint)
+        .auth(superAdminToken, { type: 'bearer' })
+        .send(createPaymentMethod)
+        .expect(HttpStatus.CREATED)
+        .then(
+          ({
+            body,
+          }: {
+            body: SerializedResponseDto<PaymentMethodResponseDto>;
+          }) => {
+            paymentMethodId = body.data.id as string;
+
+            const expectedResponse = {
+              data: expect.objectContaining({
+                type: 'payment-method',
+                id: expect.any(String),
+                attributes: expect.objectContaining({
+                  name: createPaymentMethod.name,
+                }),
+              }),
+              links: expect.arrayContaining([
+                expect.objectContaining({
+                  href: expect.stringContaining(endpoint),
+                  rel: 'self',
+                  method: HttpMethod.POST,
+                }),
+              ]),
+            };
+            expect(body).toEqual(expectedResponse);
+          },
+        );
+
+      await request(app.getHttpServer())
+        .patch(`${endpoint}/${paymentMethodId}`)
+        .auth(superAdminToken, { type: 'bearer' })
+        .send(updatePaymentMethod)
+        .expect(HttpStatus.OK)
+        .then(
+          ({
+            body,
+          }: {
+            body: SerializedResponseDto<PaymentMethodResponseDto>;
+          }) => {
+            const expectedResponse = expect.objectContaining({
+              data: expect.objectContaining({
+                type: 'payment-method',
+                id: expect.any(String),
+                attributes: expect.objectContaining({
+                  name: updatePaymentMethod.name,
+                }),
+              }),
+              links: expect.arrayContaining([
+                expect.objectContaining({
+                  href: expect.stringContaining(endpoint),
+                  rel: 'self',
+                  method: HttpMethod.PATCH,
+                }),
+              ]),
+            });
+            expect(body).toEqual(expectedResponse);
+          },
+        );
+    });
+
+    it('Should throw an error if payment method to update is not found', async () => {
+      const nonExistingPaymentMethodId = '22f38dae-00f1-49ff-8f3f-0dd6539af039';
+
+      await request(app.getHttpServer())
+        .patch(`${endpoint}/${nonExistingPaymentMethodId}`)
+        .auth(superAdminToken, { type: 'bearer' })
+        .expect(HttpStatus.NOT_FOUND)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `Entity with id ${nonExistingPaymentMethodId} not found`,
+              source: {
+                pointer: `${endpoint}/${nonExistingPaymentMethodId}`,
+              },
+              status: '404',
+              title: 'Entity not found',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+  });
+
+  describe('DELETE - /payment-method/:id', () => {
+    it('Should delete an existing payment method', async () => {
+      const createPaymentMethod = {
+        name: 'Stripe',
+      } as CreatePaymentMethodDto;
+      let paymentMethodId: string = '';
+
+      await request(app.getHttpServer())
+        .post(endpoint)
+        .auth(superAdminToken, { type: 'bearer' })
+        .send(createPaymentMethod)
+        .expect(HttpStatus.CREATED)
+        .then(
+          ({
+            body,
+          }: {
+            body: SerializedResponseDto<PaymentMethodResponseDto>;
+          }) => {
+            paymentMethodId = body.data.id as string;
+
+            const expectedResponse = {
+              data: expect.objectContaining({
+                type: 'payment-method',
+                id: expect.any(String),
+                attributes: expect.objectContaining({
+                  name: createPaymentMethod.name,
+                }),
+              }),
+              links: expect.arrayContaining([
+                expect.objectContaining({
+                  href: expect.stringContaining(endpoint),
+                  rel: 'self',
+                  method: HttpMethod.POST,
+                }),
+              ]),
+            };
+            expect(body).toEqual(expectedResponse);
+          },
+        );
+
+      await request(app.getHttpServer())
+        .delete(`${endpoint}/${paymentMethodId}`)
+        .auth(superAdminToken, { type: 'bearer' })
+        .expect(HttpStatus.OK)
+        .then(
+          ({
+            body,
+          }: {
+            body: SerializedResponseDto<SuccessOperationResponseDto>;
+          }) => {
+            const expectedResponse = expect.objectContaining({
+              data: expect.objectContaining({
+                type: 'operation',
+                attributes: expect.objectContaining({
+                  message: `The payment method with id ${paymentMethodId} has been deleted successfully`,
+                  success: true,
+                }),
+              }),
+              links: expect.arrayContaining([
+                expect.objectContaining({
+                  href: expect.stringContaining(endpoint),
+                  rel: 'self',
+                  method: HttpMethod.DELETE,
+                }),
+              ]),
+            });
+            expect(body).toEqual(expectedResponse);
+          },
+        );
+    });
+
+    it('Should throw an error if payment method to delete is not found', async () => {
+      const nonExistingPaymentMethodId = '22f38dae-00f1-49ff-8f3f-0dd6539af039';
+
+      await request(app.getHttpServer())
+        .delete(`${endpoint}/${nonExistingPaymentMethodId}`)
+        .auth(superAdminToken, { type: 'bearer' })
+        .expect(HttpStatus.NOT_FOUND)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `Entity with id ${nonExistingPaymentMethodId} not found`,
+              source: {
+                pointer: `${endpoint}/${nonExistingPaymentMethodId}`,
+              },
+              status: '404',
+              title: 'Entity not found',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+  });
+});

--- a/src/module/payment-method/application/dto/create-payment-method.dto.ts
+++ b/src/module/payment-method/application/dto/create-payment-method.dto.ts
@@ -1,0 +1,3 @@
+import { PaymentMethodDto } from '@module/payment-method/application/dto/payment-method.dto';
+
+export class CreatePaymentMethodDto extends PaymentMethodDto {}

--- a/src/module/payment-method/application/dto/payment-method-response.dto.ts
+++ b/src/module/payment-method/application/dto/payment-method-response.dto.ts
@@ -1,0 +1,10 @@
+import { BaseResponseDto } from '@common/base/application/dto/base.response.dto';
+
+export class PaymentMethodResponseDto extends BaseResponseDto {
+  name: string;
+
+  constructor(type: string, name: string, id?: string) {
+    super(type, id);
+    this.name = name;
+  }
+}

--- a/src/module/payment-method/application/dto/payment-method.dto.ts
+++ b/src/module/payment-method/application/dto/payment-method.dto.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsString, MaxLength, MinLength } from 'class-validator';
+
+import { BaseDto } from '@common/base/application/dto/base.dto';
+
+export class PaymentMethodDto extends BaseDto {
+  @IsNotEmpty()
+  @MinLength(2, { message: 'Name must be at least 2 characters long' })
+  @MaxLength(20, { message: 'Name cannot be longer than 20 characters' })
+  @IsString()
+  name!: string;
+}

--- a/src/module/payment-method/application/dto/query-params/payment-method-fields-query-params.dto.ts
+++ b/src/module/payment-method/application/dto/query-params/payment-method-fields-query-params.dto.ts
@@ -1,0 +1,20 @@
+import { Transform } from 'class-transformer';
+import { IsIn, IsOptional } from 'class-validator';
+
+import { IGetAllOptions } from '@common/base/application/dto/get-all-options.interface';
+import { fromCommaSeparatedToArray } from '@common/base/application/mapper/base.mapper';
+
+import { PaymentMethod } from '@module/payment-method/domain/payment-method.entity';
+
+type PaymentMethodFields = IGetAllOptions<PaymentMethod>['fields'];
+
+export class PaymentMethodFieldsQueryParamsDto {
+  @IsIn(['id', 'name', 'createdAt', 'updatedAt', 'deletedAt'], {
+    each: true,
+  })
+  @Transform((params) => {
+    return fromCommaSeparatedToArray(params.value as string);
+  })
+  @IsOptional()
+  target?: PaymentMethodFields;
+}

--- a/src/module/payment-method/application/dto/query-params/payment-method-filter-query-params.dto.ts
+++ b/src/module/payment-method/application/dto/query-params/payment-method-filter-query-params.dto.ts
@@ -1,0 +1,7 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class PaymentMethodFilterQueryParamsDto {
+  @IsString()
+  @IsOptional()
+  name?: string;
+}

--- a/src/module/payment-method/application/dto/query-params/payment-method-sort-query-params.dto.ts
+++ b/src/module/payment-method/application/dto/query-params/payment-method-sort-query-params.dto.ts
@@ -1,0 +1,17 @@
+import { IsEnum, IsOptional } from 'class-validator';
+
+import { SortType } from '@common/base/application/enum/sort-type.enum';
+
+export class PaymentMethodSortQueryParamsDto {
+  @IsEnum(SortType)
+  @IsOptional()
+  name?: SortType;
+
+  @IsEnum(SortType)
+  @IsOptional()
+  createdAt?: SortType;
+
+  @IsEnum(SortType)
+  @IsOptional()
+  updatedAt?: SortType;
+}

--- a/src/module/payment-method/application/dto/update-payment-method.dto.ts
+++ b/src/module/payment-method/application/dto/update-payment-method.dto.ts
@@ -1,0 +1,7 @@
+import { PartialType } from '@nestjs/mapped-types';
+
+import { CreatePaymentMethodDto } from '@module/payment-method/application/dto/create-payment-method.dto';
+
+export class UpdatePaymentMethodDto extends PartialType(
+  CreatePaymentMethodDto,
+) {}

--- a/src/module/payment-method/application/mapper/payment-method.mapper.ts
+++ b/src/module/payment-method/application/mapper/payment-method.mapper.ts
@@ -1,0 +1,40 @@
+import { IDtoMapper } from '@common/base/application/dto/dto.interface';
+import { StringTransformer } from '@common/transformers/string.transformer';
+
+import { CreatePaymentMethodDto } from '@module/payment-method/application/dto/create-payment-method.dto';
+import { PaymentMethodResponseDto } from '@module/payment-method/application/dto/payment-method-response.dto';
+import { UpdatePaymentMethodDto } from '@module/payment-method/application/dto/update-payment-method.dto';
+import { PaymentMethod } from '@module/payment-method/domain/payment-method.entity';
+
+export class PaymentMethodMapper
+  implements
+    IDtoMapper<
+      PaymentMethod,
+      CreatePaymentMethodDto,
+      UpdatePaymentMethodDto,
+      PaymentMethodResponseDto
+    >
+{
+  fromCreateDtoToEntity(dto: CreatePaymentMethodDto): PaymentMethod {
+    const { id, name } = dto;
+
+    return new PaymentMethod(name, id);
+  }
+
+  fromEntityToResponseDto(entity: PaymentMethod): PaymentMethodResponseDto {
+    const { name, id } = entity;
+
+    return new PaymentMethodResponseDto(
+      StringTransformer.toKebabCase(PaymentMethod.name),
+      name,
+      id,
+    );
+  }
+
+  fromUpdateDtoToEntity(
+    entity: PaymentMethod,
+    dto: UpdatePaymentMethodDto,
+  ): PaymentMethod {
+    return new PaymentMethod(dto.name ?? entity.name, dto.id ?? entity.id);
+  }
+}

--- a/src/module/payment-method/application/repository/payment-method-repository.interface.ts
+++ b/src/module/payment-method/application/repository/payment-method-repository.interface.ts
@@ -1,0 +1,10 @@
+import BaseRepository from '@common/base/infrastructure/database/base.repository';
+
+import { PaymentMethod } from '@module/payment-method/domain/payment-method.entity';
+
+export const PAYMENT_METHOD_REPOSITORY_KEY = 'payment_method_repository';
+
+export interface IPaymentMethodRepository
+  extends BaseRepository<PaymentMethod> {
+  findByName(name: string): Promise<PaymentMethod | null>;
+}

--- a/src/module/payment-method/application/service/payment-method-crud.service.ts
+++ b/src/module/payment-method/application/service/payment-method-crud.service.ts
@@ -1,0 +1,34 @@
+import { Inject, Injectable } from '@nestjs/common';
+
+import { BaseCRUDService } from '@common/base/application/service/base-crud.service';
+import { StringTransformer } from '@common/transformers/string.transformer';
+
+import { CreatePaymentMethodDto } from '@module/payment-method/application/dto/create-payment-method.dto';
+import { PaymentMethodResponseDto } from '@module/payment-method/application/dto/payment-method-response.dto';
+import { UpdatePaymentMethodDto } from '@module/payment-method/application/dto/update-payment-method.dto';
+import { PaymentMethodMapper } from '@module/payment-method/application/mapper/payment-method.mapper';
+import {
+  IPaymentMethodRepository,
+  PAYMENT_METHOD_REPOSITORY_KEY,
+} from '@module/payment-method/application/repository/payment-method-repository.interface';
+import { PaymentMethod } from '@module/payment-method/domain/payment-method.entity';
+
+@Injectable()
+export class PaymentMethodCRUDService extends BaseCRUDService<
+  PaymentMethod,
+  CreatePaymentMethodDto,
+  UpdatePaymentMethodDto,
+  PaymentMethodResponseDto
+> {
+  constructor(
+    @Inject(PAYMENT_METHOD_REPOSITORY_KEY)
+    private readonly paymentMethodRepository: IPaymentMethodRepository,
+    private readonly paymentMethodMapper: PaymentMethodMapper,
+  ) {
+    super(
+      paymentMethodRepository,
+      paymentMethodMapper,
+      StringTransformer.toSeparatedWords(PaymentMethod.name),
+    );
+  }
+}

--- a/src/module/payment-method/domain/payment-method.entity.ts
+++ b/src/module/payment-method/domain/payment-method.entity.ts
@@ -1,0 +1,10 @@
+import { Base } from '@common/base/domain/base.entity';
+
+export class PaymentMethod extends Base {
+  name: string;
+
+  constructor(name: string, id?: string) {
+    super(id);
+    this.name = name;
+  }
+}

--- a/src/module/payment-method/infrastructure/database/payment-method.postgres.repository.ts
+++ b/src/module/payment-method/infrastructure/database/payment-method.postgres.repository.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import BaseRepository from '@common/base/infrastructure/database/base.repository';
+import EntityAlreadyExistsException from '@common/base/infrastructure/exception/entity-already-excists.exception';
+
+import { IPaymentMethodRepository } from '@module/payment-method/application/repository/payment-method-repository.interface';
+import { PaymentMethod } from '@module/payment-method/domain/payment-method.entity';
+import { PaymentMethodSchema } from '@module/payment-method/infrastructure/database/payment-method.schema';
+
+@Injectable()
+export class PaymentMethodPostgresRepository
+  extends BaseRepository<PaymentMethod>
+  implements IPaymentMethodRepository
+{
+  constructor(
+    @InjectRepository(PaymentMethodSchema)
+    protected readonly repository: Repository<PaymentMethod>,
+  ) {
+    super(repository);
+  }
+
+  async findByName(name: string): Promise<PaymentMethod | null> {
+    const paymentMethod = await this.repository.findOne({
+      where: { name },
+    });
+
+    return paymentMethod;
+  }
+
+  async saveOne(entity: PaymentMethod): Promise<PaymentMethod> {
+    const { name } = entity;
+    const paymentMethod = await this.findByName(name);
+
+    if (paymentMethod) {
+      throw new EntityAlreadyExistsException('name', name);
+    }
+
+    return this.repository.save(entity);
+  }
+}

--- a/src/module/payment-method/infrastructure/database/payment-method.schema.ts
+++ b/src/module/payment-method/infrastructure/database/payment-method.schema.ts
@@ -1,0 +1,18 @@
+import { EntitySchema } from 'typeorm';
+
+import { withBaseSchemaColumns } from '@common/base/infrastructure/database/base.schema';
+
+import { PaymentMethod } from '@module/payment-method/domain/payment-method.entity';
+
+export const PaymentMethodSchema = new EntitySchema<PaymentMethod>({
+  name: PaymentMethod.name,
+  target: PaymentMethod,
+  tableName: 'payment_method',
+  columns: withBaseSchemaColumns({
+    name: {
+      type: String,
+      length: 20,
+      unique: true,
+    },
+  }),
+});

--- a/src/module/payment-method/interface/payment-method.controller.ts
+++ b/src/module/payment-method/interface/payment-method.controller.ts
@@ -1,0 +1,77 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  Query,
+} from '@nestjs/common';
+
+import { CollectionDto } from '@common/base/application/dto/collection.dto';
+import { PageQueryParamsDto } from '@common/base/application/dto/page-query-params';
+import { SuccessOperationResponseDto } from '@common/base/application/dto/success-operation-response.dto';
+
+import { CreatePaymentMethodDto } from '@module/payment-method/application/dto/create-payment-method.dto';
+import { PaymentMethodResponseDto } from '@module/payment-method/application/dto/payment-method-response.dto';
+import { PaymentMethodFieldsQueryParamsDto } from '@module/payment-method/application/dto/query-params/payment-method-fields-query-params.dto';
+import { PaymentMethodFilterQueryParamsDto } from '@module/payment-method/application/dto/query-params/payment-method-filter-query-params.dto';
+import { PaymentMethodSortQueryParamsDto } from '@module/payment-method/application/dto/query-params/payment-method-sort-query-params.dto';
+import { UpdatePaymentMethodDto } from '@module/payment-method/application/dto/update-payment-method.dto';
+import { PaymentMethodCRUDService } from '@module/payment-method/application/service/payment-method-crud.service';
+
+@Controller('payment-method')
+export class PaymentMethodController {
+  constructor(
+    private readonly paymentMethodService: PaymentMethodCRUDService,
+  ) {}
+
+  @Get()
+  async getAll(
+    @Query('page') page: PageQueryParamsDto,
+    @Query('filter') filter: PaymentMethodFilterQueryParamsDto,
+    @Query('fields') fields: PaymentMethodFieldsQueryParamsDto,
+    @Query('sort') sort: PaymentMethodSortQueryParamsDto,
+  ): Promise<CollectionDto<PaymentMethodResponseDto>> {
+    return await this.paymentMethodService.getAll({
+      page,
+      filter,
+      fields: fields.target,
+      sort,
+    });
+  }
+
+  @Get(':id')
+  async getOneById(
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<PaymentMethodResponseDto> {
+    return this.paymentMethodService.getOneByIdOrFail(id);
+  }
+
+  @Post()
+  async saveOne(
+    @Body() createPaymentMethodDto: CreatePaymentMethodDto,
+  ): Promise<PaymentMethodResponseDto> {
+    return await this.paymentMethodService.saveOne(createPaymentMethodDto);
+  }
+
+  @Patch(':id')
+  async updateOne(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() updatePaymentMethodDto: UpdatePaymentMethodDto,
+  ): Promise<PaymentMethodResponseDto> {
+    return await this.paymentMethodService.updateOne(
+      id,
+      updatePaymentMethodDto,
+    );
+  }
+
+  @Delete(':id')
+  async deleteOne(
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<SuccessOperationResponseDto> {
+    return this.paymentMethodService.deleteOneByIdOrFail(id);
+  }
+}

--- a/src/module/payment-method/payment-method.module.ts
+++ b/src/module/payment-method/payment-method.module.ts
@@ -1,0 +1,25 @@
+import { Module, Provider } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { PaymentMethodMapper } from '@module/payment-method/application/mapper/payment-method.mapper';
+import { PAYMENT_METHOD_REPOSITORY_KEY } from '@module/payment-method/application/repository/payment-method-repository.interface';
+import { PaymentMethodCRUDService } from '@module/payment-method/application/service/payment-method-crud.service';
+import { PaymentMethodPostgresRepository } from '@module/payment-method/infrastructure/database/payment-method.postgres.repository';
+import { PaymentMethodSchema } from '@module/payment-method/infrastructure/database/payment-method.schema';
+import { PaymentMethodController } from '@module/payment-method/interface/payment-method.controller';
+
+const paymentMethodRepositoryProvider: Provider = {
+  provide: PAYMENT_METHOD_REPOSITORY_KEY,
+  useClass: PaymentMethodPostgresRepository,
+};
+
+@Module({
+  imports: [TypeOrmModule.forFeature([PaymentMethodSchema])],
+  providers: [
+    PaymentMethodCRUDService,
+    PaymentMethodMapper,
+    paymentMethodRepositoryProvider,
+  ],
+  controllers: [PaymentMethodController],
+})
+export class PaymentMethodModule {}


### PR DESCRIPTION
# Summary

This PR introduces the `PaymentMethod` module with CRUD operations.

# Details

- Added the `PaymentMethod` domain and schema entities.
- Implemented a Postgres repository for the `PaymentMethod` entity.
- Created DTOs for create/update `PaymentMethod`'s requests.
- Added DTOs for the `PaymentMethod` getAll method's query params.
- Created a mapper to transform `PaymentModule` entities and DTOs.
- Designed a `PaymentMethodController` with CRUD route handlers. 