### PR TITLE
feat: Add self referential category relation

### DIFF
--- a/data/migrations/1751491140318-addCategorySelfRelation.ts
+++ b/data/migrations/1751491140318-addCategorySelfRelation.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddCategorySelfRelation1751491140318 implements MigrationInterface {
+    name = 'AddCategorySelfRelation1751491140318'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "category" ADD "parent_id" uuid`);
+        await queryRunner.query(`ALTER TABLE "category" ADD CONSTRAINT "UQ_CATEGORY_PARENT_NAME" UNIQUE ("name", "parent_id")`);
+        await queryRunner.query(`ALTER TABLE "category" ADD CONSTRAINT "FK_1117b4fcb3cd4abb4383e1c2743" FOREIGN KEY ("parent_id") REFERENCES "category"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "category" DROP CONSTRAINT "FK_1117b4fcb3cd4abb4383e1c2743"`);
+        await queryRunner.query(`ALTER TABLE "category" DROP CONSTRAINT "UQ_CATEGORY_PARENT_NAME"`);
+        await queryRunner.query(`ALTER TABLE "category" DROP COLUMN "parent_id"`);
+    }
+
+}

--- a/src/module/category/__test__/category.e2e.spec.ts
+++ b/src/module/category/__test__/category.e2e.spec.ts
@@ -11,12 +11,16 @@ import { HttpMethod } from '@common/base/application/enum/http-method.enum';
 import { setupApp } from '@config/app.config';
 import { datasourceOptions } from '@config/orm.config';
 
-import { testModuleBootstrapper } from '@test/test.module.bootstrapper';
+import {
+  mockTypeOrmRepository,
+  testModuleBootstrapper,
+} from '@test/test.module.bootstrapper';
 import { createAccessToken } from '@test/test.util';
 
 import { CategoryResponseDto } from '@module/category/application/dto/category-response.dto';
 import { CreateCategoryDto } from '@module/category/application/dto/create-category.dto';
 import { UpdateCategoryDto } from '@module/category/application/dto/update-category.dto';
+import { Category } from '@module/category/domain/category.entity';
 
 describe('Category Module', () => {
   let app: NestExpressApplication;
@@ -47,9 +51,29 @@ describe('Category Module', () => {
 
   const endpoint = '/api/v1/category';
 
+  const mockParent = new Category(
+    'Data Structures',
+    'e7a70fc2-5277-492f-bd24-a14ce394a5b8',
+  );
+  const mockFirstSubCategory = new Category(
+    'Algorithms',
+    'feba550d-3713-4f6a-a045-07d0508dc25e',
+    mockParent,
+    [],
+  );
+  const mockSecondSubCategory = new Category(
+    'Sorting',
+    'bd1cf912-6545-4636-8fea-087654f10232',
+    mockFirstSubCategory,
+  );
+
+  mockFirstSubCategory.subCategories?.push(mockSecondSubCategory);
+
   describe('GET - /category/:id', () => {
     it('Should return a category by its id', async () => {
-      const categoryId = '5fb9c427-2551-4787-81c4-b6c603175f45';
+      mockTypeOrmRepository.findOne.mockImplementationOnce(() => mockParent);
+      const categoryId = mockParent.id;
+
       await request(app.getHttpServer())
         .get(`${endpoint}/${categoryId}`)
         .auth(regularToken, { type: 'bearer' })
@@ -60,7 +84,7 @@ describe('Category Module', () => {
               type: 'category',
               id: categoryId,
               attributes: expect.objectContaining({
-                name: 'JavaScript',
+                name: mockParent.name,
               }),
             }),
             links: expect.arrayContaining([
@@ -77,7 +101,9 @@ describe('Category Module', () => {
     });
 
     it('Should throw an error if category is not found', async () => {
+      mockTypeOrmRepository.findOne.mockImplementationOnce(() => null);
       const nonExistingCategoryId = '22f38dae-00f1-49ff-8f3f-0dd6539af039';
+
       await request(app.getHttpServer())
         .get(`${endpoint}/${nonExistingCategoryId}`)
         .auth(regularToken, { type: 'bearer' })
@@ -96,12 +122,56 @@ describe('Category Module', () => {
           expect(body).toEqual(expectedResponse);
         });
     });
+
+    it('Should include related categories', async () => {
+      mockTypeOrmRepository.findOne.mockImplementationOnce(
+        () => mockFirstSubCategory,
+      );
+      const categoryId = mockFirstSubCategory.id;
+
+      await request(app.getHttpServer())
+        .get(`${endpoint}/${categoryId}?include=parent,subCategories`)
+        .auth(regularToken, { type: 'bearer' })
+        .expect(HttpStatus.OK)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            data: expect.objectContaining({
+              type: 'category',
+              id: categoryId,
+              attributes: expect.objectContaining({
+                name: mockFirstSubCategory.name,
+                parent: expect.objectContaining({
+                  id: mockParent.id,
+                  name: mockParent.name,
+                }),
+                subCategories: expect.arrayContaining([
+                  expect.objectContaining({
+                    id: mockSecondSubCategory.id,
+                    name: mockSecondSubCategory.name,
+                  }),
+                ]),
+              }),
+            }),
+            links: expect.arrayContaining([
+              expect.objectContaining({
+                rel: 'self',
+                href: expect.stringContaining(`${endpoint}/${categoryId}`),
+                method: HttpMethod.GET,
+              }),
+            ]),
+          });
+
+          expect(body).toEqual(expectedResponse);
+        });
+    });
   });
 
   describe('POST - /category', () => {
     it('Should create a new category', async () => {
+      mockTypeOrmRepository.findOne.mockImplementationOnce(() => null);
+      mockTypeOrmRepository.save.mockImplementationOnce(() => mockParent);
       const createCategoryDto = {
-        name: 'Design',
+        name: mockParent.name,
       } as CreateCategoryDto;
 
       await request(app.getHttpServer())
@@ -129,48 +199,108 @@ describe('Category Module', () => {
           expect(body).toEqual(expectedResponse);
         });
     });
-  });
 
-  describe('PATCH - /category/:id', () => {
-    it('Should update an existing category', async () => {
+    it('Should throw an error when the root category already exists', async () => {
+      mockTypeOrmRepository.findOne.mockImplementationOnce(() => mockParent);
       const createCategoryDto = {
-        name: 'Mathematicss',
+        name: mockParent.name,
       } as CreateCategoryDto;
-
-      const updateCategoryDto = {
-        name: 'Mathematics',
-      } as UpdateCategoryDto;
-
-      let categoryId: string = '';
 
       await request(app.getHttpServer())
         .post(endpoint)
         .auth(superAdminToken, { type: 'bearer' })
         .send(createCategoryDto)
-        .expect(HttpStatus.CREATED)
-        .then(
-          ({ body }: { body: SerializedResponseDto<CategoryResponseDto> }) => {
-            categoryId = body.data.id as string;
+        .expect(HttpStatus.CONFLICT)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `Root category '${createCategoryDto.name}' already exists`,
+              source: {
+                pointer: endpoint,
+              },
+              status: HttpStatus.CONFLICT.toString(),
+              title: 'Category already exists',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
 
-            const expectedResponse = {
-              data: expect.objectContaining({
-                type: 'category',
-                id: expect.any(String),
-                attributes: expect.objectContaining({
-                  name: createCategoryDto.name,
-                }),
-              }),
-              links: expect.arrayContaining([
-                expect.objectContaining({
-                  href: expect.stringContaining(endpoint),
-                  rel: 'self',
-                  method: HttpMethod.POST,
-                }),
-              ]),
-            };
-            expect(body).toEqual(expectedResponse);
-          },
-        );
+    it('Should throw an error when the subcategory already exists', async () => {
+      mockTypeOrmRepository.findOne
+        .mockImplementationOnce(() => mockParent)
+        .mockImplementationOnce(() => mockFirstSubCategory);
+      const createCategoryDto = {
+        name: mockFirstSubCategory.name,
+        parentId: mockParent.id,
+      } as CreateCategoryDto;
+
+      await request(app.getHttpServer())
+        .post(endpoint)
+        .auth(superAdminToken, { type: 'bearer' })
+        .send(createCategoryDto)
+        .expect(HttpStatus.CONFLICT)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `Subcategory '${createCategoryDto.name}' already exists under '${mockParent.name}' category`,
+              source: {
+                pointer: endpoint,
+              },
+              status: HttpStatus.CONFLICT.toString(),
+              title: 'Category already exists',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should throw an error when the parent category does not exist', async () => {
+      mockTypeOrmRepository.findOne.mockImplementationOnce(() => null);
+
+      const nonExistingCategoryId = '22f38dae-00f1-49ff-8f3f-0dd6539af039';
+      const createCategoryDto = {
+        name: mockFirstSubCategory.name,
+        parentId: nonExistingCategoryId,
+      } as CreateCategoryDto;
+
+      await request(app.getHttpServer())
+        .post(endpoint)
+        .auth(superAdminToken, { type: 'bearer' })
+        .send(createCategoryDto)
+        .expect(HttpStatus.NOT_FOUND)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `Entity with id ${nonExistingCategoryId} not found`,
+              source: {
+                pointer: endpoint,
+              },
+              status: HttpStatus.NOT_FOUND.toString(),
+              title: 'Entity not found',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+  });
+
+  describe('PATCH - /category/:id', () => {
+    it('Should update an existing category', async () => {
+      const updateCategoryDto = {
+        name: 'Edited',
+      } as UpdateCategoryDto;
+
+      mockTypeOrmRepository.findOne.mockImplementationOnce(
+        () => mockFirstSubCategory,
+      );
+
+      mockTypeOrmRepository.save.mockImplementationOnce(() => ({
+        ...mockFirstSubCategory,
+        name: updateCategoryDto.name,
+      }));
+
+      const categoryId = mockFirstSubCategory.id;
 
       await request(app.getHttpServer())
         .patch(`${endpoint}/${categoryId}`)
@@ -201,11 +331,17 @@ describe('Category Module', () => {
     });
 
     it('Should throw an error if category to update is not found', async () => {
+      mockTypeOrmRepository.findOne.mockImplementationOnce(() => null);
+
       const nonExistingCategoryId = '22f38dae-00f1-49ff-8f3f-0dd6539af039';
+      const updateCategoryDto = {
+        name: 'Edited',
+      } as UpdateCategoryDto;
 
       await request(app.getHttpServer())
         .patch(`${endpoint}/${nonExistingCategoryId}`)
         .auth(superAdminToken, { type: 'bearer' })
+        .send(updateCategoryDto)
         .expect(HttpStatus.NOT_FOUND)
         .then(({ body }) => {
           const expectedResponse = expect.objectContaining({
@@ -221,44 +357,102 @@ describe('Category Module', () => {
           expect(body).toEqual(expectedResponse);
         });
     });
+
+    it('Should throw an error when the root category already exists', async () => {
+      mockTypeOrmRepository.findOne
+        .mockImplementationOnce(() => mockFirstSubCategory)
+        .mockImplementationOnce(() => mockParent);
+      const updateCategoryDto = {
+        name: 'Edited',
+      } as UpdateCategoryDto;
+
+      await request(app.getHttpServer())
+        .patch(`${endpoint}/${mockFirstSubCategory.id}`)
+        .auth(superAdminToken, { type: 'bearer' })
+        .send(updateCategoryDto)
+        .expect(HttpStatus.CONFLICT)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `Root category '${updateCategoryDto.name}' already exists`,
+              source: {
+                pointer: `${endpoint}/${mockFirstSubCategory.id}`,
+              },
+              status: HttpStatus.CONFLICT.toString(),
+              title: 'Category already exists',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should throw an error when the subcategory already exists', async () => {
+      mockTypeOrmRepository.findOne
+        .mockImplementationOnce(() => mockParent)
+        .mockImplementationOnce(() => mockFirstSubCategory);
+
+      const updateCategoryDto = {
+        name: 'Edited',
+      } as UpdateCategoryDto;
+
+      await request(app.getHttpServer())
+        .patch(`${endpoint}/${mockFirstSubCategory.id}`)
+        .auth(superAdminToken, { type: 'bearer' })
+        .send(updateCategoryDto)
+        .expect(HttpStatus.CONFLICT)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `Subcategory '${updateCategoryDto.name}' already exists under '${mockParent.name}' category`,
+              source: {
+                pointer: `${endpoint}/${mockFirstSubCategory.id}`,
+              },
+              status: HttpStatus.CONFLICT.toString(),
+              title: 'Category already exists',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should throw an error when the parent category does not exist', async () => {
+      mockTypeOrmRepository.findOne.mockImplementationOnce(() => null);
+
+      const nonExistingCategoryId = '22f38dae-00f1-49ff-8f3f-0dd6539af039';
+      const updateCategoryDto = {
+        name: 'Edited',
+        parentId: nonExistingCategoryId,
+      } as UpdateCategoryDto;
+
+      await request(app.getHttpServer())
+        .patch(`${endpoint}/${mockFirstSubCategory.id}`)
+        .auth(superAdminToken, { type: 'bearer' })
+        .send(updateCategoryDto)
+        .expect(HttpStatus.NOT_FOUND)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `Entity with id ${nonExistingCategoryId} not found`,
+              source: {
+                pointer: `${endpoint}/${mockFirstSubCategory.id}`,
+              },
+              status: HttpStatus.NOT_FOUND.toString(),
+              title: 'Entity not found',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
   });
 
   describe('DELETE - /category/:id', () => {
     it('Should delete an existing category', async () => {
-      const createCategoryDto = {
-        name: 'Mathematicss',
-      } as CreateCategoryDto;
+      mockTypeOrmRepository.findOne.mockImplementationOnce(
+        () => mockFirstSubCategory,
+      );
+      mockTypeOrmRepository.softRemove.mockImplementationOnce(() => true);
 
-      let categoryId: string = '';
-
-      await request(app.getHttpServer())
-        .post(endpoint)
-        .auth(superAdminToken, { type: 'bearer' })
-        .send(createCategoryDto)
-        .expect(HttpStatus.CREATED)
-        .then(
-          ({ body }: { body: SerializedResponseDto<CategoryResponseDto> }) => {
-            categoryId = body.data.id as string;
-
-            const expectedResponse = {
-              data: expect.objectContaining({
-                type: 'category',
-                id: expect.any(String),
-                attributes: expect.objectContaining({
-                  name: createCategoryDto.name,
-                }),
-              }),
-              links: expect.arrayContaining([
-                expect.objectContaining({
-                  href: expect.stringContaining(endpoint),
-                  rel: 'self',
-                  method: HttpMethod.POST,
-                }),
-              ]),
-            };
-            expect(body).toEqual(expectedResponse);
-          },
-        );
+      const categoryId = mockFirstSubCategory.id;
 
       await request(app.getHttpServer())
         .delete(`${endpoint}/${categoryId}`)
@@ -285,27 +479,10 @@ describe('Category Module', () => {
             expect(body).toEqual(expectedResponse);
           },
         );
-
-      await request(app.getHttpServer())
-        .get(`${endpoint}/${categoryId}`)
-        .auth(superAdminToken, { type: 'bearer' })
-        .expect(HttpStatus.NOT_FOUND)
-        .then(({ body }) => {
-          const expectedResponse = expect.objectContaining({
-            error: {
-              detail: `Entity with id ${categoryId} not found`,
-              source: {
-                pointer: `${endpoint}/${categoryId}`,
-              },
-              status: HttpStatus.NOT_FOUND.toString(),
-              title: 'Entity not found',
-            },
-          });
-          expect(body).toEqual(expectedResponse);
-        });
     });
 
     it('Should throw an error if category to delete is not found', async () => {
+      mockTypeOrmRepository.findOne.mockImplementationOnce(() => null);
       const nonExistingCategoryId = '22f38dae-00f1-49ff-8f3f-0dd6539af039';
 
       await request(app.getHttpServer())

--- a/src/module/category/application/dto/category-response.dto.ts
+++ b/src/module/category/application/dto/category-response.dto.ts
@@ -1,11 +1,36 @@
 import { BaseResponseDto } from '@common/base/application/dto/base.response.dto';
 
+import { Category } from '@module/category/domain/category.entity';
+
+export type RelatedCategory = Pick<Category, 'name' | 'id'>;
+
 export class CategoryResponseDto extends BaseResponseDto {
   name: string;
+  parent?: Category;
+  subCategories?: Category[];
 
-  constructor(type: string, name: string, id?: string) {
+  constructor(
+    type: string,
+    name: string,
+    id?: string,
+    parent?: Category,
+    subCategories?: Category[],
+  ) {
     super(type, id);
 
     this.name = name;
+    this.parent = parent ? this.buildRelatedCategory(parent) : undefined;
+    this.subCategories = subCategories?.map((category) =>
+      this.buildRelatedCategory(category),
+    );
+  }
+
+  private buildRelatedCategory(category: Category): RelatedCategory {
+    const { name, id } = category;
+
+    return {
+      name,
+      id,
+    };
   }
 }

--- a/src/module/category/application/dto/category.dto.ts
+++ b/src/module/category/application/dto/category.dto.ts
@@ -2,8 +2,14 @@ import { IsNotEmpty, IsString } from 'class-validator';
 
 import { BaseDto } from '@common/base/application/dto/base.dto';
 
+import { Category } from '@module/category/domain/category.entity';
+
 export class CategoryDto extends BaseDto {
   @IsString()
   @IsNotEmpty()
   name!: string;
+
+  parent?: Category;
+
+  subCategories?: Category[];
 }

--- a/src/module/category/application/dto/create-category.dto.ts
+++ b/src/module/category/application/dto/create-category.dto.ts
@@ -1,3 +1,9 @@
+import { IsOptional, IsUUID } from 'class-validator';
+
 import { CategoryDto } from '@module/category/application/dto/category.dto';
 
-export class CreateCategoryDto extends CategoryDto {}
+export class CreateCategoryDto extends CategoryDto {
+  @IsOptional()
+  @IsUUID('4')
+  parentId?: string;
+}

--- a/src/module/category/application/dto/query/category-include-query-param.dto.ts
+++ b/src/module/category/application/dto/query/category-include-query-param.dto.ts
@@ -1,0 +1,19 @@
+import { Transform } from 'class-transformer';
+import { IsIn, IsOptional } from 'class-validator';
+
+import { IGetAllOptions } from '@common/base/application/dto/get-all-options.interface';
+import { fromCommaSeparatedToArray } from '@common/base/application/mapper/base.mapper';
+
+import { Category } from '@module/category/domain/category.entity';
+
+type CategoryRelations = IGetAllOptions<Category>['include'];
+export class CategoryIncludeQueryDto {
+  @IsIn(['parent', 'subCategories'], {
+    each: true,
+  })
+  @IsOptional()
+  @Transform((params) => {
+    return fromCommaSeparatedToArray(params.value as string);
+  })
+  target?: CategoryRelations;
+}

--- a/src/module/category/application/mapper/category.mapper.ts
+++ b/src/module/category/application/mapper/category.mapper.ts
@@ -15,20 +15,25 @@ export class CategoryMapper
     >
 {
   fromCreateDtoToEntity(dto: CreateCategoryDto): Category {
-    const { id, name } = dto;
+    const { id, name, parent, subCategories } = dto;
 
-    return new Category(name, id);
+    return new Category(name, id, parent, subCategories);
   }
 
   fromUpdateDtoToEntity(entity: Category, dto: UpdateCategoryDto): Category {
-    const { id } = entity;
+    const { id, parent, subCategories } = entity;
 
-    return new Category(dto.name ?? entity.name, id);
+    return new Category(dto.name ?? entity.name, id, parent, subCategories);
   }
 
   fromEntityToResponseDto(entity: Category): CategoryResponseDto {
-    const { name, id } = entity;
-
-    return new CategoryResponseDto(Category.getEntityName(), name, id);
+    const { name, id, parent, subCategories } = entity;
+    return new CategoryResponseDto(
+      Category.getEntityName(),
+      name,
+      id,
+      parent,
+      subCategories,
+    );
   }
 }

--- a/src/module/category/application/service/category-crud.service.ts
+++ b/src/module/category/application/service/category-crud.service.ts
@@ -26,4 +26,27 @@ export class CategoryCRUDService extends BaseCRUDService<
   ) {
     super(categoryRepository, categoryMapper, Category.getEntityName());
   }
+
+  async saveOne(createDto: CreateCategoryDto): Promise<CategoryResponseDto> {
+    const { parentId } = createDto;
+
+    createDto.parent = parentId
+      ? await this.categoryRepository.getOneByIdOrFail(parentId)
+      : undefined;
+
+    return super.saveOne(createDto);
+  }
+
+  async updateOne(
+    id: string,
+    updateDto: UpdateCategoryDto,
+  ): Promise<CategoryResponseDto> {
+    const { parentId } = updateDto;
+
+    updateDto.parent = parentId
+      ? await this.categoryRepository.getOneByIdOrFail(parentId)
+      : undefined;
+
+    return super.updateOne(id, updateDto);
+  }
 }

--- a/src/module/category/domain/category.entity.ts
+++ b/src/module/category/domain/category.entity.ts
@@ -2,10 +2,19 @@ import { Base } from '@common/base/domain/base.entity';
 
 export class Category extends Base {
   name: string;
+  parent?: Category;
+  subCategories?: Category[];
 
-  constructor(name: string, id?: string) {
+  constructor(
+    name: string,
+    id?: string,
+    parent?: Category,
+    subCategories?: Category[],
+  ) {
     super(id);
 
     this.name = name;
+    this.parent = parent;
+    this.subCategories = subCategories;
   }
 }

--- a/src/module/category/infrastructure/database/category.postgres.repository.ts
+++ b/src/module/category/infrastructure/database/category.postgres.repository.ts
@@ -1,11 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { IsNull, Repository } from 'typeorm';
 
 import BaseRepository from '@common/base/infrastructure/database/base.repository';
 
 import { Category } from '@module/category/domain/category.entity';
 import { CategorySchema } from '@module/category/infrastructure/database/category.schema';
+import { CategoryAlreadyExistsException } from '@module/category/infrastructure/database/exception/category-alredy-exists.exception';
 
 @Injectable()
 export class CategoryPostgresRepository extends BaseRepository<Category> {
@@ -14,5 +15,34 @@ export class CategoryPostgresRepository extends BaseRepository<Category> {
     private readonly categoryRepository: Repository<Category>,
   ) {
     super(categoryRepository);
+  }
+
+  async saveOne(entity: Category): Promise<Category> {
+    const existingCategory = await this.findExistingCategory(
+      entity.name,
+      entity.parent?.id,
+    );
+
+    if (existingCategory) {
+      throw new CategoryAlreadyExistsException(
+        entity.name,
+        !existingCategory.parent,
+        existingCategory.parent?.name,
+      );
+    }
+
+    return await this.categoryRepository.save(entity);
+  }
+  private async findExistingCategory(
+    name: string,
+    parentId?: string,
+  ): Promise<Category | null> {
+    return this.categoryRepository.findOne({
+      where: {
+        name,
+        parent: parentId ? { id: parentId } : IsNull(),
+      },
+      relations: ['parent'],
+    });
   }
 }

--- a/src/module/category/infrastructure/database/category.postgres.repository.ts
+++ b/src/module/category/infrastructure/database/category.postgres.repository.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { IsNull, Repository } from 'typeorm';
 
 import BaseRepository from '@common/base/infrastructure/database/base.repository';
+import EntityNotFoundException from '@common/base/infrastructure/exception/not.found.exception';
 
 import { Category } from '@module/category/domain/category.entity';
 import { CategorySchema } from '@module/category/infrastructure/database/category.schema';
@@ -33,6 +34,20 @@ export class CategoryPostgresRepository extends BaseRepository<Category> {
 
     return await this.categoryRepository.save(entity);
   }
+
+  async deleteOneByIdOrFail(id: string): Promise<void> {
+    const category = await this.repository.findOne({
+      where: { id },
+      relations: ['subCategories'],
+    });
+
+    if (!category) {
+      throw new EntityNotFoundException(id);
+    }
+
+    await this.repository.softRemove(category);
+  }
+
   private async findExistingCategory(
     name: string,
     parentId?: string,

--- a/src/module/category/infrastructure/database/category.schema.ts
+++ b/src/module/category/infrastructure/database/category.schema.ts
@@ -14,4 +14,24 @@ export const CategorySchema = new EntitySchema<Category>({
       length: 60,
     },
   }),
+  relations: {
+    parent: {
+      type: 'many-to-one',
+      target: Category.name,
+      nullable: true,
+      inverseSide: 'subCategories',
+    },
+    subCategories: {
+      type: 'one-to-many',
+      target: Category.name,
+      inverseSide: 'parent',
+      cascade: ['soft-remove'],
+    },
+  },
+  uniques: [
+    {
+      name: 'UQ_CATEGORY_PARENT_NAME',
+      columns: ['name', 'parent'],
+    },
+  ],
 });

--- a/src/module/category/infrastructure/database/exception/category-alredy-exists.exception.ts
+++ b/src/module/category/infrastructure/database/exception/category-alredy-exists.exception.ts
@@ -1,0 +1,10 @@
+import { ConflictException } from '@nestjs/common';
+
+export class CategoryAlreadyExistsException extends ConflictException {
+  constructor(categoryName: string, isRoot: boolean, parentName?: string) {
+    const message = isRoot
+      ? `Root category '${categoryName}' already exists`
+      : `Subcategory '${categoryName}' already exists under '${parentName}' category`;
+    super(message);
+  }
+}

--- a/src/module/category/interface/category.controller.ts
+++ b/src/module/category/interface/category.controller.ts
@@ -7,12 +7,14 @@ import {
   ParseUUIDPipe,
   Patch,
   Post,
+  Query,
 } from '@nestjs/common';
 
 import { SuccessOperationResponseDto } from '@common/base/application/dto/success-operation-response.dto';
 
 import { CategoryResponseDto } from '@module/category/application/dto/category-response.dto';
 import { CreateCategoryDto } from '@module/category/application/dto/create-category.dto';
+import { CategoryIncludeQueryDto } from '@module/category/application/dto/query/category-include-query-param.dto';
 import { UpdateCategoryDto } from '@module/category/application/dto/update-category.dto';
 import { CategoryCRUDService } from '@module/category/application/service/category-crud.service';
 
@@ -23,8 +25,9 @@ export class CategoryController {
   @Get(':id')
   async getOneById(
     @Param('id', ParseUUIDPipe) id: string,
+    @Query('include') include: CategoryIncludeQueryDto,
   ): Promise<CategoryResponseDto> {
-    return await this.categoryService.getOneByIdOrFail(id);
+    return await this.categoryService.getOneByIdOrFail(id, include.target);
   }
 
   @Post()

--- a/src/test/test.module.bootstrapper.ts
+++ b/src/test/test.module.bootstrapper.ts
@@ -1,6 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
 
 import { AppModule } from '@module/app.module';
+import { Category } from '@module/category/domain/category.entity';
 import { FILE_STORAGE_PROVIDER_SERVICE_KEY } from '@module/cloud/application/interface/file-storage-provider.interface';
 import { IDENTITY_PROVIDER_SERVICE_KEY } from '@module/iam/authentication/application/service/identity-provider.service.interface';
 
@@ -19,6 +21,15 @@ export const fileStorageProviderServiceMock = {
   deleteFile: jest.fn(() => Promise.resolve()),
 };
 
+export const mockTypeOrmRepository = {
+  create: jest.fn(),
+  save: jest.fn(),
+  find: jest.fn(),
+  findOne: jest.fn(),
+  softDelete: jest.fn(),
+  softRemove: jest.fn(),
+};
+
 export const testModuleBootstrapper = (): Promise<TestingModule> => {
   return Test.createTestingModule({
     imports: [AppModule],
@@ -27,5 +38,7 @@ export const testModuleBootstrapper = (): Promise<TestingModule> => {
     .useValue(identityProviderServiceMock)
     .overrideProvider(FILE_STORAGE_PROVIDER_SERVICE_KEY)
     .useValue(fileStorageProviderServiceMock)
+    .overrideProvider(getRepositoryToken(Category))
+    .useValue(mockTypeOrmRepository)
     .compile();
 };


### PR DESCRIPTION
# Summary

This PR introduces self-referential relations to the Category entity to support hierarchical categories.

# Details

- Updated the Category domain/schema entities with self-referential relations.
- Modified the Category DTOs and their mapper to include self-referential relation fields.
- Refactored the Category service and repository to:
- - Validate against saving duplicate categories.
- - Enable cascade deletion when removing a root category.
- Updated CategoryModule tests to mock TypeORM's Repository responses, as better-sqlite3 lacks support for self-referential relations.
