### PR TITLE
feat: Add category relation to course entity

### DIFF
--- a/data/migrations/1752257284570-addCourseCategoryRelation.ts
+++ b/data/migrations/1752257284570-addCourseCategoryRelation.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddCourseCategoryRelation1752257284570 implements MigrationInterface {
+    name = 'AddCourseCategoryRelation1752257284570'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "course" ADD "category_id" uuid`);
+        await queryRunner.query(`ALTER TABLE "course" ADD CONSTRAINT "FK_2f133fd8aa7a4d85ff7cd6f7c98" FOREIGN KEY ("category_id") REFERENCES "category"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "course" DROP CONSTRAINT "FK_2f133fd8aa7a4d85ff7cd6f7c98"`);
+        await queryRunner.query(`ALTER TABLE "course" DROP COLUMN "category_id"`);
+    }
+
+}

--- a/src/module/category/category.module.ts
+++ b/src/module/category/category.module.ts
@@ -52,6 +52,7 @@ const policyHandlersProviders = [
     categoryTreeRepositoryProvider,
   ],
   controllers: [CategoryController],
+  exports: [categoryRepositoryProvider],
 })
 export class CategoryModule implements OnModuleInit {
   constructor(private readonly registry: AppSubjectPermissionStorage) {}

--- a/src/module/category/category.module.ts
+++ b/src/module/category/category.module.ts
@@ -52,7 +52,7 @@ const policyHandlersProviders = [
     categoryTreeRepositoryProvider,
   ],
   controllers: [CategoryController],
-  exports: [categoryRepositoryProvider],
+  exports: [categoryRepositoryProvider, categoryTreeRepositoryProvider],
 })
 export class CategoryModule implements OnModuleInit {
   constructor(private readonly registry: AppSubjectPermissionStorage) {}

--- a/src/module/category/infrastructure/database/category.entity.ts
+++ b/src/module/category/infrastructure/database/category.entity.ts
@@ -1,8 +1,16 @@
-import { Column, Entity, Tree, TreeChildren, TreeParent } from 'typeorm';
+import {
+  Column,
+  Entity,
+  OneToMany,
+  Tree,
+  TreeChildren,
+  TreeParent,
+} from 'typeorm';
 
 import { BaseEntity } from '@common/base/infrastructure/database/base.entity';
 
 import { Category } from '@module/category/domain/category.entity';
+import { CourseEntity } from '@module/course/infrastructure/database/course.entity';
 
 @Entity('category')
 @Tree('closure-table')
@@ -17,6 +25,9 @@ export class CategoryEntity extends BaseEntity {
     cascade: ['soft-remove'],
   })
   children?: Category[];
+
+  @OneToMany(() => CourseEntity, (course) => course.category)
+  courses?: CourseEntity[];
 
   constructor(
     name: string,

--- a/src/module/course/__test__/fixture/Category.yml
+++ b/src/module/course/__test__/fixture/Category.yml
@@ -1,0 +1,15 @@
+entity: category
+items:
+  category1:
+    id: '2d915994-8c06-425c-9a64-23a7b2b8603e'
+    name: 'Category 1'
+  category2:
+    id: '5fb9c427-2551-4787-81c4-b6c603175f45'
+    name: 'Category 2'
+    parent: '@category1'
+  category3:
+    id: '143ce6ee-b7c0-4d25-9463-76d0f7a14663'
+    name: 'Category 3'
+    parent: '@category2'
+  category{4..23}:
+    name: '{{person.firstName}}'

--- a/src/module/course/__test__/fixture/Course.yml
+++ b/src/module/course/__test__/fixture/Course.yml
@@ -10,6 +10,7 @@ items:
     slug: 'introduction-to-programming'
     difficulty: beginner
     instructor: '@admin-user'
+    category: '@category3'
   course2:
     title: 'Advanced Web Development'
     description: 'Master React, Node.js and modern web architectures'
@@ -19,6 +20,7 @@ items:
     slug: 'advanced-web-development'
     difficulty: advanced
     instructor: '@admin-user'
+    category: '@category3'
   course3:
     title: 'Data Science Fundamentals'
     description: 'Introduction to data analysis and machine learning'
@@ -28,6 +30,7 @@ items:
     slug: 'data-science-fundamentals'
     difficulty: intermediate
     instructor: '@admin-user'
+    category: '@category3'
   course{4..23}:
     title: '{{commerce.productName}} Course'
     description: '{{lorem.paragraph}}'
@@ -37,3 +40,4 @@ items:
     slug: '{{lorem.slug}}'
     difficulty: '{{@key % 3 == 0 ? "beginner" : (@key % 3 == 1 ? "intermediate" : "advanced")}}'
     instructor: '@admin-user'
+    category: '@category3'

--- a/src/module/course/application/dto/course-include.dto.ts
+++ b/src/module/course/application/dto/course-include.dto.ts
@@ -8,7 +8,7 @@ import { Course } from '@module/course/domain/course.entity';
 
 type CourseRelations = IGetAllOptions<Course>['include'];
 export class CourseIncludeQueryDto {
-  @IsIn(['instructor'], {
+  @IsIn(['instructor', 'category'], {
     each: true,
   })
   @IsOptional()

--- a/src/module/course/application/dto/course-response.dto.ts
+++ b/src/module/course/application/dto/course-response.dto.ts
@@ -2,6 +2,7 @@ import { BaseResponseDto } from '@common/base/application/dto/base.response.dto'
 import { Difficulty } from '@common/base/application/enum/difficulty.enum';
 import { PublishStatus } from '@common/base/application/enum/publish-status.enum';
 
+import { Category } from '@module/category/domain/category.entity';
 import { User } from '@module/iam/user/domain/user.entity';
 
 export type CourseResponseInstructor = Pick<
@@ -19,6 +20,8 @@ export class CourseResponseDto extends BaseResponseDto {
   slug?: string;
   difficulty?: Difficulty;
   instructor?: CourseResponseInstructor;
+  category?: Category;
+
   constructor(
     type: string,
     instructorId: string,
@@ -31,6 +34,7 @@ export class CourseResponseDto extends BaseResponseDto {
     difficulty?: Difficulty,
     instructor?: CourseResponseInstructor,
     id?: string,
+    category?: Category,
   ) {
     super(type, id);
 
@@ -45,5 +49,6 @@ export class CourseResponseDto extends BaseResponseDto {
     if (instructor) {
       this.instructor = instructor;
     }
+    this.category = category;
   }
 }

--- a/src/module/course/application/dto/create-course.dto.ts
+++ b/src/module/course/application/dto/create-course.dto.ts
@@ -1,10 +1,18 @@
 import { OmitType } from '@nestjs/mapped-types';
+import { IsOptional, IsUUID } from 'class-validator';
 
+import { CategoryWithAncestors } from '@module/category/application/repository/category.repository.interface';
 import { CourseDto } from '@module/course/application/dto/course.dto';
 
-export class CreateCourseRequestDto extends OmitType(CourseDto, [
+export class CreateCourseDto extends CourseDto {
+  @IsUUID('4')
+  @IsOptional()
+  categoryId?: string;
+
+  category?: CategoryWithAncestors;
+}
+
+export class CreateCourseRequestDto extends OmitType(CreateCourseDto, [
   'instructorId',
   'imageUrl',
 ]) {}
-
-export class CreateCourseDto extends CourseDto {}

--- a/src/module/course/application/mapper/course-dto.mapper.ts
+++ b/src/module/course/application/mapper/course-dto.mapper.ts
@@ -1,5 +1,6 @@
 import { IDtoMapper } from '@common/base/application/mapper/entity.mapper';
 
+import { Category } from '@module/category/domain/category.entity';
 import {
   CourseResponseDto,
   CourseResponseInstructor,
@@ -25,6 +26,8 @@ export class CourseDtoMapper
       dto.difficulty,
       dto.status,
       dto.instructor,
+      dto.sections,
+      dto.category,
     );
   }
 
@@ -40,6 +43,8 @@ export class CourseDtoMapper
       dto.difficulty ?? entity.difficulty,
       dto.status ?? entity.status,
       dto.instructor ?? entity.instructor,
+      dto.sections ?? entity.sections,
+      dto.category ?? entity.category,
     );
   }
 
@@ -47,6 +52,7 @@ export class CourseDtoMapper
     const instructor = entity.instructor
       ? this.fromInstructorToCourseResponseInstructor(entity.instructor)
       : undefined;
+
     return new CourseResponseDto(
       Course.getEntityName(),
       entity.instructorId,
@@ -59,6 +65,7 @@ export class CourseDtoMapper
       entity.difficulty,
       instructor,
       entity.id,
+      entity.category ? this.buildCategoryPath(entity.category) : undefined,
     );
   }
 
@@ -70,5 +77,18 @@ export class CourseDtoMapper
       lastName: instructor.lastName,
       avatarUrl: instructor.avatarUrl,
     };
+  }
+
+  private buildCategoryPath(category: Category): Category {
+    const categoryPath = {
+      id: category.id,
+      name: category.name,
+    } as Category;
+
+    if (category.parent) {
+      categoryPath.parent = this.buildCategoryPath(category.parent);
+    }
+
+    return categoryPath;
   }
 }

--- a/src/module/course/application/mapper/course.mapper.ts
+++ b/src/module/course/application/mapper/course.mapper.ts
@@ -1,10 +1,14 @@
 import { Difficulty } from '@common/base/application/enum/difficulty.enum';
 import { IEntityMapper } from '@common/base/application/mapper/entity.mapper';
 
+import { CategoryWithAncestors } from '@module/category/application/repository/category.repository.interface';
+import { CategoryEntity } from '@module/category/infrastructure/database/category.entity';
 import { Course } from '@module/course/domain/course.entity';
 import { CourseEntity } from '@module/course/infrastructure/database/course.entity';
 import { User } from '@module/iam/user/domain/user.entity';
 import { UserEntity } from '@module/iam/user/infrastructure/database/user.entity';
+import { Section } from '@module/section/domain/section.entity';
+import { SectionEntity } from '@module/section/infrastructure/database/section.entity';
 
 export class CourseMapper implements IEntityMapper<Course, CourseEntity> {
   toDomainEntity(entity: CourseEntity): Course {
@@ -19,6 +23,8 @@ export class CourseMapper implements IEntityMapper<Course, CourseEntity> {
       entity.difficulty as Difficulty,
       entity.status,
       entity.instructor as User,
+      entity.sections as Section[],
+      entity.category as CategoryWithAncestors,
     );
   }
 
@@ -34,6 +40,8 @@ export class CourseMapper implements IEntityMapper<Course, CourseEntity> {
       domainEntity.slug,
       domainEntity.difficulty,
       domainEntity.instructor as UserEntity,
+      domainEntity.sections as SectionEntity[],
+      domainEntity.category as CategoryEntity,
     );
   }
 }

--- a/src/module/course/course.module.ts
+++ b/src/module/course/course.module.ts
@@ -1,6 +1,8 @@
 import { Module, OnModuleInit, Provider } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { CategoryModule } from '@module/category/category.module';
+import { CategoryEntity } from '@module/category/infrastructure/database/category.entity';
 import { CourseDtoMapper } from '@module/course/application/mapper/course-dto.mapper';
 import { CourseMapper } from '@module/course/application/mapper/course.mapper';
 import { CreateCoursePolicyHandler } from '@module/course/application/policy/create-course-policy-handler';
@@ -29,8 +31,9 @@ const policyHandlersProviders = [
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([CourseEntity]),
+    TypeOrmModule.forFeature([CourseEntity, CategoryEntity]),
     AuthorizationModule.forFeature(),
+    CategoryModule,
   ],
   providers: [
     CourseService,

--- a/src/module/course/domain/course.entity.ts
+++ b/src/module/course/domain/course.entity.ts
@@ -2,6 +2,7 @@ import { Difficulty } from '@common/base/application/enum/difficulty.enum';
 import { PublishStatus } from '@common/base/application/enum/publish-status.enum';
 import { Base } from '@common/base/domain/base.entity';
 
+import { Category } from '@module/category/domain/category.entity';
 import { User } from '@module/iam/user/domain/user.entity';
 import { Section } from '@module/section/domain/section.entity';
 
@@ -16,6 +17,7 @@ export class Course extends Base {
   difficulty?: Difficulty;
   instructor?: User;
   sections?: Section[];
+  category?: Category;
 
   constructor(
     instructorId: string,
@@ -29,6 +31,7 @@ export class Course extends Base {
     status?: PublishStatus,
     instructor?: User,
     sections?: Section[],
+    category?: Category,
   ) {
     super(id);
     this.title = title;
@@ -41,5 +44,6 @@ export class Course extends Base {
     this.instructorId = instructorId;
     this.instructor = instructor;
     this.sections = sections;
+    this.category = category;
   }
 }

--- a/src/module/course/infrastructure/database/course.entity.ts
+++ b/src/module/course/infrastructure/database/course.entity.ts
@@ -3,6 +3,7 @@ import { Column, Entity, ManyToOne, OneToMany } from 'typeorm';
 import { PublishStatus } from '@common/base/application/enum/publish-status.enum';
 import { BaseEntity } from '@common/base/infrastructure/database/base.entity';
 
+import { CategoryEntity } from '@module/category/infrastructure/database/category.entity';
 import { UserEntity } from '@module/iam/user/infrastructure/database/user.entity';
 import { SectionEntity } from '@module/section/infrastructure/database/section.entity';
 
@@ -52,6 +53,9 @@ export class CourseEntity extends BaseEntity {
   })
   sections?: SectionEntity[];
 
+  @ManyToOne(() => CategoryEntity, (category) => category.courses)
+  category?: CategoryEntity;
+
   constructor(
     instructorId: string,
     id?: string,
@@ -64,6 +68,7 @@ export class CourseEntity extends BaseEntity {
     difficulty?: string,
     instructor?: UserEntity,
     sections?: SectionEntity[],
+    category?: CategoryEntity,
   ) {
     super(id);
 
@@ -77,5 +82,6 @@ export class CourseEntity extends BaseEntity {
     this.difficulty = difficulty;
     this.instructor = instructor;
     this.sections = sections;
+    this.category = category;
   }
 }


### PR DESCRIPTION
# Summary

This PR introduces a `ManyToOne` relation between `CourseEntity` and `CategoryEntity`, updating methods to include course's category on request/responses.

# Details

- Created the `ManyToOne` relation between `CourseEntity` and `CategoryEntity`.
- Updated the course's DTOs and mappers to include course's category with its ancestors, in order to build a hierarchical path of categories.
- Refactored the `saveOne` and `updateOne` methods from the `CourseCRUDService` in order to include categories on the mechanism.
- Changed the `getOneByIdOrFail` method on the `CoursePostgresRepository` to include the category with its ancestors when the query includes the relation.