### PR TITLE
feat: Add payment method permissions

### DIFF
--- a/src/module/iam/authorization/infrastructure/casl/type/app-subjects.type.ts
+++ b/src/module/iam/authorization/infrastructure/casl/type/app-subjects.type.ts
@@ -3,6 +3,7 @@ import { InferSubjects } from '@casl/ability';
 import { Course } from '@module/course/domain/course.entity';
 import { User } from '@module/iam/user/domain/user.entity';
 import { Lesson } from '@module/lesson/domain/lesson.entity';
+import { PaymentMethod } from '@module/payment-method/domain/payment-method.entity';
 import { Section } from '@module/section/domain/section.entity';
 
 export type AppSubjects =
@@ -15,5 +16,7 @@ export type AppSubjects =
       | Section
       | typeof Lesson
       | Lesson
+      | typeof PaymentMethod
+      | PaymentMethod
     >
   | 'all';

--- a/src/module/payment-method/__test__/payment-method.e2e.spec.ts
+++ b/src/module/payment-method/__test__/payment-method.e2e.spec.ts
@@ -503,6 +503,101 @@ describe('PaymentMethod Module', () => {
           expect(body).toEqual(expectedResponse);
         });
     });
+
+    it('Should deny access to non-super-admin users', async () => {
+      const createPaymentMethod = {
+        name: 'Payment method',
+      } as CreatePaymentMethodDto;
+
+      const updatePaymentMethod = {
+        name: 'credit-card',
+      } as UpdatePaymentMethodDto;
+
+      let paymentMethodId: string = '';
+
+      await request(app.getHttpServer())
+        .post(endpoint)
+        .auth(superAdminToken, { type: 'bearer' })
+        .send(createPaymentMethod)
+        .expect(HttpStatus.CREATED)
+        .then(
+          ({
+            body,
+          }: {
+            body: SerializedResponseDto<PaymentMethodResponseDto>;
+          }) => {
+            paymentMethodId = body.data.id as string;
+
+            const expectedResponse = {
+              data: expect.objectContaining({
+                type: 'payment-method',
+                id: expect.any(String),
+                attributes: expect.objectContaining({
+                  name: createPaymentMethod.name,
+                }),
+              }),
+              links: expect.arrayContaining([
+                expect.objectContaining({
+                  href: expect.stringContaining(endpoint),
+                  rel: 'self',
+                  method: HttpMethod.POST,
+                }),
+              ]),
+            };
+            expect(body).toEqual(expectedResponse);
+          },
+        );
+
+      await request(app.getHttpServer())
+        .patch(`${endpoint}/${paymentMethodId}`)
+        .auth(regularToken, { type: 'bearer' })
+        .send(updatePaymentMethod)
+        .expect(HttpStatus.FORBIDDEN)
+        .then(
+          ({
+            body,
+          }: {
+            body: SerializedResponseDto<PaymentMethodResponseDto>;
+          }) => {
+            const expectedResponse = expect.objectContaining({
+              error: {
+                detail: `You are not allowed to ${AppAction.Update.toUpperCase()} this resource`,
+                source: {
+                  pointer: `${endpoint}/${paymentMethodId}`,
+                },
+                status: HttpStatus.FORBIDDEN.toString(),
+                title: 'Forbidden',
+              },
+            });
+            expect(body).toEqual(expectedResponse);
+          },
+        );
+
+      return await request(app.getHttpServer())
+        .patch(`${endpoint}/${paymentMethodId}`)
+        .auth(adminToken, { type: 'bearer' })
+        .send(updatePaymentMethod)
+        .expect(HttpStatus.FORBIDDEN)
+        .then(
+          ({
+            body,
+          }: {
+            body: SerializedResponseDto<PaymentMethodResponseDto>;
+          }) => {
+            const expectedResponse = expect.objectContaining({
+              error: {
+                detail: `You are not allowed to ${AppAction.Update.toUpperCase()} this resource`,
+                source: {
+                  pointer: `${endpoint}/${paymentMethodId}`,
+                },
+                status: HttpStatus.FORBIDDEN.toString(),
+                title: 'Forbidden',
+              },
+            });
+            expect(body).toEqual(expectedResponse);
+          },
+        );
+    });
   });
 
   describe('DELETE - /payment-method/:id', () => {

--- a/src/module/payment-method/application/policy/create-payment-method-policy.handler.ts
+++ b/src/module/payment-method/application/policy/create-payment-method-policy.handler.ts
@@ -1,0 +1,41 @@
+import { ForbiddenException, Injectable } from '@nestjs/common';
+import { Request } from 'express';
+
+import { BasePolicyHandler } from '@module/iam/authorization/application/policy/base-policy.handler';
+import { AuthorizationService } from '@module/iam/authorization/application/service/authorization.service';
+import { AppAction } from '@module/iam/authorization/domain/app.action.enum';
+import { IPolicyHandler } from '@module/iam/authorization/infrastructure/policy/handler/policy-handler.interface';
+import { PolicyHandlerStorage } from '@module/iam/authorization/infrastructure/policy/storage/policies-handler.storage';
+import { PaymentMethod } from '@module/payment-method/domain/payment-method.entity';
+
+@Injectable()
+export class CreatePaymentMethodPolicyHandler
+  extends BasePolicyHandler
+  implements IPolicyHandler
+{
+  private readonly action = AppAction.Create;
+
+  constructor(
+    private readonly policyHandlerStorage: PolicyHandlerStorage,
+    private readonly authorizationService: AuthorizationService,
+  ) {
+    super();
+    this.policyHandlerStorage.add(CreatePaymentMethodPolicyHandler, this);
+  }
+
+  handle(request: Request): Promise<void> | void {
+    const user = this.getCurrentUser(request);
+    console.log(user);
+    const isAllowed = this.authorizationService.isAllowed(
+      user,
+      this.action,
+      PaymentMethod,
+    );
+    console.log(isAllowed);
+    if (!isAllowed) {
+      throw new ForbiddenException(
+        `You are not allowed to ${this.action.toUpperCase()} this resource`,
+      );
+    }
+  }
+}

--- a/src/module/payment-method/application/policy/create-payment-method-policy.handler.ts
+++ b/src/module/payment-method/application/policy/create-payment-method-policy.handler.ts
@@ -25,13 +25,13 @@ export class CreatePaymentMethodPolicyHandler
 
   handle(request: Request): Promise<void> | void {
     const user = this.getCurrentUser(request);
-    console.log(user);
+
     const isAllowed = this.authorizationService.isAllowed(
       user,
       this.action,
       PaymentMethod,
     );
-    console.log(isAllowed);
+
     if (!isAllowed) {
       throw new ForbiddenException(
         `You are not allowed to ${this.action.toUpperCase()} this resource`,

--- a/src/module/payment-method/application/policy/delete-payment-method-policy.handler.ts
+++ b/src/module/payment-method/application/policy/delete-payment-method-policy.handler.ts
@@ -1,0 +1,41 @@
+import { ForbiddenException, Injectable } from '@nestjs/common';
+import { Request } from 'express';
+
+import { BasePolicyHandler } from '@module/iam/authorization/application/policy/base-policy.handler';
+import { AuthorizationService } from '@module/iam/authorization/application/service/authorization.service';
+import { AppAction } from '@module/iam/authorization/domain/app.action.enum';
+import { IPolicyHandler } from '@module/iam/authorization/infrastructure/policy/handler/policy-handler.interface';
+import { PolicyHandlerStorage } from '@module/iam/authorization/infrastructure/policy/storage/policies-handler.storage';
+import { PaymentMethod } from '@module/payment-method/domain/payment-method.entity';
+
+@Injectable()
+export class DeletePaymentMethodPolicyHandler
+  extends BasePolicyHandler
+  implements IPolicyHandler
+{
+  private readonly action = AppAction.Delete;
+
+  constructor(
+    private readonly policyHandlerStorage: PolicyHandlerStorage,
+    private readonly authorizationService: AuthorizationService,
+  ) {
+    super();
+    this.policyHandlerStorage.add(DeletePaymentMethodPolicyHandler, this);
+  }
+
+  handle(request: Request): Promise<void> | void {
+    const user = this.getCurrentUser(request);
+
+    const isAllowed = this.authorizationService.isAllowed(
+      user,
+      this.action,
+      PaymentMethod,
+    );
+
+    if (!isAllowed) {
+      throw new ForbiddenException(
+        `You are not allowed to ${this.action.toUpperCase()} this resource`,
+      );
+    }
+  }
+}

--- a/src/module/payment-method/application/policy/update-payment-method-policy.handler.ts
+++ b/src/module/payment-method/application/policy/update-payment-method-policy.handler.ts
@@ -1,0 +1,41 @@
+import { ForbiddenException, Injectable } from '@nestjs/common';
+import { Request } from 'express';
+
+import { BasePolicyHandler } from '@module/iam/authorization/application/policy/base-policy.handler';
+import { AuthorizationService } from '@module/iam/authorization/application/service/authorization.service';
+import { AppAction } from '@module/iam/authorization/domain/app.action.enum';
+import { IPolicyHandler } from '@module/iam/authorization/infrastructure/policy/handler/policy-handler.interface';
+import { PolicyHandlerStorage } from '@module/iam/authorization/infrastructure/policy/storage/policies-handler.storage';
+import { PaymentMethod } from '@module/payment-method/domain/payment-method.entity';
+
+@Injectable()
+export class UpdatePaymentMethodPolicyHandler
+  extends BasePolicyHandler
+  implements IPolicyHandler
+{
+  private readonly action = AppAction.Update;
+
+  constructor(
+    private readonly policyHandlerStorage: PolicyHandlerStorage,
+    private readonly authorizationService: AuthorizationService,
+  ) {
+    super();
+    this.policyHandlerStorage.add(UpdatePaymentMethodPolicyHandler, this);
+  }
+
+  handle(request: Request): Promise<void> | void {
+    const user = this.getCurrentUser(request);
+
+    const isAllowed = this.authorizationService.isAllowed(
+      user,
+      this.action,
+      PaymentMethod,
+    );
+
+    if (!isAllowed) {
+      throw new ForbiddenException(
+        `You are not allowed to ${this.action.toUpperCase()} this resource`,
+      );
+    }
+  }
+}

--- a/src/module/payment-method/domain/payment-method.permissions.ts
+++ b/src/module/payment-method/domain/payment-method.permissions.ts
@@ -1,0 +1,16 @@
+import { AppRole } from '@module/iam/authorization/domain/app-role.enum';
+import { AppAction } from '@module/iam/authorization/domain/app.action.enum';
+import { IPermissionsDefinition } from '@module/iam/authorization/infrastructure/policy/type/permissions-definition.interface';
+import { PaymentMethod } from '@module/payment-method/domain/payment-method.entity';
+
+export const paymentMethodPermissions: IPermissionsDefinition = {
+  [AppRole.Regular](_, { can }) {
+    can(AppAction.Read, PaymentMethod);
+  },
+  [AppRole.Admin](_, { can }) {
+    can(AppAction.Read, PaymentMethod);
+  },
+  [AppRole.SuperAdmin](_, { can }) {
+    can(AppAction.Manage, PaymentMethod);
+  },
+};

--- a/src/module/payment-method/interface/payment-method.controller.ts
+++ b/src/module/payment-method/interface/payment-method.controller.ts
@@ -8,21 +8,26 @@ import {
   Patch,
   Post,
   Query,
+  UseGuards,
 } from '@nestjs/common';
 
 import { CollectionDto } from '@common/base/application/dto/collection.dto';
 import { PageQueryParamsDto } from '@common/base/application/dto/page-query-params';
 import { SuccessOperationResponseDto } from '@common/base/application/dto/success-operation-response.dto';
 
+import { Policies } from '@module/iam/authorization/infrastructure/policy/decorator/policy.decorator';
+import { PoliciesGuard } from '@module/iam/authorization/infrastructure/policy/guard/policy.guard';
 import { CreatePaymentMethodDto } from '@module/payment-method/application/dto/create-payment-method.dto';
 import { PaymentMethodResponseDto } from '@module/payment-method/application/dto/payment-method-response.dto';
 import { PaymentMethodFieldsQueryParamsDto } from '@module/payment-method/application/dto/query-params/payment-method-fields-query-params.dto';
 import { PaymentMethodFilterQueryParamsDto } from '@module/payment-method/application/dto/query-params/payment-method-filter-query-params.dto';
 import { PaymentMethodSortQueryParamsDto } from '@module/payment-method/application/dto/query-params/payment-method-sort-query-params.dto';
 import { UpdatePaymentMethodDto } from '@module/payment-method/application/dto/update-payment-method.dto';
+import { CreatePaymentMethodPolicyHandler } from '@module/payment-method/application/policy/create-payment-method-policy.handler';
 import { PaymentMethodCRUDService } from '@module/payment-method/application/service/payment-method-crud.service';
 
 @Controller('payment-method')
+@UseGuards(PoliciesGuard)
 export class PaymentMethodController {
   constructor(
     private readonly paymentMethodService: PaymentMethodCRUDService,
@@ -51,6 +56,7 @@ export class PaymentMethodController {
   }
 
   @Post()
+  @Policies(CreatePaymentMethodPolicyHandler)
   async saveOne(
     @Body() createPaymentMethodDto: CreatePaymentMethodDto,
   ): Promise<PaymentMethodResponseDto> {

--- a/src/module/payment-method/interface/payment-method.controller.ts
+++ b/src/module/payment-method/interface/payment-method.controller.ts
@@ -24,6 +24,7 @@ import { PaymentMethodFilterQueryParamsDto } from '@module/payment-method/applic
 import { PaymentMethodSortQueryParamsDto } from '@module/payment-method/application/dto/query-params/payment-method-sort-query-params.dto';
 import { UpdatePaymentMethodDto } from '@module/payment-method/application/dto/update-payment-method.dto';
 import { CreatePaymentMethodPolicyHandler } from '@module/payment-method/application/policy/create-payment-method-policy.handler';
+import { UpdatePaymentMethodPolicyHandler } from '@module/payment-method/application/policy/update-payment-method-policy.handler';
 import { PaymentMethodCRUDService } from '@module/payment-method/application/service/payment-method-crud.service';
 
 @Controller('payment-method')
@@ -64,6 +65,7 @@ export class PaymentMethodController {
   }
 
   @Patch(':id')
+  @Policies(UpdatePaymentMethodPolicyHandler)
   async updateOne(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() updatePaymentMethodDto: UpdatePaymentMethodDto,

--- a/src/module/payment-method/interface/payment-method.controller.ts
+++ b/src/module/payment-method/interface/payment-method.controller.ts
@@ -24,6 +24,7 @@ import { PaymentMethodFilterQueryParamsDto } from '@module/payment-method/applic
 import { PaymentMethodSortQueryParamsDto } from '@module/payment-method/application/dto/query-params/payment-method-sort-query-params.dto';
 import { UpdatePaymentMethodDto } from '@module/payment-method/application/dto/update-payment-method.dto';
 import { CreatePaymentMethodPolicyHandler } from '@module/payment-method/application/policy/create-payment-method-policy.handler';
+import { DeletePaymentMethodPolicyHandler } from '@module/payment-method/application/policy/delete-payment-method-policy.handler';
 import { UpdatePaymentMethodPolicyHandler } from '@module/payment-method/application/policy/update-payment-method-policy.handler';
 import { PaymentMethodCRUDService } from '@module/payment-method/application/service/payment-method-crud.service';
 
@@ -77,6 +78,7 @@ export class PaymentMethodController {
   }
 
   @Delete(':id')
+  @Policies(DeletePaymentMethodPolicyHandler)
   async deleteOne(
     @Param('id', ParseUUIDPipe) id: string,
   ): Promise<SuccessOperationResponseDto> {

--- a/src/module/payment-method/payment-method.module.ts
+++ b/src/module/payment-method/payment-method.module.ts
@@ -4,6 +4,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthorizationModule } from '@module/iam/authorization/authorization.module';
 import { AppSubjectPermissionStorage } from '@module/iam/authorization/infrastructure/casl/storage/app-subject-permissions-storage';
 import { PaymentMethodMapper } from '@module/payment-method/application/mapper/payment-method.mapper';
+import { CreatePaymentMethodPolicyHandler } from '@module/payment-method/application/policy/create-payment-method-policy.handler';
 import { PAYMENT_METHOD_REPOSITORY_KEY } from '@module/payment-method/application/repository/payment-method-repository.interface';
 import { PaymentMethodCRUDService } from '@module/payment-method/application/service/payment-method-crud.service';
 import { PaymentMethod } from '@module/payment-method/domain/payment-method.entity';
@@ -17,6 +18,8 @@ const paymentMethodRepositoryProvider: Provider = {
   useClass: PaymentMethodPostgresRepository,
 };
 
+const policyHandlersProviders = [CreatePaymentMethodPolicyHandler];
+
 @Module({
   imports: [
     TypeOrmModule.forFeature([PaymentMethodSchema]),
@@ -26,6 +29,7 @@ const paymentMethodRepositoryProvider: Provider = {
     PaymentMethodCRUDService,
     PaymentMethodMapper,
     paymentMethodRepositoryProvider,
+    ...policyHandlersProviders,
   ],
   controllers: [PaymentMethodController],
 })

--- a/src/module/payment-method/payment-method.module.ts
+++ b/src/module/payment-method/payment-method.module.ts
@@ -5,6 +5,7 @@ import { AuthorizationModule } from '@module/iam/authorization/authorization.mod
 import { AppSubjectPermissionStorage } from '@module/iam/authorization/infrastructure/casl/storage/app-subject-permissions-storage';
 import { PaymentMethodMapper } from '@module/payment-method/application/mapper/payment-method.mapper';
 import { CreatePaymentMethodPolicyHandler } from '@module/payment-method/application/policy/create-payment-method-policy.handler';
+import { UpdatePaymentMethodPolicyHandler } from '@module/payment-method/application/policy/update-payment-method-policy.handler';
 import { PAYMENT_METHOD_REPOSITORY_KEY } from '@module/payment-method/application/repository/payment-method-repository.interface';
 import { PaymentMethodCRUDService } from '@module/payment-method/application/service/payment-method-crud.service';
 import { PaymentMethod } from '@module/payment-method/domain/payment-method.entity';
@@ -18,7 +19,10 @@ const paymentMethodRepositoryProvider: Provider = {
   useClass: PaymentMethodPostgresRepository,
 };
 
-const policyHandlersProviders = [CreatePaymentMethodPolicyHandler];
+const policyHandlersProviders = [
+  CreatePaymentMethodPolicyHandler,
+  UpdatePaymentMethodPolicyHandler,
+];
 
 @Module({
   imports: [

--- a/src/module/payment-method/payment-method.module.ts
+++ b/src/module/payment-method/payment-method.module.ts
@@ -5,6 +5,7 @@ import { AuthorizationModule } from '@module/iam/authorization/authorization.mod
 import { AppSubjectPermissionStorage } from '@module/iam/authorization/infrastructure/casl/storage/app-subject-permissions-storage';
 import { PaymentMethodMapper } from '@module/payment-method/application/mapper/payment-method.mapper';
 import { CreatePaymentMethodPolicyHandler } from '@module/payment-method/application/policy/create-payment-method-policy.handler';
+import { DeletePaymentMethodPolicyHandler } from '@module/payment-method/application/policy/delete-payment-method-policy.handler';
 import { UpdatePaymentMethodPolicyHandler } from '@module/payment-method/application/policy/update-payment-method-policy.handler';
 import { PAYMENT_METHOD_REPOSITORY_KEY } from '@module/payment-method/application/repository/payment-method-repository.interface';
 import { PaymentMethodCRUDService } from '@module/payment-method/application/service/payment-method-crud.service';
@@ -22,6 +23,7 @@ const paymentMethodRepositoryProvider: Provider = {
 const policyHandlersProviders = [
   CreatePaymentMethodPolicyHandler,
   UpdatePaymentMethodPolicyHandler,
+  DeletePaymentMethodPolicyHandler,
 ];
 
 @Module({


### PR DESCRIPTION
# Summary

This PR introduces `PaymentMethod` permissions to validate creation, updates and deletes requests.

# Details

- Implemented `PaymentMethod` permissions definition for `regular`, `admin` and `superAdmin` users.
- Created the `Create`, `Update` and `Delete` policy handers to validate the user from the request based on its roles.