### PR TITLE
feat: Add get categories root method

### DIFF
--- a/src/common/base/application/dto/collection.dto.ts
+++ b/src/common/base/application/dto/collection.dto.ts
@@ -6,13 +6,13 @@ export class CollectionDto<Data extends IResponseDto>
 {
   readonly data: Data[];
 
-  readonly pageNumber: number;
+  readonly pageNumber?: number;
 
-  readonly pageSize: number;
+  readonly pageSize?: number;
 
-  readonly pageCount: number;
+  readonly pageCount?: number;
 
-  readonly itemCount: number;
+  readonly itemCount?: number;
 
   constructor({
     data,

--- a/src/common/base/application/dto/collection.interface.ts
+++ b/src/common/base/application/dto/collection.interface.ts
@@ -6,6 +6,6 @@ export interface IPagingCollectionData {
 }
 
 export interface ICollection<Entity extends object>
-  extends IPagingCollectionData {
+  extends Partial<IPagingCollectionData> {
   data: Entity[];
 }

--- a/src/common/base/application/dto/serialized-response.dto.ts
+++ b/src/common/base/application/dto/serialized-response.dto.ts
@@ -8,21 +8,21 @@ import {
 export class SerializedResponseDtoCollection<ResponseDto extends object> {
   data: ISerializedResponseData<ResponseDto>[];
   links: ICollectionLinks;
-  meta: IPagingCollectionData;
+  meta?: IPagingCollectionData;
 
   constructor(
     data: ISerializedResponseData<ResponseDto>[],
     links: ICollectionLinks,
-    meta: IPagingCollectionData,
+    meta?: IPagingCollectionData,
   ) {
     this.data = data;
     this.links = links;
-    this.meta = meta;
+    if (meta) this.meta = meta;
   }
 }
 
 export class SerializedResponseDto<ResponseDto extends object> {
-  data: ISerializedResponseData<ResponseDto>;
+  data: Omit<ISerializedResponseData<ResponseDto>, 'links'>;
   links: IResponseDtoLinks;
 
   constructor(

--- a/src/common/base/application/dto/serialized-response.interface.ts
+++ b/src/common/base/application/dto/serialized-response.interface.ts
@@ -18,10 +18,16 @@ export interface ISerializedCollection<Entity extends object> {
   meta: IPagingCollectionData;
 }
 
+export type INonPaginatedSerializedCollection<Entity extends object> = Omit<
+  ISerializedCollection<Entity>,
+  'meta'
+>;
+
 export interface ISerializedResponseData<ResponseDto extends IDto> {
   type: string;
   id?: string;
   attributes: ResponseDto;
+  links?: IResponseDtoLinks;
 }
 export interface ISerializeResponseDtoParams<ResponseDto extends IDto> {
   responseDto: ResponseDto;

--- a/src/module/app/application/service/link-builder.service.interface.ts
+++ b/src/module/app/application/service/link-builder.service.interface.ts
@@ -16,9 +16,13 @@ export interface ILinkBuilderService {
     responseDto: BaseResponseDto,
     params: Record<string, string>,
   ): ILink[];
-  buildCollectionLinks(
+  buildPaginatedCollectionLinks(
     currentRequestUrl: string,
     currentRequestMethod: HttpMethod,
     pagingData: IPagingCollectionData,
+  ): ICollectionLinks;
+  buildCollectionLinks(
+    currentRequestUrl: string,
+    currentRequestMethod: HttpMethod,
   ): ICollectionLinks;
 }

--- a/src/module/app/application/service/link-builder.service.ts
+++ b/src/module/app/application/service/link-builder.service.ts
@@ -24,11 +24,11 @@ export class LinkBuilderService implements ILinkBuilderService {
     linksMetadata: ILinkMetadata[],
     responseDto: BaseResponseDto,
     params: Record<string, string>,
+    withSelfLink = true,
   ): ILink[] {
-    const selfLink = this.buildSelfLink(
-      currentRequestUrl,
-      currentRequestMethod,
-    );
+    const selfLink =
+      withSelfLink &&
+      this.buildSelfLink(currentRequestUrl, currentRequestMethod);
     const relatedLinks = this.buildRelatedLinks(
       linksMetadata,
       baseAppUrl,
@@ -36,10 +36,10 @@ export class LinkBuilderService implements ILinkBuilderService {
       params,
     );
 
-    return [selfLink, ...relatedLinks];
+    return selfLink ? [selfLink, ...relatedLinks] : relatedLinks;
   }
 
-  buildCollectionLinks(
+  buildPaginatedCollectionLinks(
     currentRequestUrl: string,
     currentRequestMethod: HttpMethod,
     pagingData: IPagingCollectionData,
@@ -51,6 +51,18 @@ export class LinkBuilderService implements ILinkBuilderService {
 
     const pagingLinks = this.buildPagingLinks(currentRequestUrl, pagingData);
     return [selfLink, ...pagingLinks];
+  }
+
+  buildCollectionLinks(
+    currentRequestUrl: string,
+    currentRequestMethod: HttpMethod,
+  ): ICollectionLinks {
+    const selfLinks = this.buildSelfLink(
+      currentRequestUrl,
+      currentRequestMethod,
+    );
+
+    return [selfLinks];
   }
 
   private buildPagingLinks(

--- a/src/module/category/application/dto/category.dto.ts
+++ b/src/module/category/application/dto/category.dto.ts
@@ -12,4 +12,8 @@ export class CategoryDto extends BaseDto {
   parent?: Category;
 
   subCategories?: Category[];
+
+  children?: Category[];
+
+  ancestors?: Category[];
 }

--- a/src/module/category/application/repository/category.repository.interface.ts
+++ b/src/module/category/application/repository/category.repository.interface.ts
@@ -1,3 +1,4 @@
+import { ICollection } from '@common/base/application/dto/collection.interface';
 import BaseRepository from '@common/base/infrastructure/database/base.repository';
 
 import { Category } from '@module/category/domain/category.entity';
@@ -19,4 +20,5 @@ export interface ICategoryRepository extends BaseRepository<Category> {
     include?: (keyof Category)[],
   ): Promise<CategoryWithAncestors>;
   getChildrenByIdOrFail(id: string): Promise<CategoryWithChildren>;
+  getCategoriesRoot(): Promise<ICollection<Category>>;
 }

--- a/src/module/category/application/service/category-crud.service.ts
+++ b/src/module/category/application/service/category-crud.service.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 
+import { CollectionDto } from '@common/base/application/dto/collection.dto';
 import { BaseCRUDService } from '@common/base/application/service/base-crud.service';
 
 import { CategoryResponseDto } from '@module/category/application/dto/category-response.dto';
@@ -25,6 +26,16 @@ export class CategoryCRUDService extends BaseCRUDService<
     private readonly categoryMapper: CategoryMapper,
   ) {
     super(categoryRepository, categoryMapper, Category.getEntityName());
+  }
+
+  async getCategoriesRoot(): Promise<CollectionDto<CategoryResponseDto>> {
+    const categories = await this.categoryRepository.getCategoriesRoot();
+
+    return new CollectionDto({
+      data: categories.data.map((category) =>
+        this.categoryMapper.fromEntityToResponseDto(category),
+      ),
+    });
   }
 
   async getChildrenByIdOrFail(id: string): Promise<CategoryResponseDto> {

--- a/src/module/category/domain/category.entity.ts
+++ b/src/module/category/domain/category.entity.ts
@@ -2,7 +2,6 @@ import { Base } from '@common/base/domain/base.entity';
 
 export class Category extends Base {
   name: string;
-  parentId?: string;
   parent?: Category;
   subCategories?: Category[];
 
@@ -16,7 +15,6 @@ export class Category extends Base {
 
     this.name = name;
     this.parent = parent;
-    this.parentId = parent?.id;
     this.subCategories = subCategories;
   }
 }

--- a/src/module/category/interface/category.controller.ts
+++ b/src/module/category/interface/category.controller.ts
@@ -50,6 +50,18 @@ export class CategoryController {
     });
   }
 
+  @Get('roots')
+  @Hypermedia([
+    {
+      endpoint: '/category/:id/children',
+      rel: 'get-category-children',
+      method: HttpMethod.GET,
+    },
+  ])
+  async getCategoriesRoots(): Promise<CollectionDto<CategoryResponseDto>> {
+    return await this.categoryService.getCategoriesRoot();
+  }
+
   @Get(':id')
   @Hypermedia([
     {

--- a/src/module/course/__test__/course.e2e.spec.ts
+++ b/src/module/course/__test__/course.e2e.spec.ts
@@ -7,6 +7,7 @@ import request from 'supertest';
 import { loadFixtures } from '@data/util/fixture-loader';
 
 import { MAX_FILE_SIZES } from '@common/base/application/constant/file.constant';
+import { IPagingCollectionData } from '@common/base/application/dto/collection.interface';
 import {
   SerializedResponseDto,
   SerializedResponseDtoCollection,
@@ -170,7 +171,7 @@ describe('Course Module', () => {
             body: SerializedResponseDtoCollection<CourseResponseDto>;
           }) => {
             firstCourse.title = body.data[0].attributes.title;
-            pageCount = body.meta.pageCount;
+            pageCount = (body.meta as IPagingCollectionData).pageCount;
           },
         );
 

--- a/src/module/iam/user/__test__/user.e2e.spec.ts
+++ b/src/module/iam/user/__test__/user.e2e.spec.ts
@@ -7,6 +7,7 @@ import request from 'supertest';
 import { loadFixtures } from '@data/util/fixture-loader';
 
 import { MAX_FILE_SIZES } from '@common/base/application/constant/file.constant';
+import { IPagingCollectionData } from '@common/base/application/dto/collection.interface';
 import {
   SerializedResponseDto,
   SerializedResponseDtoCollection,
@@ -152,7 +153,7 @@ describe('User Module', () => {
             body: SerializedResponseDtoCollection<UserResponseDto>;
           }) => {
             firstUser.firstName = body.data[0].attributes.firstName;
-            pageCount = body.meta.pageCount;
+            pageCount = (body.meta as IPagingCollectionData).pageCount;
           },
         );
 

--- a/src/module/payment-method/__test__/payment-method.e2e.spec.ts
+++ b/src/module/payment-method/__test__/payment-method.e2e.spec.ts
@@ -5,6 +5,7 @@ import request from 'supertest';
 
 import { loadFixtures } from '@data/util/fixture-loader';
 
+import { IPagingCollectionData } from '@common/base/application/dto/collection.interface';
 import {
   SerializedResponseDto,
   SerializedResponseDtoCollection,
@@ -148,7 +149,7 @@ describe('PaymentMethod Module', () => {
             body: SerializedResponseDtoCollection<PaymentMethodResponseDto>;
           }) => {
             firstPaymentMethod.name = body.data[0].attributes.name;
-            pageCount = body.meta.pageCount;
+            pageCount = (body.meta as IPagingCollectionData).pageCount;
           },
         );
 


### PR DESCRIPTION
# Summary

This PR introduces the route to fetch for categories root. Also, removes the `CategoryPostgresRepository`'s getAll method as is no longer necessary to use it with custom filters to obtain categories root.

# Details

- Refactored the `CollectionDTOs` so that pagination metadata is optional, in order to create non-paginated DTOs.
- Changed the `ResponseInterceptorFormatter` and `LinkBuilderService` to build non-paginated CollectionDTOs.
- Implemented a route handler for the `getRootCategories` method.
- Added a `getRootCategories` method to the CategoryModule's service and repository.