### PR TITLE
feat: Add hypermedia links to category controller responses

### DIFF
--- a/src/module/category/__test__/category.e2e.spec.ts
+++ b/src/module/category/__test__/category.e2e.spec.ts
@@ -190,6 +190,21 @@ describe('Category Module', () => {
                 href: expect.stringContaining(`${endpoint}/${categoryId}`),
                 method: HttpMethod.GET,
               }),
+              expect.objectContaining({
+                rel: 'create-category',
+                href: expect.stringContaining(endpoint),
+                method: HttpMethod.POST,
+              }),
+              expect.objectContaining({
+                rel: 'update-category',
+                href: expect.stringContaining(`${endpoint}/${categoryId}`),
+                method: HttpMethod.PATCH,
+              }),
+              expect.objectContaining({
+                rel: 'delete-category',
+                href: expect.stringContaining(`${endpoint}/${categoryId}`),
+                method: HttpMethod.DELETE,
+              }),
             ]),
           });
 
@@ -280,7 +295,7 @@ describe('Category Module', () => {
           const expectedResponse = {
             data: expect.objectContaining({
               type: 'category',
-              id: expect.any(String),
+              id: mockParent.id,
               attributes: expect.objectContaining({
                 name: createCategoryDto.name,
               }),
@@ -290,6 +305,21 @@ describe('Category Module', () => {
                 href: expect.stringContaining(endpoint),
                 rel: 'self',
                 method: HttpMethod.POST,
+              }),
+              expect.objectContaining({
+                rel: 'get-category',
+                href: expect.stringContaining(`${endpoint}/${mockParent.id}`),
+                method: HttpMethod.GET,
+              }),
+              expect.objectContaining({
+                rel: 'update-category',
+                href: expect.stringContaining(`${endpoint}/${mockParent.id}`),
+                method: HttpMethod.PATCH,
+              }),
+              expect.objectContaining({
+                rel: 'delete-category',
+                href: expect.stringContaining(`${endpoint}/${mockParent.id}`),
+                method: HttpMethod.DELETE,
               }),
             ]),
           };
@@ -463,6 +493,21 @@ describe('Category Module', () => {
                   href: expect.stringContaining(`${endpoint}/${categoryId}`),
                   rel: 'self',
                   method: HttpMethod.PATCH,
+                }),
+                expect.objectContaining({
+                  rel: 'get-category',
+                  href: expect.stringContaining(`${endpoint}/${categoryId}`),
+                  method: HttpMethod.GET,
+                }),
+                expect.objectContaining({
+                  rel: 'create-category',
+                  href: expect.stringContaining(`${endpoint}/${categoryId}`),
+                  method: HttpMethod.POST,
+                }),
+                expect.objectContaining({
+                  rel: 'delete-category',
+                  href: expect.stringContaining(`${endpoint}/${categoryId}`),
+                  method: HttpMethod.DELETE,
                 }),
               ]),
             };
@@ -661,6 +706,11 @@ describe('Category Module', () => {
                   href: expect.stringContaining(`${endpoint}/${categoryId}`),
                   rel: 'self',
                   method: HttpMethod.DELETE,
+                }),
+                expect.objectContaining({
+                  rel: 'create-category',
+                  href: expect.stringContaining(endpoint),
+                  method: HttpMethod.POST,
                 }),
               ]),
             };

--- a/src/module/category/interface/category.controller.ts
+++ b/src/module/category/interface/category.controller.ts
@@ -11,9 +11,11 @@ import {
   UseGuards,
 } from '@nestjs/common';
 
+import { Hypermedia } from '@common/base/application/decorator/hypermedia.decorator';
 import { CollectionDto } from '@common/base/application/dto/collection.dto';
 import { PageQueryParamsDto } from '@common/base/application/dto/page-query-params';
 import { SuccessOperationResponseDto } from '@common/base/application/dto/success-operation-response.dto';
+import { HttpMethod } from '@common/base/application/enum/http-method.enum';
 
 import { CategoryResponseDto } from '@module/category/application/dto/category-response.dto';
 import { CreateCategoryDto } from '@module/category/application/dto/create-category.dto';
@@ -52,6 +54,23 @@ export class CategoryController {
   }
 
   @Get(':id')
+  @Hypermedia([
+    {
+      endpoint: '/category',
+      rel: 'create-category',
+      method: HttpMethod.POST,
+    },
+    {
+      endpoint: '/category/:id',
+      rel: 'update-category',
+      method: HttpMethod.PATCH,
+    },
+    {
+      endpoint: '/category/:id',
+      rel: 'delete-category',
+      method: HttpMethod.DELETE,
+    },
+  ])
   async getOneById(
     @Param('id', ParseUUIDPipe) id: string,
     @Query('include') include: CategoryIncludeQueryDto,
@@ -60,6 +79,23 @@ export class CategoryController {
   }
 
   @Post()
+  @Hypermedia([
+    {
+      endpoint: '/category/:id',
+      rel: 'get-category',
+      method: HttpMethod.GET,
+    },
+    {
+      endpoint: '/category/:id',
+      rel: 'update-category',
+      method: HttpMethod.PATCH,
+    },
+    {
+      endpoint: '/category/:id',
+      rel: 'delete-category',
+      method: HttpMethod.DELETE,
+    },
+  ])
   @Policies(CreateCategoryPolicyHandler)
   async saveOne(
     @Body() createCategoryDto: CreateCategoryDto,
@@ -68,6 +104,23 @@ export class CategoryController {
   }
 
   @Patch(':id')
+  @Hypermedia([
+    {
+      endpoint: '/category/:id',
+      rel: 'get-category',
+      method: HttpMethod.GET,
+    },
+    {
+      endpoint: '/category/:id',
+      rel: 'create-category',
+      method: HttpMethod.POST,
+    },
+    {
+      endpoint: '/category/:id',
+      rel: 'delete-category',
+      method: HttpMethod.DELETE,
+    },
+  ])
   @Policies(UpdateCategoryPolicyHandler)
   async updateOne(
     @Param('id', ParseUUIDPipe) id: string,
@@ -77,6 +130,13 @@ export class CategoryController {
   }
 
   @Delete(':id')
+  @Hypermedia([
+    {
+      endpoint: '/category/:id',
+      rel: 'create-category',
+      method: HttpMethod.POST,
+    },
+  ])
   @Policies(DeleteCategoryPolicyHandler)
   async deleteOne(
     @Param('id', ParseUUIDPipe) id: string,


### PR DESCRIPTION
# Summary

This PR introduces hypermedia links to the `CategoryController` responses.

# Details

- Embed the `getById`, `saveOne`, `updateOne` and `deleteOne` methods with hypermedia links.