### PR TITLE
feat: Add getAll method to CategoryController 

### DIFF
--- a/src/module/category/application/dto/category-response.dto.ts
+++ b/src/module/category/application/dto/category-response.dto.ts
@@ -29,8 +29,8 @@ export class CategoryResponseDto extends BaseResponseDto {
     const { name, id } = category;
 
     return {
-      name,
       id,
+      name,
     };
   }
 }

--- a/src/module/category/application/dto/query-params/category-fields-query-params.dto.ts
+++ b/src/module/category/application/dto/query-params/category-fields-query-params.dto.ts
@@ -6,14 +6,15 @@ import { fromCommaSeparatedToArray } from '@common/base/application/mapper/base.
 
 import { Category } from '@module/category/domain/category.entity';
 
-type CategoryRelations = IGetAllOptions<Category>['include'];
-export class CategoryIncludeQueryDto {
-  @IsIn(['parent', 'subCategories'], {
+type CategoryFields = IGetAllOptions<Category>['fields'];
+
+export class CategoryFieldsQueryParamsDto {
+  @IsIn(['id', 'name', 'createdAt', 'updatedAt', 'deletedAt'], {
     each: true,
   })
-  @IsOptional()
   @Transform((params) => {
     return fromCommaSeparatedToArray(params.value as string);
   })
-  target?: CategoryRelations;
+  @IsOptional()
+  target?: CategoryFields;
 }

--- a/src/module/category/application/dto/query-params/category-filter-query-params.dto.ts
+++ b/src/module/category/application/dto/query-params/category-filter-query-params.dto.ts
@@ -1,0 +1,7 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class CategoryFilterQueryParamsDto {
+  @IsString()
+  @IsOptional()
+  name?: string;
+}

--- a/src/module/category/application/dto/query-params/category-include-query-param.dto.ts
+++ b/src/module/category/application/dto/query-params/category-include-query-param.dto.ts
@@ -1,0 +1,20 @@
+import { Transform } from 'class-transformer';
+import { IsIn, IsOptional } from 'class-validator';
+
+import { IGetAllOptions } from '@common/base/application/dto/get-all-options.interface';
+import { fromCommaSeparatedToArray } from '@common/base/application/mapper/base.mapper';
+
+import { Category } from '@module/category/domain/category.entity';
+
+type CategoryRelations = IGetAllOptions<Category>['include'];
+
+export class CategoryIncludeQueryDto {
+  @IsIn(['parent', 'subCategories'], {
+    each: true,
+  })
+  @IsOptional()
+  @Transform((params) => {
+    return fromCommaSeparatedToArray(params.value as string);
+  })
+  target?: CategoryRelations;
+}

--- a/src/module/category/application/dto/query-params/category-sort-query-params.dto.ts
+++ b/src/module/category/application/dto/query-params/category-sort-query-params.dto.ts
@@ -1,0 +1,17 @@
+import { IsEnum, IsOptional } from 'class-validator';
+
+import { SortType } from '@common/base/application/enum/sort-type.enum';
+
+export class CategorySortQueryParamsDto {
+  @IsEnum(SortType)
+  @IsOptional()
+  name?: SortType;
+
+  @IsEnum(SortType)
+  @IsOptional()
+  createdAt?: SortType;
+
+  @IsEnum(SortType)
+  @IsOptional()
+  updatedAt?: SortType;
+}

--- a/src/module/category/interface/category.controller.ts
+++ b/src/module/category/interface/category.controller.ts
@@ -10,17 +10,39 @@ import {
   Query,
 } from '@nestjs/common';
 
+import { CollectionDto } from '@common/base/application/dto/collection.dto';
+import { PageQueryParamsDto } from '@common/base/application/dto/page-query-params';
 import { SuccessOperationResponseDto } from '@common/base/application/dto/success-operation-response.dto';
 
 import { CategoryResponseDto } from '@module/category/application/dto/category-response.dto';
 import { CreateCategoryDto } from '@module/category/application/dto/create-category.dto';
-import { CategoryIncludeQueryDto } from '@module/category/application/dto/query/category-include-query-param.dto';
+import { CategoryFieldsQueryParamsDto } from '@module/category/application/dto/query-params/category-fields-query-params.dto';
+import { CategoryFilterQueryParamsDto } from '@module/category/application/dto/query-params/category-filter-query-params.dto';
+import { CategoryIncludeQueryDto } from '@module/category/application/dto/query-params/category-include-query-param.dto';
+import { CategorySortQueryParamsDto } from '@module/category/application/dto/query-params/category-sort-query-params.dto';
 import { UpdateCategoryDto } from '@module/category/application/dto/update-category.dto';
 import { CategoryCRUDService } from '@module/category/application/service/category-crud.service';
 
 @Controller('category')
 export class CategoryController {
   constructor(private readonly categoryService: CategoryCRUDService) {}
+
+  @Get()
+  async getAll(
+    @Query('page') page: PageQueryParamsDto,
+    @Query('filter') filter: CategoryFilterQueryParamsDto,
+    @Query('fields') fields: CategoryFieldsQueryParamsDto,
+    @Query('sort') sort: CategorySortQueryParamsDto,
+    @Query('include') include: CategoryIncludeQueryDto,
+  ): Promise<CollectionDto<CategoryResponseDto>> {
+    return await this.categoryService.getAll({
+      page,
+      filter,
+      fields: fields.target,
+      sort,
+      include: include.target,
+    });
+  }
 
   @Get(':id')
   async getOneById(

--- a/src/test/test.module.bootstrapper.ts
+++ b/src/test/test.module.bootstrapper.ts
@@ -25,6 +25,7 @@ export const mockTypeOrmRepository = {
   create: jest.fn(),
   save: jest.fn(),
   find: jest.fn(),
+  findAndCount: jest.fn(),
   findOne: jest.fn(),
   softDelete: jest.fn(),
   softRemove: jest.fn(),


### PR DESCRIPTION
# Summary

This PR introduches the `getAll` method to the `CategoryController`.

# Details

- Implemented Category DTOs to validate and use query params on the `getAll` method.
- Added the `getAll` method to the `CategoryController`.
- Updated `CategoryModule` tests to verify `CategoryController`'s getAll flow