### PR TITLE
refactor: Rebuild ancestors in get category by id

### DIFF
--- a/src/module/category/__test__/category.e2e.spec.ts
+++ b/src/module/category/__test__/category.e2e.spec.ts
@@ -342,20 +342,14 @@ describe('Category Module', () => {
               id: categoryId,
               attributes: expect.objectContaining({
                 name: 'Category 3',
-                path: expect.arrayContaining([
-                  expect.objectContaining({
-                    id: expect.any(String),
+                parent: expect.objectContaining({
+                  id: '5fb9c427-2551-4787-81c4-b6c603175f45',
+                  name: 'Category 2',
+                  parent: expect.objectContaining({
+                    id: '2d915994-8c06-425c-9a64-23a7b2b8603e',
                     name: 'Category 1',
                   }),
-                  expect.objectContaining({
-                    id: expect.any(String),
-                    name: 'Category 2',
-                  }),
-                  expect.objectContaining({
-                    id: expect.any(String),
-                    name: 'Category 3',
-                  }),
-                ]),
+                }),
               }),
             }),
             links: expect.arrayContaining([

--- a/src/module/category/application/dto/category-response.dto.ts
+++ b/src/module/category/application/dto/category-response.dto.ts
@@ -6,23 +6,20 @@ export type RelatedCategory = Pick<Category, 'name' | 'id'>;
 
 export class CategoryResponseDto extends BaseResponseDto {
   name: string;
-  path?: RelatedCategory[];
-  children?: RelatedCategory[];
+  parent?: Category;
+  children?: Category[];
 
   constructor(
     type: string,
     name: string,
     id?: string,
-    ancestors?: Category[],
+    parent?: Category,
     children?: Category[],
   ) {
     super(type, id);
 
     this.name = name;
-    this.path = ancestors?.map((cat) => ({
-      id: cat.id,
-      name: cat.name,
-    }));
+    this.parent = parent;
     this.children = children?.map((cat) => ({
       id: cat.id,
       name: cat.name,

--- a/src/module/category/application/mapper/category-dto.mapper.ts
+++ b/src/module/category/application/mapper/category-dto.mapper.ts
@@ -3,10 +3,7 @@ import { IDtoMapper } from '@common/base/application/mapper/entity.mapper';
 import { CategoryResponseDto } from '@module/category/application/dto/category-response.dto';
 import { CreateCategoryDto } from '@module/category/application/dto/create-category.dto';
 import { UpdateCategoryDto } from '@module/category/application/dto/update-category.dto';
-import {
-  CategoryWithAncestors,
-  CategoryWithChildren,
-} from '@module/category/application/repository/category.repository.interface';
+import { CategoryWithChildren } from '@module/category/application/repository/category.repository.interface';
 import { Category } from '@module/category/domain/category.entity';
 
 export class CategoryDtoMapper
@@ -34,20 +31,29 @@ export class CategoryDtoMapper
   }
 
   fromEntityToResponseDto(
-    entity: CategoryWithAncestors | CategoryWithChildren,
+    entity: Category | CategoryWithChildren,
   ): CategoryResponseDto {
-    const { name, id } = entity;
-
-    const hasChildren = 'children' in entity && Array.isArray(entity.children);
-    const hasAncestors =
-      'ancestors' in entity && Array.isArray(entity.ancestors);
+    const { name, id, parent, children } = entity;
 
     return new CategoryResponseDto(
       Category.getEntityName(),
       name,
       id,
-      hasAncestors ? entity.ancestors : undefined,
-      hasChildren ? entity.children : undefined,
+      parent ? this.buildCategoryPath(parent) : undefined,
+      children,
     );
+  }
+
+  private buildCategoryPath(category: Category): Category {
+    const categoryPath = {
+      id: category.id,
+      name: category.name,
+    } as Category;
+
+    if (category.parent) {
+      categoryPath.parent = this.buildCategoryPath(category.parent);
+    }
+
+    return categoryPath;
   }
 }

--- a/src/module/category/application/repository/category.repository.interface.ts
+++ b/src/module/category/application/repository/category.repository.interface.ts
@@ -7,20 +7,13 @@ import { CategoryEntity } from '@module/category/infrastructure/database/categor
 export const CATEGORY_REPOSITORY_KEY = 'category_repository';
 export const CATEGORY_TREE_REPOSITORY_KEY = 'category_tree_repository';
 
-export interface CategoryWithAncestors extends Category {
-  ancestors?: Category[];
-}
-
 export interface CategoryWithChildren extends Category {
   children?: Category[];
 }
 
 export interface ICategoryRepository
   extends BaseRepository<Category, CategoryEntity> {
-  getOneByIdOrFail(
-    id: string,
-    include?: (keyof Category)[],
-  ): Promise<CategoryWithAncestors>;
+  getOneByIdOrFail(id: string, include?: (keyof Category)[]): Promise<Category>;
   getChildrenByIdOrFail(id: string): Promise<CategoryWithChildren>;
   getCategoriesRoot(): Promise<ICollection<Category>>;
 }

--- a/src/module/category/infrastructure/database/category.postgres.repository.ts
+++ b/src/module/category/infrastructure/database/category.postgres.repository.ts
@@ -9,7 +9,6 @@ import EntityNotFoundException from '@common/base/infrastructure/exception/not.f
 import { CategoryMapper } from '@module/category/application/mapper/category.mapper';
 import {
   CATEGORY_TREE_REPOSITORY_KEY,
-  CategoryWithAncestors,
   CategoryWithChildren,
   ICategoryRepository,
 } from '@module/category/application/repository/category.repository.interface';
@@ -65,7 +64,7 @@ export class CategoryPostgresRepository
     return category ? this.categoryMapper.toDomainEntity(category) : null;
   }
 
-  async getOneByIdOrFail(id: string): Promise<CategoryWithAncestors> {
+  async getOneByIdOrFail(id: string): Promise<Category> {
     const category = await this.getOneEntityById(id);
 
     if (!category) {
@@ -75,12 +74,7 @@ export class CategoryPostgresRepository
     const categoryWithAncestors =
       await this.treeRepository.findAncestorsTree(category);
 
-    return {
-      ...this.categoryMapper.toDomainEntity(category),
-      ancestors: this.buildPathFromTree(
-        this.categoryMapper.toDomainEntity(categoryWithAncestors),
-      ),
-    };
+    return this.categoryMapper.toDomainEntity(categoryWithAncestors);
   }
 
   async saveOne(entity: Category): Promise<Category> {
@@ -132,18 +126,6 @@ export class CategoryPostgresRepository
     });
 
     return category ? this.categoryMapper.toDomainEntity(category) : null;
-  }
-
-  private buildPathFromTree(node: Category): Category[] {
-    const path: Category[] = [];
-    let current: Category | null | undefined = node;
-
-    while (current) {
-      path.unshift(current);
-      current = current.parent;
-    }
-
-    return path;
   }
 
   private async findChildren(parentId: string): Promise<Category[]> {

--- a/src/module/course/application/dto/create-course.dto.ts
+++ b/src/module/course/application/dto/create-course.dto.ts
@@ -1,7 +1,7 @@
 import { OmitType } from '@nestjs/mapped-types';
 import { IsOptional, IsUUID } from 'class-validator';
 
-import { CategoryWithAncestors } from '@module/category/application/repository/category.repository.interface';
+import { Category } from '@module/category/domain/category.entity';
 import { CourseDto } from '@module/course/application/dto/course.dto';
 
 export class CreateCourseDto extends CourseDto {
@@ -9,7 +9,7 @@ export class CreateCourseDto extends CourseDto {
   @IsOptional()
   categoryId?: string;
 
-  category?: CategoryWithAncestors;
+  category?: Category;
 }
 
 export class CreateCourseRequestDto extends OmitType(CreateCourseDto, [

--- a/src/module/course/application/mapper/course.mapper.ts
+++ b/src/module/course/application/mapper/course.mapper.ts
@@ -1,7 +1,7 @@
 import { Difficulty } from '@common/base/application/enum/difficulty.enum';
 import { IEntityMapper } from '@common/base/application/mapper/entity.mapper';
 
-import { CategoryWithAncestors } from '@module/category/application/repository/category.repository.interface';
+import { Category } from '@module/category/domain/category.entity';
 import { CategoryEntity } from '@module/category/infrastructure/database/category.entity';
 import { Course } from '@module/course/domain/course.entity';
 import { CourseEntity } from '@module/course/infrastructure/database/course.entity';
@@ -24,7 +24,7 @@ export class CourseMapper implements IEntityMapper<Course, CourseEntity> {
       entity.status,
       entity.instructor as User,
       entity.sections as Section[],
-      entity.category as CategoryWithAncestors,
+      entity.category as Category,
     );
   }
 


### PR DESCRIPTION
# Summary

This PR refactores the category's get by id method in order to build ancestors as parents (Category objects instead of an array of Categories), to improve consistency between categories parents from course and category modules.