### PR TITLE
feat: Add hypermedia links to payment method routes

### DIFF
--- a/src/module/payment-method/__test__/payment-method.e2e.spec.ts
+++ b/src/module/payment-method/__test__/payment-method.e2e.spec.ts
@@ -219,6 +219,21 @@ describe('PaymentMethod Module', () => {
                 href: expect.stringContaining(`${endpoint}/${paymentMethodId}`),
                 method: HttpMethod.GET,
               }),
+              expect.objectContaining({
+                rel: 'create-payment-method',
+                href: expect.stringContaining(endpoint),
+                method: HttpMethod.POST,
+              }),
+              expect.objectContaining({
+                rel: 'update-payment-method',
+                href: expect.stringContaining(`${endpoint}/${paymentMethodId}`),
+                method: HttpMethod.PATCH,
+              }),
+              expect.objectContaining({
+                rel: 'delete-payment-method',
+                href: expect.stringContaining(`${endpoint}/${paymentMethodId}`),
+                method: HttpMethod.DELETE,
+              }),
             ]),
           });
 
@@ -253,6 +268,7 @@ describe('PaymentMethod Module', () => {
       const createPaymentMethod = {
         name: 'Mercado Pago',
       } as CreatePaymentMethodDto;
+      let paymentMethodId = '';
 
       await request(app.getHttpServer())
         .post(endpoint)
@@ -265,6 +281,7 @@ describe('PaymentMethod Module', () => {
           }: {
             body: SerializedResponseDto<PaymentMethodResponseDto>;
           }) => {
+            paymentMethodId = body.data.id as string;
             const expectedResponse = {
               data: expect.objectContaining({
                 type: 'payment-method',
@@ -278,6 +295,27 @@ describe('PaymentMethod Module', () => {
                   href: expect.stringContaining(endpoint),
                   rel: 'self',
                   method: HttpMethod.POST,
+                }),
+                expect.objectContaining({
+                  rel: 'get-payment-method',
+                  href: expect.stringContaining(
+                    `${endpoint}/${paymentMethodId}`,
+                  ),
+                  method: HttpMethod.GET,
+                }),
+                expect.objectContaining({
+                  rel: 'update-payment-method',
+                  href: expect.stringContaining(
+                    `${endpoint}/${paymentMethodId}`,
+                  ),
+                  method: HttpMethod.PATCH,
+                }),
+                expect.objectContaining({
+                  rel: 'delete-payment-method',
+                  href: expect.stringContaining(
+                    `${endpoint}/${paymentMethodId}`,
+                  ),
+                  method: HttpMethod.DELETE,
                 }),
               ]),
             };
@@ -475,6 +513,25 @@ describe('PaymentMethod Module', () => {
                   rel: 'self',
                   method: HttpMethod.PATCH,
                 }),
+                expect.objectContaining({
+                  rel: 'get-payment-method',
+                  href: expect.stringContaining(
+                    `${endpoint}/${paymentMethodId}`,
+                  ),
+                  method: HttpMethod.GET,
+                }),
+                expect.objectContaining({
+                  rel: 'create-payment-method',
+                  href: expect.stringContaining(endpoint),
+                  method: HttpMethod.POST,
+                }),
+                expect.objectContaining({
+                  rel: 'delete-payment-method',
+                  href: expect.stringContaining(
+                    `${endpoint}/${paymentMethodId}`,
+                  ),
+                  method: HttpMethod.DELETE,
+                }),
               ]),
             });
             expect(body).toEqual(expectedResponse);
@@ -663,6 +720,11 @@ describe('PaymentMethod Module', () => {
                   href: expect.stringContaining(endpoint),
                   rel: 'self',
                   method: HttpMethod.DELETE,
+                }),
+                expect.objectContaining({
+                  rel: 'create-payment-method',
+                  href: expect.stringContaining(endpoint),
+                  method: HttpMethod.POST,
                 }),
               ]),
             });

--- a/src/module/payment-method/interface/payment-method.controller.ts
+++ b/src/module/payment-method/interface/payment-method.controller.ts
@@ -11,9 +11,11 @@ import {
   UseGuards,
 } from '@nestjs/common';
 
+import { Hypermedia } from '@common/base/application/decorator/hypermedia.decorator';
 import { CollectionDto } from '@common/base/application/dto/collection.dto';
 import { PageQueryParamsDto } from '@common/base/application/dto/page-query-params';
 import { SuccessOperationResponseDto } from '@common/base/application/dto/success-operation-response.dto';
+import { HttpMethod } from '@common/base/application/enum/http-method.enum';
 
 import { Policies } from '@module/iam/authorization/infrastructure/policy/decorator/policy.decorator';
 import { PoliciesGuard } from '@module/iam/authorization/infrastructure/policy/guard/policy.guard';
@@ -51,6 +53,23 @@ export class PaymentMethodController {
   }
 
   @Get(':id')
+  @Hypermedia([
+    {
+      endpoint: '/payment-method',
+      rel: 'create-payment-method',
+      method: HttpMethod.POST,
+    },
+    {
+      endpoint: '/payment-method/:id',
+      rel: 'update-payment-method',
+      method: HttpMethod.PATCH,
+    },
+    {
+      endpoint: '/payment-method/:id',
+      rel: 'delete-payment-method',
+      method: HttpMethod.DELETE,
+    },
+  ])
   async getOneById(
     @Param('id', ParseUUIDPipe) id: string,
   ): Promise<PaymentMethodResponseDto> {
@@ -58,6 +77,23 @@ export class PaymentMethodController {
   }
 
   @Post()
+  @Hypermedia([
+    {
+      endpoint: '/payment-method/:id',
+      rel: 'get-payment-method',
+      method: HttpMethod.GET,
+    },
+    {
+      endpoint: '/payment-method/:id',
+      rel: 'update-payment-method',
+      method: HttpMethod.PATCH,
+    },
+    {
+      endpoint: '/payment-method/:id',
+      rel: 'delete-payment-method',
+      method: HttpMethod.DELETE,
+    },
+  ])
   @Policies(CreatePaymentMethodPolicyHandler)
   async saveOne(
     @Body() createPaymentMethodDto: CreatePaymentMethodDto,
@@ -66,6 +102,23 @@ export class PaymentMethodController {
   }
 
   @Patch(':id')
+  @Hypermedia([
+    {
+      endpoint: '/payment-method/:id',
+      rel: 'get-payment-method',
+      method: HttpMethod.GET,
+    },
+    {
+      endpoint: '/payment-method/:id',
+      rel: 'create-payment-method',
+      method: HttpMethod.POST,
+    },
+    {
+      endpoint: '/payment-method/:id',
+      rel: 'delete-payment-method',
+      method: HttpMethod.DELETE,
+    },
+  ])
   @Policies(UpdatePaymentMethodPolicyHandler)
   async updateOne(
     @Param('id', ParseUUIDPipe) id: string,
@@ -78,6 +131,13 @@ export class PaymentMethodController {
   }
 
   @Delete(':id')
+  @Hypermedia([
+    {
+      endpoint: '/payment-method/:id',
+      rel: 'create-payment-method',
+      method: HttpMethod.POST,
+    },
+  ])
   @Policies(DeletePaymentMethodPolicyHandler)
   async deleteOne(
     @Param('id', ParseUUIDPipe) id: string,


### PR DESCRIPTION
# Summary

This PR introduces hypermedia links to the `PaymentMethodController`'s route handlers.

# Details

- Updated the `PaymentMethodController` with hypermedia links by using `@Hypermedia()` decorator.
- Updated the `PaymentMethodModule` tests to verify hypermedia links on responses.