### PR TITLE
feat: Add get category children by id method

### DIFF
--- a/src/module/category/__test__/category.e2e.spec.ts
+++ b/src/module/category/__test__/category.e2e.spec.ts
@@ -341,6 +341,80 @@ describe('Category Module', () => {
     });
   });
 
+  describe('GET - /category/:id/children', () => {
+    it('Should return a category with its children by id', async () => {
+      const categoryId = '2d915994-8c06-425c-9a64-23a7b2b8603e';
+
+      await request(app.getHttpServer())
+        .get(`${endpoint}/${categoryId}/children`)
+        .auth(regularToken, { type: 'bearer' })
+        .expect(HttpStatus.OK)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            data: expect.objectContaining({
+              type: 'category',
+              id: categoryId,
+              attributes: expect.objectContaining({
+                name: 'Category 1',
+                children: expect.arrayContaining([
+                  expect.objectContaining({
+                    id: expect.any(String),
+                    name: 'Category 2',
+                  }),
+                ]),
+              }),
+            }),
+            links: expect.arrayContaining([
+              expect.objectContaining({
+                rel: 'self',
+                href: expect.stringContaining(`${endpoint}/${categoryId}`),
+                method: HttpMethod.GET,
+              }),
+              expect.objectContaining({
+                rel: 'create-category',
+                href: expect.stringContaining(endpoint),
+                method: HttpMethod.POST,
+              }),
+              expect.objectContaining({
+                rel: 'update-category',
+                href: expect.stringContaining(`${endpoint}/${categoryId}`),
+                method: HttpMethod.PATCH,
+              }),
+              expect.objectContaining({
+                rel: 'delete-category',
+                href: expect.stringContaining(`${endpoint}/${categoryId}`),
+                method: HttpMethod.DELETE,
+              }),
+            ]),
+          });
+
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should throw an error if category is not found', async () => {
+      const nonExistingCategoryId = '22f38dae-00f1-49ff-8f3f-0dd6539af039';
+
+      await request(app.getHttpServer())
+        .get(`${endpoint}/${nonExistingCategoryId}`)
+        .auth(regularToken, { type: 'bearer' })
+        .expect(HttpStatus.NOT_FOUND)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `Entity with id ${nonExistingCategoryId} not found`,
+              source: {
+                pointer: `${endpoint}/${nonExistingCategoryId}`,
+              },
+              status: HttpStatus.NOT_FOUND.toString(),
+              title: 'Entity not found',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+  });
+
   describe('POST - /category', () => {
     it('Should create a new category', async () => {
       const createCategoryDto = {

--- a/src/module/category/application/dto/category-response.dto.ts
+++ b/src/module/category/application/dto/category-response.dto.ts
@@ -7,12 +7,23 @@ export type RelatedCategory = Pick<Category, 'name' | 'id'>;
 export class CategoryResponseDto extends BaseResponseDto {
   name: string;
   path?: RelatedCategory[];
+  children?: RelatedCategory[];
 
-  constructor(type: string, name: string, id?: string, ancestors?: Category[]) {
+  constructor(
+    type: string,
+    name: string,
+    id?: string,
+    ancestors?: Category[],
+    children?: Category[],
+  ) {
     super(type, id);
 
     this.name = name;
     this.path = ancestors?.map((cat) => ({
+      id: cat.id,
+      name: cat.name,
+    }));
+    this.children = children?.map((cat) => ({
       id: cat.id,
       name: cat.name,
     }));

--- a/src/module/category/application/mapper/category.mapper.ts
+++ b/src/module/category/application/mapper/category.mapper.ts
@@ -3,7 +3,10 @@ import { IDtoMapper } from '@common/base/application/dto/dto.interface';
 import { CategoryResponseDto } from '@module/category/application/dto/category-response.dto';
 import { CreateCategoryDto } from '@module/category/application/dto/create-category.dto';
 import { UpdateCategoryDto } from '@module/category/application/dto/update-category.dto';
-import { CategoryWithAncestors } from '@module/category/application/repository/category.repository.interface';
+import {
+  CategoryWithAncestors,
+  CategoryWithChildren,
+} from '@module/category/application/repository/category.repository.interface';
 import { Category } from '@module/category/domain/category.entity';
 
 export class CategoryMapper
@@ -30,14 +33,21 @@ export class CategoryMapper
     return new Category(dto.name ?? entity.name, id, parent, subCategories);
   }
 
-  fromEntityToResponseDto(entity: CategoryWithAncestors): CategoryResponseDto {
-    const { name, id, ancestors } = entity;
+  fromEntityToResponseDto(
+    entity: CategoryWithAncestors | CategoryWithChildren,
+  ): CategoryResponseDto {
+    const { name, id } = entity;
+
+    const hasChildren = 'children' in entity && Array.isArray(entity.children);
+    const hasAncestors =
+      'ancestors' in entity && Array.isArray(entity.ancestors);
 
     return new CategoryResponseDto(
       Category.getEntityName(),
       name,
       id,
-      ancestors,
+      hasAncestors ? entity.ancestors : undefined,
+      hasChildren ? entity.children : undefined,
     );
   }
 }

--- a/src/module/category/application/repository/category.repository.interface.ts
+++ b/src/module/category/application/repository/category.repository.interface.ts
@@ -9,9 +9,14 @@ export interface CategoryWithAncestors extends Category {
   ancestors?: Category[];
 }
 
+export interface CategoryWithChildren extends Category {
+  children?: Category[];
+}
+
 export interface ICategoryRepository extends BaseRepository<Category> {
   getOneByIdOrFail(
     id: string,
     include?: (keyof Category)[],
   ): Promise<CategoryWithAncestors>;
+  getChildrenByIdOrFail(id: string): Promise<CategoryWithChildren>;
 }

--- a/src/module/category/application/service/category-crud.service.ts
+++ b/src/module/category/application/service/category-crud.service.ts
@@ -27,6 +27,14 @@ export class CategoryCRUDService extends BaseCRUDService<
     super(categoryRepository, categoryMapper, Category.getEntityName());
   }
 
+  async getChildrenByIdOrFail(id: string): Promise<CategoryResponseDto> {
+    const category = await this.categoryRepository.getChildrenByIdOrFail(id);
+    const categoryResponseDto =
+      this.categoryMapper.fromEntityToResponseDto(category);
+
+    return categoryResponseDto;
+  }
+
   async saveOne(createDto: CreateCategoryDto): Promise<CategoryResponseDto> {
     const { parentId } = createDto;
 

--- a/src/module/category/interface/category.controller.ts
+++ b/src/module/category/interface/category.controller.ts
@@ -74,6 +74,30 @@ export class CategoryController {
     return await this.categoryService.getOneByIdOrFail(id);
   }
 
+  @Get(':id/children')
+  @Hypermedia([
+    {
+      endpoint: '/category',
+      rel: 'create-category',
+      method: HttpMethod.POST,
+    },
+    {
+      endpoint: '/category/:id',
+      rel: 'update-category',
+      method: HttpMethod.PATCH,
+    },
+    {
+      endpoint: '/category/:id',
+      rel: 'delete-category',
+      method: HttpMethod.DELETE,
+    },
+  ])
+  async getChildrenById(
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<CategoryResponseDto> {
+    return await this.categoryService.getChildrenByIdOrFail(id);
+  }
+
   @Post()
   @Hypermedia([
     {


### PR DESCRIPTION
# Summary

This PR introduces the `getChildrenById` mechanism to the `CategoryModule`.

# Details

- Refactored the `CategoryResponseDto` to include conditionally children or ancestors depending on the received entity.
- Updated the category's controller, service and repository with a mechanism to obtain a category's with it children by a received id.
- Added tests to verify the functionality of the `getChildrenById` mechanism.