### PR TITLE
feat: Add category module

### DIFF
--- a/data/migrations/1751474291125-addCategoryTable.ts
+++ b/data/migrations/1751474291125-addCategoryTable.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddCategoryTable1751474291125 implements MigrationInterface {
+    name = 'AddCategoryTable1751474291125'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "category" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "name" character varying(60) NOT NULL, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), "deleted_at" TIMESTAMP, CONSTRAINT "PK_9c4e4a89e3674fc9f382d733f03" PRIMARY KEY ("id"))`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE "category"`);
+    }
+
+}

--- a/src/module/app.module.ts
+++ b/src/module/app.module.ts
@@ -7,6 +7,7 @@ import { datasourceOptions } from '@config/orm.config';
 
 import { LinkBuilderService } from '@module/app/application/service/link-builder.service';
 import { SlugService } from '@module/app/application/service/slug.service';
+import { CategoryModule } from '@module/category/category.module';
 import { CloudModule } from '@module/cloud/cloud.module';
 import { CourseModule } from '@module/course/course.module';
 import { IamModule } from '@module/iam/iam.module';
@@ -33,6 +34,7 @@ import { SectionModule } from '@module/section/section.module';
     SectionModule,
     LessonModule,
     PaymentMethodModule,
+    CategoryModule,
   ],
   providers: [LinkBuilderService, SlugService],
   exports: [LinkBuilderService, SlugService],

--- a/src/module/category/__test__/category.e2e.spec.ts
+++ b/src/module/category/__test__/category.e2e.spec.ts
@@ -1,0 +1,330 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { HttpStatus } from '@nestjs/common';
+import { NestExpressApplication } from '@nestjs/platform-express';
+import request from 'supertest';
+
+import { loadFixtures } from '@data/util/fixture-loader';
+
+import { SerializedResponseDto } from '@common/base/application/dto/serialized-response.dto';
+import { HttpMethod } from '@common/base/application/enum/http-method.enum';
+
+import { setupApp } from '@config/app.config';
+import { datasourceOptions } from '@config/orm.config';
+
+import { testModuleBootstrapper } from '@test/test.module.bootstrapper';
+import { createAccessToken } from '@test/test.util';
+
+import { CategoryResponseDto } from '@module/category/application/dto/category-response.dto';
+import { CreateCategoryDto } from '@module/category/application/dto/create-category.dto';
+import { UpdateCategoryDto } from '@module/category/application/dto/update-category.dto';
+
+describe('Category Module', () => {
+  let app: NestExpressApplication;
+
+  const regularToken = createAccessToken({
+    sub: '00000000-0000-0000-0000-00000000000Z',
+  });
+
+  const superAdminToken = createAccessToken({
+    sub: '00000000-0000-0000-0000-00000000000X',
+  });
+
+  beforeAll(async () => {
+    await loadFixtures(`${__dirname}/fixture`, datasourceOptions);
+    const moduleRef = await testModuleBootstrapper();
+    app = moduleRef.createNestApplication({ logger: false });
+    setupApp(app);
+    await app.init();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  const endpoint = '/api/v1/category';
+
+  describe('GET - /category/:id', () => {
+    it('Should return a category by its id', async () => {
+      const categoryId = '5fb9c427-2551-4787-81c4-b6c603175f45';
+      await request(app.getHttpServer())
+        .get(`${endpoint}/${categoryId}`)
+        .auth(regularToken, { type: 'bearer' })
+        .expect(HttpStatus.OK)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            data: expect.objectContaining({
+              type: 'category',
+              id: categoryId,
+              attributes: expect.objectContaining({
+                name: 'JavaScript',
+              }),
+            }),
+            links: expect.arrayContaining([
+              expect.objectContaining({
+                rel: 'self',
+                href: expect.stringContaining(`${endpoint}/${categoryId}`),
+                method: HttpMethod.GET,
+              }),
+            ]),
+          });
+
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should throw an error if category is not found', async () => {
+      const nonExistingCategoryId = '22f38dae-00f1-49ff-8f3f-0dd6539af039';
+      await request(app.getHttpServer())
+        .get(`${endpoint}/${nonExistingCategoryId}`)
+        .auth(regularToken, { type: 'bearer' })
+        .expect(HttpStatus.NOT_FOUND)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `Entity with id ${nonExistingCategoryId} not found`,
+              source: {
+                pointer: `${endpoint}/${nonExistingCategoryId}`,
+              },
+              status: HttpStatus.NOT_FOUND.toString(),
+              title: 'Entity not found',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+  });
+
+  describe('POST - /category', () => {
+    it('Should create a new category', async () => {
+      const createCategoryDto = {
+        name: 'Design',
+      } as CreateCategoryDto;
+
+      await request(app.getHttpServer())
+        .post(endpoint)
+        .auth(superAdminToken, { type: 'bearer' })
+        .send(createCategoryDto)
+        .expect(HttpStatus.CREATED)
+        .then(({ body }) => {
+          const expectedResponse = {
+            data: expect.objectContaining({
+              type: 'category',
+              id: expect.any(String),
+              attributes: expect.objectContaining({
+                name: createCategoryDto.name,
+              }),
+            }),
+            links: expect.arrayContaining([
+              expect.objectContaining({
+                href: expect.stringContaining(endpoint),
+                rel: 'self',
+                method: HttpMethod.POST,
+              }),
+            ]),
+          };
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+  });
+
+  describe('PATCH - /category/:id', () => {
+    it('Should update an existing category', async () => {
+      const createCategoryDto = {
+        name: 'Mathematicss',
+      } as CreateCategoryDto;
+
+      const updateCategoryDto = {
+        name: 'Mathematics',
+      } as UpdateCategoryDto;
+
+      let categoryId: string = '';
+
+      await request(app.getHttpServer())
+        .post(endpoint)
+        .auth(superAdminToken, { type: 'bearer' })
+        .send(createCategoryDto)
+        .expect(HttpStatus.CREATED)
+        .then(
+          ({ body }: { body: SerializedResponseDto<CategoryResponseDto> }) => {
+            categoryId = body.data.id as string;
+
+            const expectedResponse = {
+              data: expect.objectContaining({
+                type: 'category',
+                id: expect.any(String),
+                attributes: expect.objectContaining({
+                  name: createCategoryDto.name,
+                }),
+              }),
+              links: expect.arrayContaining([
+                expect.objectContaining({
+                  href: expect.stringContaining(endpoint),
+                  rel: 'self',
+                  method: HttpMethod.POST,
+                }),
+              ]),
+            };
+            expect(body).toEqual(expectedResponse);
+          },
+        );
+
+      await request(app.getHttpServer())
+        .patch(`${endpoint}/${categoryId}`)
+        .auth(superAdminToken, { type: 'bearer' })
+        .send(updateCategoryDto)
+        .expect(HttpStatus.OK)
+        .then(
+          ({ body }: { body: SerializedResponseDto<CategoryResponseDto> }) => {
+            const expectedResponse = {
+              data: expect.objectContaining({
+                type: 'category',
+                id: expect.any(String),
+                attributes: expect.objectContaining({
+                  name: updateCategoryDto.name,
+                }),
+              }),
+              links: expect.arrayContaining([
+                expect.objectContaining({
+                  href: expect.stringContaining(`${endpoint}/${categoryId}`),
+                  rel: 'self',
+                  method: HttpMethod.PATCH,
+                }),
+              ]),
+            };
+            expect(body).toEqual(expectedResponse);
+          },
+        );
+    });
+
+    it('Should throw an error if category to update is not found', async () => {
+      const nonExistingCategoryId = '22f38dae-00f1-49ff-8f3f-0dd6539af039';
+
+      await request(app.getHttpServer())
+        .patch(`${endpoint}/${nonExistingCategoryId}`)
+        .auth(superAdminToken, { type: 'bearer' })
+        .expect(HttpStatus.NOT_FOUND)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `Entity with id ${nonExistingCategoryId} not found`,
+              source: {
+                pointer: `${endpoint}/${nonExistingCategoryId}`,
+              },
+              status: '404',
+              title: 'Entity not found',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+  });
+
+  describe('DELETE - /category/:id', () => {
+    it('Should delete an existing category', async () => {
+      const createCategoryDto = {
+        name: 'Mathematicss',
+      } as CreateCategoryDto;
+
+      let categoryId: string = '';
+
+      await request(app.getHttpServer())
+        .post(endpoint)
+        .auth(superAdminToken, { type: 'bearer' })
+        .send(createCategoryDto)
+        .expect(HttpStatus.CREATED)
+        .then(
+          ({ body }: { body: SerializedResponseDto<CategoryResponseDto> }) => {
+            categoryId = body.data.id as string;
+
+            const expectedResponse = {
+              data: expect.objectContaining({
+                type: 'category',
+                id: expect.any(String),
+                attributes: expect.objectContaining({
+                  name: createCategoryDto.name,
+                }),
+              }),
+              links: expect.arrayContaining([
+                expect.objectContaining({
+                  href: expect.stringContaining(endpoint),
+                  rel: 'self',
+                  method: HttpMethod.POST,
+                }),
+              ]),
+            };
+            expect(body).toEqual(expectedResponse);
+          },
+        );
+
+      await request(app.getHttpServer())
+        .delete(`${endpoint}/${categoryId}`)
+        .auth(superAdminToken, { type: 'bearer' })
+        .expect(HttpStatus.OK)
+        .then(
+          ({ body }: { body: SerializedResponseDto<CategoryResponseDto> }) => {
+            const expectedResponse = {
+              data: expect.objectContaining({
+                type: 'operation',
+                attributes: expect.objectContaining({
+                  message: `The category with id ${categoryId} has been deleted successfully`,
+                  success: true,
+                }),
+              }),
+              links: expect.arrayContaining([
+                expect.objectContaining({
+                  href: expect.stringContaining(`${endpoint}/${categoryId}`),
+                  rel: 'self',
+                  method: HttpMethod.DELETE,
+                }),
+              ]),
+            };
+            expect(body).toEqual(expectedResponse);
+          },
+        );
+
+      await request(app.getHttpServer())
+        .get(`${endpoint}/${categoryId}`)
+        .auth(superAdminToken, { type: 'bearer' })
+        .expect(HttpStatus.NOT_FOUND)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `Entity with id ${categoryId} not found`,
+              source: {
+                pointer: `${endpoint}/${categoryId}`,
+              },
+              status: HttpStatus.NOT_FOUND.toString(),
+              title: 'Entity not found',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should throw an error if category to delete is not found', async () => {
+      const nonExistingCategoryId = '22f38dae-00f1-49ff-8f3f-0dd6539af039';
+
+      await request(app.getHttpServer())
+        .delete(`${endpoint}/${nonExistingCategoryId}`)
+        .auth(superAdminToken, { type: 'bearer' })
+        .expect(HttpStatus.NOT_FOUND)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `Entity with id ${nonExistingCategoryId} not found`,
+              source: {
+                pointer: `${endpoint}/${nonExistingCategoryId}`,
+              },
+              status: HttpStatus.NOT_FOUND.toString(),
+              title: 'Entity not found',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+  });
+});

--- a/src/module/category/__test__/fixture/Category.yml
+++ b/src/module/category/__test__/fixture/Category.yml
@@ -1,0 +1,12 @@
+entity: Category
+items:
+  category1:
+    id: '2d915994-8c06-425c-9a64-23a7b2b8603e'
+    name: 'Programming'
+  category2:
+    id: '5fb9c427-2551-4787-81c4-b6c603175f45'
+    name: 'JavaScript'
+  category3:
+    name: 'Algorithms'
+  category{4..23}:
+    name: '{{person.firstName}}'

--- a/src/module/category/__test__/fixture/User.yml
+++ b/src/module/category/__test__/fixture/User.yml
@@ -1,0 +1,24 @@
+entity: User
+items:
+  super-admin-user:
+    firstName: super-admin-name
+    lastName: super-admin-surname
+    email: 'test_super_admin@email.co'
+    avatarUrl: '{{internet.url}}'
+    externalId: '00000000-0000-0000-0000-00000000000X'
+    roles: regular,admin,superAdmin
+  admin-user:
+    id: a90108bf-42c6-481f-a63f-4b51fed1300c
+    firstName: admin-name
+    lastName: admin-surname
+    email: 'test_admin@email.co'
+    avatarUrl: '{{internet.url}}'
+    externalId: '00000000-0000-0000-0000-00000000000Y'
+    roles: regular,admin
+  regular-user:
+    firstName: regular-name
+    lastName: regular-surname
+    email: 'test_regular@email.co'
+    avatarUrl: '{{internet.url}}'
+    externalId: '00000000-0000-0000-0000-00000000000Z'
+    roles: regular

--- a/src/module/category/application/dto/category-response.dto.ts
+++ b/src/module/category/application/dto/category-response.dto.ts
@@ -1,0 +1,11 @@
+import { BaseResponseDto } from '@common/base/application/dto/base.response.dto';
+
+export class CategoryResponseDto extends BaseResponseDto {
+  name: string;
+
+  constructor(type: string, name: string, id?: string) {
+    super(type, id);
+
+    this.name = name;
+  }
+}

--- a/src/module/category/application/dto/category.dto.ts
+++ b/src/module/category/application/dto/category.dto.ts
@@ -1,0 +1,9 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+import { BaseDto } from '@common/base/application/dto/base.dto';
+
+export class CategoryDto extends BaseDto {
+  @IsString()
+  @IsNotEmpty()
+  name!: string;
+}

--- a/src/module/category/application/dto/create-category.dto.ts
+++ b/src/module/category/application/dto/create-category.dto.ts
@@ -1,0 +1,3 @@
+import { CategoryDto } from '@module/category/application/dto/category.dto';
+
+export class CreateCategoryDto extends CategoryDto {}

--- a/src/module/category/application/dto/update-category.dto.ts
+++ b/src/module/category/application/dto/update-category.dto.ts
@@ -1,0 +1,5 @@
+import { PartialType } from '@nestjs/mapped-types';
+
+import { CreateCategoryDto } from '@module/category/application/dto/create-category.dto';
+
+export class UpdateCategoryDto extends PartialType(CreateCategoryDto) {}

--- a/src/module/category/application/mapper/category.mapper.ts
+++ b/src/module/category/application/mapper/category.mapper.ts
@@ -1,0 +1,34 @@
+import { IDtoMapper } from '@common/base/application/dto/dto.interface';
+
+import { CategoryResponseDto } from '@module/category/application/dto/category-response.dto';
+import { CreateCategoryDto } from '@module/category/application/dto/create-category.dto';
+import { UpdateCategoryDto } from '@module/category/application/dto/update-category.dto';
+import { Category } from '@module/category/domain/category.entity';
+
+export class CategoryMapper
+  implements
+    IDtoMapper<
+      Category,
+      CreateCategoryDto,
+      UpdateCategoryDto,
+      CategoryResponseDto
+    >
+{
+  fromCreateDtoToEntity(dto: CreateCategoryDto): Category {
+    const { id, name } = dto;
+
+    return new Category(name, id);
+  }
+
+  fromUpdateDtoToEntity(entity: Category, dto: UpdateCategoryDto): Category {
+    const { id } = entity;
+
+    return new Category(dto.name ?? entity.name, id);
+  }
+
+  fromEntityToResponseDto(entity: Category): CategoryResponseDto {
+    const { name, id } = entity;
+
+    return new CategoryResponseDto(Category.getEntityName(), name, id);
+  }
+}

--- a/src/module/category/application/repository/category.repository.interface.ts
+++ b/src/module/category/application/repository/category.repository.interface.ts
@@ -1,0 +1,8 @@
+import BaseRepository from '@common/base/infrastructure/database/base.repository';
+
+import { Category } from '@module/category/domain/category.entity';
+
+export const CATEGORY_REPOSITORY_KEY = 'category_repository';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface ICategoryRepository extends BaseRepository<Category> {}

--- a/src/module/category/application/service/category-crud.service.ts
+++ b/src/module/category/application/service/category-crud.service.ts
@@ -1,0 +1,29 @@
+import { Inject, Injectable } from '@nestjs/common';
+
+import { BaseCRUDService } from '@common/base/application/service/base-crud.service';
+
+import { CategoryResponseDto } from '@module/category/application/dto/category-response.dto';
+import { CreateCategoryDto } from '@module/category/application/dto/create-category.dto';
+import { UpdateCategoryDto } from '@module/category/application/dto/update-category.dto';
+import { CategoryMapper } from '@module/category/application/mapper/category.mapper';
+import {
+  CATEGORY_REPOSITORY_KEY,
+  ICategoryRepository,
+} from '@module/category/application/repository/category.repository.interface';
+import { Category } from '@module/category/domain/category.entity';
+
+@Injectable()
+export class CategoryCRUDService extends BaseCRUDService<
+  Category,
+  CreateCategoryDto,
+  UpdateCategoryDto,
+  CategoryResponseDto
+> {
+  constructor(
+    @Inject(CATEGORY_REPOSITORY_KEY)
+    private readonly categoryRepository: ICategoryRepository,
+    private readonly categoryMapper: CategoryMapper,
+  ) {
+    super(categoryRepository, categoryMapper, Category.getEntityName());
+  }
+}

--- a/src/module/category/category.module.ts
+++ b/src/module/category/category.module.ts
@@ -1,0 +1,21 @@
+import { Module, Provider } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { CategoryMapper } from '@module/category/application/mapper/category.mapper';
+import { CATEGORY_REPOSITORY_KEY } from '@module/category/application/repository/category.repository.interface';
+import { CategoryCRUDService } from '@module/category/application/service/category-crud.service';
+import { CategoryPostgresRepository } from '@module/category/infrastructure/database/category.postgres.repository';
+import { CategorySchema } from '@module/category/infrastructure/database/category.schema';
+import { CategoryController } from '@module/category/interface/category.controller';
+
+const categoryRepositoryProvider: Provider = {
+  provide: CATEGORY_REPOSITORY_KEY,
+  useClass: CategoryPostgresRepository,
+};
+
+@Module({
+  imports: [TypeOrmModule.forFeature([CategorySchema])],
+  providers: [CategoryCRUDService, CategoryMapper, categoryRepositoryProvider],
+  controllers: [CategoryController],
+})
+export class CategoryModule {}

--- a/src/module/category/domain/category.entity.ts
+++ b/src/module/category/domain/category.entity.ts
@@ -1,0 +1,11 @@
+import { Base } from '@common/base/domain/base.entity';
+
+export class Category extends Base {
+  name: string;
+
+  constructor(name: string, id?: string) {
+    super(id);
+
+    this.name = name;
+  }
+}

--- a/src/module/category/infrastructure/database/category.postgres.repository.ts
+++ b/src/module/category/infrastructure/database/category.postgres.repository.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import BaseRepository from '@common/base/infrastructure/database/base.repository';
+
+import { Category } from '@module/category/domain/category.entity';
+import { CategorySchema } from '@module/category/infrastructure/database/category.schema';
+
+@Injectable()
+export class CategoryPostgresRepository extends BaseRepository<Category> {
+  constructor(
+    @InjectRepository(CategorySchema)
+    private readonly categoryRepository: Repository<Category>,
+  ) {
+    super(categoryRepository);
+  }
+}

--- a/src/module/category/infrastructure/database/category.schema.ts
+++ b/src/module/category/infrastructure/database/category.schema.ts
@@ -1,0 +1,17 @@
+import { EntitySchema } from 'typeorm';
+
+import { withBaseSchemaColumns } from '@common/base/infrastructure/database/base.schema';
+
+import { Category } from '@module/category/domain/category.entity';
+
+export const CategorySchema = new EntitySchema<Category>({
+  name: Category.name,
+  target: Category,
+  tableName: 'category',
+  columns: withBaseSchemaColumns({
+    name: {
+      type: String,
+      length: 60,
+    },
+  }),
+});

--- a/src/module/category/interface/category.controller.ts
+++ b/src/module/category/interface/category.controller.ts
@@ -1,0 +1,51 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+} from '@nestjs/common';
+
+import { SuccessOperationResponseDto } from '@common/base/application/dto/success-operation-response.dto';
+
+import { CategoryResponseDto } from '@module/category/application/dto/category-response.dto';
+import { CreateCategoryDto } from '@module/category/application/dto/create-category.dto';
+import { UpdateCategoryDto } from '@module/category/application/dto/update-category.dto';
+import { CategoryCRUDService } from '@module/category/application/service/category-crud.service';
+
+@Controller('category')
+export class CategoryController {
+  constructor(private readonly categoryService: CategoryCRUDService) {}
+
+  @Get(':id')
+  async getOneById(
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<CategoryResponseDto> {
+    return await this.categoryService.getOneByIdOrFail(id);
+  }
+
+  @Post()
+  async saveOne(
+    @Body() createCategoryDto: CreateCategoryDto,
+  ): Promise<CategoryResponseDto> {
+    return await this.categoryService.saveOne(createCategoryDto);
+  }
+
+  @Patch(':id')
+  async updateOne(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() updateCategoryDto: UpdateCategoryDto,
+  ): Promise<CategoryResponseDto> {
+    return await this.categoryService.updateOne(id, updateCategoryDto);
+  }
+
+  @Delete(':id')
+  async deleteOne(
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<SuccessOperationResponseDto> {
+    return await this.categoryService.deleteOneByIdOrFail(id);
+  }
+}


### PR DESCRIPTION
# Summary

This PR introduces the `CategoryModule` with CRUD operations.

# Details

- Added the `Category` domain and schema entities.
- Implemented a Postgres repository for the `Category` entity.
- Created DTOs for create/update `Category`'s requests.
- Added DTOs for the `Category` getAll method's query params.
- Created a mapper to transform `Category` entities and DTOs.
- Designed a `CategoryController` with CRUD route handlers. 