### PR TITLE
refactor: Transforms category table into a tree

### DIFF
--- a/data/migrations/1751914838838-convertCategoryTableToTreeTable.ts
+++ b/data/migrations/1751914838838-convertCategoryTableToTreeTable.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class ConvertCategoryTableToTreeTable1751914838838 implements MigrationInterface {
+    name = 'ConvertCategoryTableToTreeTable1751914838838'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "category" DROP CONSTRAINT "UQ_CATEGORY_PARENT_NAME"`);
+        await queryRunner.query(`CREATE TABLE "category_closure" ("id_ancestor" uuid NOT NULL, "id_descendant" uuid NOT NULL, CONSTRAINT "PK_8da8666fc72217687e9b4f4c7e9" PRIMARY KEY ("id_ancestor", "id_descendant"))`);
+        await queryRunner.query(`CREATE INDEX "IDX_4aa1348fc4b7da9bef0fae8ff4" ON "category_closure" ("id_ancestor") `);
+        await queryRunner.query(`CREATE INDEX "IDX_6a22002acac4976977b1efd114" ON "category_closure" ("id_descendant") `);
+        await queryRunner.query(`ALTER TABLE "category_closure" ADD CONSTRAINT "FK_4aa1348fc4b7da9bef0fae8ff48" FOREIGN KEY ("id_ancestor") REFERENCES "category"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "category_closure" ADD CONSTRAINT "FK_6a22002acac4976977b1efd114a" FOREIGN KEY ("id_descendant") REFERENCES "category"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "category_closure" DROP CONSTRAINT "FK_6a22002acac4976977b1efd114a"`);
+        await queryRunner.query(`ALTER TABLE "category_closure" DROP CONSTRAINT "FK_4aa1348fc4b7da9bef0fae8ff48"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_6a22002acac4976977b1efd114"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_4aa1348fc4b7da9bef0fae8ff4"`);
+        await queryRunner.query(`DROP TABLE "category_closure"`);
+        await queryRunner.query(`ALTER TABLE "category" ADD CONSTRAINT "UQ_CATEGORY_PARENT_NAME" UNIQUE ("name", "parent_id")`);
+    }
+
+}

--- a/src/common/base/infrastructure/database/base.entity.ts
+++ b/src/common/base/infrastructure/database/base.entity.ts
@@ -1,0 +1,20 @@
+import {
+  CreateDateColumn,
+  DeleteDateColumn,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+export abstract class BaseEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+
+  @UpdateDateColumn()
+  updatedAt!: Date;
+
+  @DeleteDateColumn()
+  deletedAt!: Date;
+}

--- a/src/module/category/__test__/fixture/Category.yml
+++ b/src/module/category/__test__/fixture/Category.yml
@@ -1,12 +1,15 @@
-entity: Category
+entity: category
 items:
   category1:
     id: '2d915994-8c06-425c-9a64-23a7b2b8603e'
-    name: 'Programming'
+    name: 'Category 1'
   category2:
     id: '5fb9c427-2551-4787-81c4-b6c603175f45'
-    name: 'JavaScript'
+    name: 'Category 2'
+    parent: '@category1'
   category3:
-    name: 'Algorithms'
+    id: '143ce6ee-b7c0-4d25-9463-76d0f7a14663'
+    name: 'Category 3'
+    parent: '@category2'
   category{4..23}:
     name: '{{person.firstName}}'

--- a/src/module/category/application/dto/category-response.dto.ts
+++ b/src/module/category/application/dto/category-response.dto.ts
@@ -6,31 +6,15 @@ export type RelatedCategory = Pick<Category, 'name' | 'id'>;
 
 export class CategoryResponseDto extends BaseResponseDto {
   name: string;
-  parent?: Category;
-  subCategories?: Category[];
+  path?: RelatedCategory[];
 
-  constructor(
-    type: string,
-    name: string,
-    id?: string,
-    parent?: Category,
-    subCategories?: Category[],
-  ) {
+  constructor(type: string, name: string, id?: string, ancestors?: Category[]) {
     super(type, id);
 
     this.name = name;
-    this.parent = parent ? this.buildRelatedCategory(parent) : undefined;
-    this.subCategories = subCategories?.map((category) =>
-      this.buildRelatedCategory(category),
-    );
-  }
-
-  private buildRelatedCategory(category: Category): RelatedCategory {
-    const { name, id } = category;
-
-    return {
-      id,
-      name,
-    };
+    this.path = ancestors?.map((cat) => ({
+      id: cat.id,
+      name: cat.name,
+    }));
   }
 }

--- a/src/module/category/application/mapper/category.mapper.ts
+++ b/src/module/category/application/mapper/category.mapper.ts
@@ -3,15 +3,19 @@ import { IDtoMapper } from '@common/base/application/dto/dto.interface';
 import { CategoryResponseDto } from '@module/category/application/dto/category-response.dto';
 import { CreateCategoryDto } from '@module/category/application/dto/create-category.dto';
 import { UpdateCategoryDto } from '@module/category/application/dto/update-category.dto';
+import { CategoryWithAncestors } from '@module/category/application/repository/category.repository.interface';
 import { Category } from '@module/category/domain/category.entity';
 
 export class CategoryMapper
   implements
-    IDtoMapper<
-      Category,
-      CreateCategoryDto,
-      UpdateCategoryDto,
-      CategoryResponseDto
+    Omit<
+      IDtoMapper<
+        Category,
+        CreateCategoryDto,
+        UpdateCategoryDto,
+        CategoryResponseDto
+      >,
+      'fromEntityToResponseDto'
     >
 {
   fromCreateDtoToEntity(dto: CreateCategoryDto): Category {
@@ -26,14 +30,14 @@ export class CategoryMapper
     return new Category(dto.name ?? entity.name, id, parent, subCategories);
   }
 
-  fromEntityToResponseDto(entity: Category): CategoryResponseDto {
-    const { name, id, parent, subCategories } = entity;
+  fromEntityToResponseDto(entity: CategoryWithAncestors): CategoryResponseDto {
+    const { name, id, ancestors } = entity;
+
     return new CategoryResponseDto(
       Category.getEntityName(),
       name,
       id,
-      parent,
-      subCategories,
+      ancestors,
     );
   }
 }

--- a/src/module/category/application/repository/category.repository.interface.ts
+++ b/src/module/category/application/repository/category.repository.interface.ts
@@ -3,6 +3,15 @@ import BaseRepository from '@common/base/infrastructure/database/base.repository
 import { Category } from '@module/category/domain/category.entity';
 
 export const CATEGORY_REPOSITORY_KEY = 'category_repository';
+export const CATEGORY_TREE_REPOSITORY_KEY = 'category_tree_repository';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface ICategoryRepository extends BaseRepository<Category> {}
+export interface CategoryWithAncestors extends Category {
+  ancestors?: Category[];
+}
+
+export interface ICategoryRepository extends BaseRepository<Category> {
+  getOneByIdOrFail(
+    id: string,
+    include?: (keyof Category)[],
+  ): Promise<CategoryWithAncestors>;
+}

--- a/src/module/category/infrastructure/database/category.schema.ts
+++ b/src/module/category/infrastructure/database/category.schema.ts
@@ -1,37 +1,20 @@
-import { EntitySchema } from 'typeorm';
+import { Column, Entity, Tree, TreeChildren, TreeParent } from 'typeorm';
 
-import { withBaseSchemaColumns } from '@common/base/infrastructure/database/base.schema';
+import { BaseEntity } from '@common/base/infrastructure/database/base.entity';
 
 import { Category } from '@module/category/domain/category.entity';
 
-export const CategorySchema = new EntitySchema<Category>({
-  name: Category.name,
-  target: Category,
-  tableName: 'category',
-  columns: withBaseSchemaColumns({
-    name: {
-      type: String,
-      length: 60,
-    },
-  }),
-  relations: {
-    parent: {
-      type: 'many-to-one',
-      target: Category.name,
-      nullable: true,
-      inverseSide: 'subCategories',
-    },
-    subCategories: {
-      type: 'one-to-many',
-      target: Category.name,
-      inverseSide: 'parent',
-      cascade: ['soft-remove'],
-    },
-  },
-  uniques: [
-    {
-      name: 'UQ_CATEGORY_PARENT_NAME',
-      columns: ['name', 'parent'],
-    },
-  ],
-});
+@Entity('category')
+@Tree('closure-table')
+export class CategoryEntity extends BaseEntity {
+  @Column({ type: 'varchar', length: 60 })
+  name!: string;
+
+  @TreeParent()
+  parent!: Category | null;
+
+  @TreeChildren({
+    cascade: ['soft-remove'],
+  })
+  children!: Category[];
+}

--- a/src/module/category/interface/category.controller.ts
+++ b/src/module/category/interface/category.controller.ts
@@ -73,9 +73,8 @@ export class CategoryController {
   ])
   async getOneById(
     @Param('id', ParseUUIDPipe) id: string,
-    @Query('include') include: CategoryIncludeQueryDto,
   ): Promise<CategoryResponseDto> {
-    return await this.categoryService.getOneByIdOrFail(id, include.target);
+    return await this.categoryService.getOneByIdOrFail(id);
   }
 
   @Post()

--- a/src/test/test.module.bootstrapper.ts
+++ b/src/test/test.module.bootstrapper.ts
@@ -1,8 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { getRepositoryToken } from '@nestjs/typeorm';
 
 import { AppModule } from '@module/app.module';
-import { Category } from '@module/category/domain/category.entity';
 import { FILE_STORAGE_PROVIDER_SERVICE_KEY } from '@module/cloud/application/interface/file-storage-provider.interface';
 import { IDENTITY_PROVIDER_SERVICE_KEY } from '@module/iam/authentication/application/service/identity-provider.service.interface';
 
@@ -21,16 +19,6 @@ export const fileStorageProviderServiceMock = {
   deleteFile: jest.fn(() => Promise.resolve()),
 };
 
-export const mockTypeOrmRepository = {
-  create: jest.fn(),
-  save: jest.fn(),
-  find: jest.fn(),
-  findAndCount: jest.fn(),
-  findOne: jest.fn(),
-  softDelete: jest.fn(),
-  softRemove: jest.fn(),
-};
-
 export const testModuleBootstrapper = (): Promise<TestingModule> => {
   return Test.createTestingModule({
     imports: [AppModule],
@@ -39,7 +27,6 @@ export const testModuleBootstrapper = (): Promise<TestingModule> => {
     .useValue(identityProviderServiceMock)
     .overrideProvider(FILE_STORAGE_PROVIDER_SERVICE_KEY)
     .useValue(fileStorageProviderServiceMock)
-    .overrideProvider(getRepositoryToken(Category))
-    .useValue(mockTypeOrmRepository)
+
     .compile();
 };


### PR DESCRIPTION
# Summary

This PR transforms the `CategorySchema` into a TypeORM's `@Tree('closure-table')` entity to improve category hierarchy management for both read and write operations.

# Details

- Created a `BaseEntity` for the TypeORM's entities with common columns.
- Transformed the `CategorySchema` into a `@Tree('closure-table')` with parent and children columns.
- Updated the `CategoryResponseDTO` to include a path with all category's inheritance.
- Implemented a `categoryTreeRepositoryProvider` to inject the category's tree repository on the `CategoryPostgresRepository`.
- Refactored `CategoryPostgresRepository` to leverage two repository methods for:
  - Parent-child consideration in deletion.
  - Tree structure-aware queries.
- Updated `CategoryModule` tests to:
  - Remove repository mocking, as this is no longer necessary.
  - Implement more realistic test scenarios.
  - Verify tree structure operations.