### PR TITLE
feat: Add purchase module

### DIFF
--- a/data/migrations/1753108245945-addPurchaseTable.ts
+++ b/data/migrations/1753108245945-addPurchaseTable.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddPurchaseTable1753108245945 implements MigrationInterface {
+    name = 'AddPurchaseTable1753108245945'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "purchase" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), "deleted_at" TIMESTAMP, "user_id" uuid NOT NULL, "course_id" uuid NOT NULL, "amount" numeric(10,2), "status" character varying NOT NULL, "external_id" character varying, CONSTRAINT "PK_86cc2ebeb9e17fc9c0774b05f69" PRIMARY KEY ("id"))`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE "purchase"`);
+    }
+
+}

--- a/src/common/base/application/exception/base-exception.messages.ts
+++ b/src/common/base/application/exception/base-exception.messages.ts
@@ -1,0 +1,1 @@
+export const IS_NOT_VALID_MESSAGE = 'is not valid';

--- a/src/common/base/application/service/base-crud.service.ts
+++ b/src/common/base/application/service/base-crud.service.ts
@@ -69,7 +69,10 @@ export class BaseCRUDService<
     return responseDto;
   }
 
-  async updateOne(id: string, updateDto: UpdateDto): Promise<ResponseDto> {
+  async updateOneByIdOrFail(
+    id: string,
+    updateDto: UpdateDto,
+  ): Promise<ResponseDto> {
     const entityToUpdate = await this.repository.getOneByIdOrFail(id);
     const entity = this.mapper.fromUpdateDtoToEntity(entityToUpdate, updateDto);
     const updatedEntity = await this.repository.saveOne(entity);

--- a/src/common/base/application/service/crud-service.interface.ts
+++ b/src/common/base/application/service/crud-service.interface.ts
@@ -13,6 +13,6 @@ export interface ICRUDService<
   getAll(options?: IGetAllOptions<Entity>): Promise<CollectionDto<ResponseDto>>;
   getOneByIdOrFail(id: string): Promise<ResponseDto>;
   saveOne(createDto: CreateDto): Promise<ResponseDto>;
-  updateOne(id: string, updateDto: UpdateDto): Promise<ResponseDto>;
+  updateOneByIdOrFail(id: string, updateDto: UpdateDto): Promise<ResponseDto>;
   deleteOneByIdOrFail(id: string): Promise<SuccessOperationResponseDto>;
 }

--- a/src/module/app.module.ts
+++ b/src/module/app.module.ts
@@ -13,6 +13,7 @@ import { CourseModule } from '@module/course/course.module';
 import { IamModule } from '@module/iam/iam.module';
 import { LessonModule } from '@module/lesson/lesson.module';
 import { PaymentMethodModule } from '@module/payment-method/payment-method.module';
+import { PurchaseModule } from '@module/purchase/purchase.module';
 import { SectionModule } from '@module/section/section.module';
 
 @Global()
@@ -35,6 +36,7 @@ import { SectionModule } from '@module/section/section.module';
     LessonModule,
     PaymentMethodModule,
     CategoryModule,
+    PurchaseModule,
   ],
   providers: [LinkBuilderService, SlugService],
   exports: [LinkBuilderService, SlugService],

--- a/src/module/category/application/service/category-crud.service.ts
+++ b/src/module/category/application/service/category-crud.service.ts
@@ -68,6 +68,6 @@ export class CategoryCRUDService extends BaseCRUDService<
       ? await this.categoryRepository.getOneByIdOrFail(parentId)
       : undefined;
 
-    return super.updateOne(id, updateDto);
+    return super.updateOneByIdOrFail(id, updateDto);
   }
 }

--- a/src/module/lesson/application/service/lesson.service.ts
+++ b/src/module/lesson/application/service/lesson.service.ts
@@ -81,7 +81,7 @@ export class LessonService extends BaseCRUDService<
         this.MIME_TYPE_TO_LESSON_TYPE[lessonFile.mimetype];
     }
 
-    return super.updateOne(id, UpdateLessonDto);
+    return super.updateOneByIdOrFail(id, UpdateLessonDto);
   }
 
   private buildFileFolder(courseId: string, sectionId: string): string {

--- a/src/module/payment-method/interface/payment-method.controller.ts
+++ b/src/module/payment-method/interface/payment-method.controller.ts
@@ -124,7 +124,7 @@ export class PaymentMethodController {
     @Param('id', ParseUUIDPipe) id: string,
     @Body() updatePaymentMethodDto: UpdatePaymentMethodDto,
   ): Promise<PaymentMethodResponseDto> {
-    return await this.paymentMethodService.updateOne(
+    return await this.paymentMethodService.updateOneByIdOrFail(
       id,
       updatePaymentMethodDto,
     );

--- a/src/module/purchase/__test__/fixture/Category.yml
+++ b/src/module/purchase/__test__/fixture/Category.yml
@@ -1,0 +1,15 @@
+entity: category
+items:
+  category1:
+    id: '2d915994-8c06-425c-9a64-23a7b2b8603e'
+    name: 'Category 1'
+  category2:
+    id: '5fb9c427-2551-4787-81c4-b6c603175f45'
+    name: 'Category 2'
+    parent: '@category1'
+  category3:
+    id: '143ce6ee-b7c0-4d25-9463-76d0f7a14663'
+    name: 'Category 3'
+    parent: '@category2'
+  category{4..23}:
+    name: '{{person.firstName}}'

--- a/src/module/purchase/__test__/fixture/Course.yml
+++ b/src/module/purchase/__test__/fixture/Course.yml
@@ -1,0 +1,35 @@
+entity: course
+items:
+  course1:
+    id: '29694b5e-c5d1-487e-a6e8-3f7aa6c4238c'
+    title: 'Introduction to Programming'
+    description: 'Learn the basics of programming with JavaScript'
+    price: 49.99
+    imageUrl: '{{internet.url}}/intro-programming.jpg'
+    status: published
+    slug: 'introduction-to-programming'
+    difficulty: beginner
+    instructor: '@admin-user'
+    category: '@category3'
+  course2:
+    id: '89dd5d47-9c71-463b-b021-0bc3289f998d'
+    title: 'Advanced Web Development'
+    description: 'Master React, Node.js and modern web architectures'
+    price: 89.99
+    imageUrl: '{{internet.url}}/advanced-web.jpg'
+    status: archived
+    slug: 'advanced-web-development'
+    difficulty: advanced
+    instructor: '@admin-user'
+    category: '@category3'
+  course3:
+    id: '57732eea-ce64-4e9b-80c6-63a08ee82764'
+    title: 'Data Science Fundamentals'
+    description: 'Introduction to data analysis and machine learning'
+    price: 79.99
+    imageUrl: '{{internet.url}}/data-science.jpg'
+    status: published
+    slug: 'data-science-fundamentals'
+    difficulty: intermediate
+    instructor: '@admin-user'
+    category: '@category3'

--- a/src/module/purchase/__test__/fixture/Purchase.yml
+++ b/src/module/purchase/__test__/fixture/Purchase.yml
@@ -1,0 +1,14 @@
+entity: purchase
+items:
+  purchase:
+    id: 'e6c78b10-d9b0-4819-ac4e-a36ca36f8554'
+    userId: '5e822193-13ca-4846-9b60-9f2f38d7eefa'
+    courseId: 'ba7fc4eb-e4f7-47a9-b963-f1e733d39748'
+    status: pending
+    amount: 49.99
+  purchase1:
+    id: 'a5978602-defc-4415-ae50-33ce6902e113'
+    userId: '5e822193-13ca-4846-9b60-9f2f38d7eefa'
+    courseId: '57732eea-ce64-4e9b-80c6-63a08ee82764'
+    status: completed
+    amount: 39.99

--- a/src/module/purchase/__test__/fixture/User.yml
+++ b/src/module/purchase/__test__/fixture/User.yml
@@ -1,0 +1,18 @@
+entity: user
+items:
+  admin-user:
+    id: a90108bf-42c6-481f-a63f-4b51fed1300c
+    firstName: admin-name
+    lastName: admin-surname
+    email: 'test_admin@email.co'
+    avatarUrl: '{{internet.url}}'
+    externalId: '00000000-0000-0000-0000-00000000000Y'
+    roles: regular,admin
+  regular-user:
+    id: '5e822193-13ca-4846-9b60-9f2f38d7eefa'
+    firstName: regular-name
+    lastName: regular-surname
+    email: 'test_regular@email.co'
+    avatarUrl: '{{internet.url}}'
+    externalId: '00000000-0000-0000-0000-00000000000Z'
+    roles: regular

--- a/src/module/purchase/__test__/purchase.e2e.spec.ts
+++ b/src/module/purchase/__test__/purchase.e2e.spec.ts
@@ -1,0 +1,375 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { HttpStatus } from '@nestjs/common';
+import { NestExpressApplication } from '@nestjs/platform-express';
+import request from 'supertest';
+
+import { loadFixtures } from '@data/util/fixture-loader';
+
+import { HttpMethod } from '@common/base/application/enum/http-method.enum';
+import { IS_NOT_VALID_MESSAGE } from '@common/base/application/exception/base-exception.messages';
+
+import { setupApp } from '@config/app.config';
+import { datasourceOptions } from '@config/orm.config';
+
+import { testModuleBootstrapper } from '@test/test.module.bootstrapper';
+import { createAccessToken } from '@test/test.util';
+
+import { CreatePurchaseDtoRequest } from '@module/purchase/application/dto/create-purchase.dto';
+import { UpdatePurchaseDto } from '@module/purchase/application/dto/update-purchase.dto';
+import {
+  CAN_NOT_BUY_OWN_COURSE_MESSAGE,
+  COURSE_NOT_PUBLISHED_MESSAGE,
+  COURSE_WITH_ID_MESSAGE,
+  PURCHASE_ALREADY_EXISTS_MESSAGE,
+  PURCHASE_FOR_COURSE_MESSAGE,
+  STATUS_TRANSITION_MESSAGE,
+} from '@module/purchase/application/exception/purchase-exception.messages';
+import { Purchase } from '@module/purchase/domain/purchase.entity';
+import { PurchaseStatus } from '@module/purchase/domain/purchase.status.enum';
+
+describe('Purchase Module', () => {
+  let app: NestExpressApplication;
+
+  const regularToken = createAccessToken({
+    sub: '00000000-0000-0000-0000-00000000000Z',
+  });
+  const adminToken = createAccessToken({
+    sub: '00000000-0000-0000-0000-00000000000Y',
+  });
+
+  beforeAll(async () => {
+    await loadFixtures(`${__dirname}/fixture`, datasourceOptions);
+    const moduleRef = await testModuleBootstrapper();
+    app = moduleRef.createNestApplication({ logger: false });
+    setupApp(app);
+    await app.init();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  const endpoint = '/api/v1/purchase';
+  const existingsCourses = {
+    first: {
+      id: '29694b5e-c5d1-487e-a6e8-3f7aa6c4238c',
+      amount: 49.99,
+    },
+    second: {
+      id: '89dd5d47-9c71-463b-b021-0bc3289f998d',
+      amount: 89.99,
+    },
+    third: {
+      id: '57732eea-ce64-4e9b-80c6-63a08ee82764',
+      amount: 79.99,
+    },
+  };
+  const existingUsers = {
+    regular: {
+      id: '5e822193-13ca-4846-9b60-9f2f38d7eefa',
+    },
+  };
+
+  describe('GET - /purchase/:id', () => {
+    it('Should return a purchase', async () => {
+      const existingPurchaseId = 'e6c78b10-d9b0-4819-ac4e-a36ca36f8554';
+
+      return await request(app.getHttpServer())
+        .get(`${endpoint}/${existingPurchaseId}`)
+        .auth(regularToken, { type: 'bearer' })
+        .expect(HttpStatus.OK)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            data: expect.objectContaining({
+              id: existingPurchaseId,
+              type: Purchase.getEntityName(),
+              attributes: expect.objectContaining({
+                status: PurchaseStatus.PENDING,
+                amount: expect.any(Number),
+                userId: expect.any(String),
+                courseId: expect.any(String),
+              }),
+            }),
+            links: expect.arrayContaining([
+              expect.objectContaining({
+                rel: 'self',
+                href: expect.stringContaining(
+                  `${endpoint}/${existingPurchaseId}`,
+                ),
+                method: HttpMethod.GET,
+              }),
+            ]),
+          });
+
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should throw an error if the purchase does not exist', async () => {
+      const nonExistingPurchaseId = '3287e48b-89d7-458c-9ad9-ce88b487fa53';
+
+      return await request(app.getHttpServer())
+        .get(`${endpoint}/${nonExistingPurchaseId}`)
+        .auth(regularToken, { type: 'bearer' })
+        .expect(HttpStatus.NOT_FOUND)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `Entity with id ${nonExistingPurchaseId} not found`,
+              source: {
+                pointer: `${endpoint}/${nonExistingPurchaseId}`,
+              },
+              status: HttpStatus.NOT_FOUND.toString(),
+              title: 'Entity not found',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+  });
+
+  describe('POST - /purchase', () => {
+    it('Should create a purchase', async () => {
+      const createPurchaseDto = {
+        courseId: existingsCourses.first.id,
+      } as CreatePurchaseDtoRequest;
+
+      await request(app.getHttpServer())
+        .post(endpoint)
+        .auth(regularToken, { type: 'bearer' })
+        .send(createPurchaseDto)
+        .expect(HttpStatus.CREATED)
+        .then(({ body }) => {
+          const expectedResponse = {
+            data: expect.objectContaining({
+              id: expect.any(String),
+              type: Purchase.getEntityName(),
+              attributes: expect.objectContaining({
+                status: PurchaseStatus.PENDING,
+                amount: existingsCourses.first.amount,
+                userId: existingUsers.regular.id,
+                courseId: existingsCourses.first.id,
+                createdAt: expect.any(String),
+              }),
+            }),
+            links: expect.arrayContaining([
+              expect.objectContaining({
+                rel: 'self',
+                href: expect.stringContaining(`${endpoint}`),
+                method: HttpMethod.POST,
+              }),
+            ]),
+          };
+
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should deny purchases for not published courses', async () => {
+      const courseId = existingsCourses.second.id;
+      const createPurchaseDto = {
+        courseId,
+      } as CreatePurchaseDtoRequest;
+
+      return await request(app.getHttpServer())
+        .post(endpoint)
+        .auth(regularToken, { type: 'bearer' })
+        .send(createPurchaseDto)
+        .expect(HttpStatus.FORBIDDEN)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `${COURSE_WITH_ID_MESSAGE} ${courseId} ${COURSE_NOT_PUBLISHED_MESSAGE}`,
+              source: {
+                pointer: endpoint,
+              },
+              status: HttpStatus.FORBIDDEN.toString(),
+              title: 'Course not published',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should deny purchases to not existing courses', async () => {
+      const nonExistingCourseId = 'bf16df65-145f-4a1c-a566-17ac56229a57';
+
+      const createPurchaseDto = {
+        courseId: nonExistingCourseId,
+      } as CreatePurchaseDtoRequest;
+
+      return await request(app.getHttpServer())
+        .post(endpoint)
+        .auth(regularToken, { type: 'bearer' })
+        .send(createPurchaseDto)
+        .expect(HttpStatus.NOT_FOUND)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `Entity with id ${nonExistingCourseId} not found`,
+              source: {
+                pointer: endpoint,
+              },
+              status: HttpStatus.NOT_FOUND.toString(),
+              title: 'Entity not found',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should deny purchases when user is instructor', async () => {
+      const courseId = existingsCourses.first.id;
+      const createPurchaseDto = {
+        courseId,
+      } as CreatePurchaseDtoRequest;
+
+      return await request(app.getHttpServer())
+        .post(endpoint)
+        .auth(adminToken, { type: 'bearer' })
+        .send(createPurchaseDto)
+        .expect(HttpStatus.FORBIDDEN)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: CAN_NOT_BUY_OWN_COURSE_MESSAGE,
+              source: {
+                pointer: endpoint,
+              },
+              status: HttpStatus.FORBIDDEN.toString(),
+              title: 'Self purchase not allowed',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should deny duplicate purchases', async () => {
+      const courseId = existingsCourses.third.id;
+
+      const createPurchaseDto = {
+        courseId,
+      } as CreatePurchaseDtoRequest;
+
+      return await request(app.getHttpServer())
+        .post(endpoint)
+        .auth(regularToken, { type: 'bearer' })
+        .send(createPurchaseDto)
+        .expect(HttpStatus.CONFLICT)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `${PURCHASE_FOR_COURSE_MESSAGE} ${courseId} ${PURCHASE_ALREADY_EXISTS_MESSAGE} ${PurchaseStatus.COMPLETED}`,
+              source: {
+                pointer: endpoint,
+              },
+              status: HttpStatus.CONFLICT.toString(),
+              title: 'Purchase already exists',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+  });
+
+  describe('PATCH - /purchase/:id', () => {
+    it('Should update a purchase', async () => {
+      const existingPurchaseId = 'e6c78b10-d9b0-4819-ac4e-a36ca36f8554';
+      const externalId = '00000000-0000-0000-0000-000000000000';
+      const updatePurchaseDto = {
+        status: PurchaseStatus.COMPLETED,
+        externalId,
+      } as UpdatePurchaseDto;
+
+      return await request(app.getHttpServer())
+        .patch(`${endpoint}/${existingPurchaseId}`)
+        .auth(adminToken, { type: 'bearer' })
+        .send(updatePurchaseDto)
+        .expect(HttpStatus.OK)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            data: expect.objectContaining({
+              id: existingPurchaseId,
+              type: Purchase.getEntityName(),
+              attributes: expect.objectContaining({
+                status: PurchaseStatus.COMPLETED,
+                amount: expect.any(Number),
+                userId: expect.any(String),
+                courseId: expect.any(String),
+                updatedAt: expect.any(String),
+                externalId,
+              }),
+            }),
+            links: expect.arrayContaining([
+              expect.objectContaining({
+                rel: 'self',
+                href: expect.stringContaining(
+                  `${endpoint}/${existingPurchaseId}`,
+                ),
+                method: HttpMethod.PATCH,
+              }),
+            ]),
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should throw an error if the purchase does not exist', async () => {
+      const nonExistingPurchaseId = 'a731f47d-cd6c-4cdb-ac60-c9e9fc52f589';
+      const updatePurchaseDto = {
+        status: PurchaseStatus.COMPLETED,
+        externalId: '00000000-0000-0000-0000-000000000000',
+      } as UpdatePurchaseDto;
+
+      return await request(app.getHttpServer())
+        .patch(`${endpoint}/${nonExistingPurchaseId}`)
+        .auth(adminToken, { type: 'bearer' })
+        .send(updatePurchaseDto)
+        .expect(HttpStatus.NOT_FOUND)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `Entity with id ${nonExistingPurchaseId} not found`,
+              source: {
+                pointer: `${endpoint}/${nonExistingPurchaseId}`,
+              },
+              status: HttpStatus.NOT_FOUND.toString(),
+              title: 'Entity not found',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should throw an error with invalid status transition', async () => {
+      const purchaseId = 'a5978602-defc-4415-ae50-33ce6902e113';
+      const updatePurchaseDto = {
+        status: PurchaseStatus.PENDING,
+        externalId: '00000000-0000-0000-0000-000000000000',
+      } as UpdatePurchaseDto;
+
+      return await request(app.getHttpServer())
+        .patch(`${endpoint}/${purchaseId}`)
+        .auth(adminToken, { type: 'bearer' })
+        .send(updatePurchaseDto)
+        .expect(HttpStatus.BAD_REQUEST)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `${STATUS_TRANSITION_MESSAGE} ${PurchaseStatus.COMPLETED} to ${updatePurchaseDto.status} ${IS_NOT_VALID_MESSAGE}`,
+              source: {
+                pointer: `${endpoint}/${purchaseId}`,
+              },
+              status: HttpStatus.BAD_REQUEST.toString(),
+              title: 'Invalid purchase',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+  });
+});

--- a/src/module/purchase/application/dto/create-purchase.dto.ts
+++ b/src/module/purchase/application/dto/create-purchase.dto.ts
@@ -1,0 +1,16 @@
+import { OmitType } from '@nestjs/mapped-types';
+
+import { PurchaseDto } from '@module/purchase/application/dto/purchase.dto';
+import { PurchaseStatus } from '@module/purchase/domain/purchase.status.enum';
+
+export class CreatePurchaseDto extends OmitType(PurchaseDto, ['amount']) {
+  amount?: number;
+}
+
+export class CreatePurchaseDtoRequest extends OmitType(CreatePurchaseDto, [
+  'userId',
+  'amount',
+]) {
+  status: PurchaseStatus = PurchaseStatus.PENDING;
+  userId!: string;
+}

--- a/src/module/purchase/application/dto/purchase-response.dto.ts
+++ b/src/module/purchase/application/dto/purchase-response.dto.ts
@@ -1,0 +1,35 @@
+import { BaseResponseDto } from '@common/base/application/dto/base.response.dto';
+
+import { PurchaseStatus } from '@module/purchase/domain/purchase.status.enum';
+
+export class PurchaseResponseDto extends BaseResponseDto {
+  userId: string;
+  courseId: string;
+  amount: number;
+  status: PurchaseStatus;
+  externalId?: string;
+  createdAt?: string;
+  updatedAt?: string;
+
+  constructor(
+    type: string,
+    userId: string,
+    courseId: string,
+    amount: number,
+    status: PurchaseStatus,
+    externalId?: string,
+    id?: string,
+    createdAt?: string,
+    updatedAt?: string,
+  ) {
+    super(type, id);
+
+    this.userId = userId;
+    this.courseId = courseId;
+    this.amount = amount;
+    this.status = status;
+    this.externalId = externalId;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
+}

--- a/src/module/purchase/application/dto/purchase.dto.ts
+++ b/src/module/purchase/application/dto/purchase.dto.ts
@@ -1,0 +1,43 @@
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Max,
+  Min,
+} from 'class-validator';
+
+import { BaseDto } from '@common/base/application/dto/base.dto';
+
+import { PurchaseStatus } from '@module/purchase/domain/purchase.status.enum';
+
+export class PurchaseDto extends BaseDto {
+  @IsNotEmpty()
+  @IsUUID('4')
+  userId!: string;
+
+  @IsNotEmpty()
+  @IsUUID('4')
+  courseId!: string;
+
+  @IsNotEmpty()
+  @IsNumber(
+    {
+      maxDecimalPlaces: 2,
+    },
+    { message: 'Amount must be a number with 2 decimal places' },
+  )
+  @Min(0, { message: 'Amount cannot be negative' })
+  @Max(10000, { message: 'Amount cannot exceed $10,000' })
+  amount!: number;
+
+  @IsNotEmpty()
+  @IsEnum(PurchaseStatus)
+  status!: PurchaseStatus;
+
+  @IsOptional()
+  @IsString()
+  externalId?: string;
+}

--- a/src/module/purchase/application/dto/update-purchase.dto.ts
+++ b/src/module/purchase/application/dto/update-purchase.dto.ts
@@ -1,0 +1,19 @@
+import { IsEnum, IsNotEmpty, IsString, ValidateIf } from 'class-validator';
+
+import { PurchaseStatus } from '@module/purchase/domain/purchase.status.enum';
+
+export class UpdatePurchaseDto {
+  @IsNotEmpty()
+  @IsEnum(PurchaseStatus)
+  status!: PurchaseStatus;
+
+  @ValidateIf((o: UpdatePurchaseDto) =>
+    [
+      PurchaseStatus.COMPLETED,
+      PurchaseStatus.FAILED,
+      PurchaseStatus.REFUNDED,
+    ].includes(o.status),
+  )
+  @IsString()
+  externalId?: string;
+}

--- a/src/module/purchase/application/exception/course-not-published.exception.ts
+++ b/src/module/purchase/application/exception/course-not-published.exception.ts
@@ -1,0 +1,9 @@
+import { ForbiddenException } from '@nestjs/common';
+
+import { IBaseErrorInfo } from '@common/base/application/exception/app-error-response.interface';
+
+export class CourseNotPublishedException extends ForbiddenException {
+  constructor(params: IBaseErrorInfo) {
+    super(params);
+  }
+}

--- a/src/module/purchase/application/exception/invalid-purchase.exception.ts
+++ b/src/module/purchase/application/exception/invalid-purchase.exception.ts
@@ -1,0 +1,9 @@
+import { BadRequestException } from '@nestjs/common';
+
+import { IBaseErrorInfo } from '@common/base/application/exception/app-error-response.interface';
+
+export class InvalidPurchaseException extends BadRequestException {
+  constructor(params: IBaseErrorInfo) {
+    super(params);
+  }
+}

--- a/src/module/purchase/application/exception/purchase-already-exists-exception.ts
+++ b/src/module/purchase/application/exception/purchase-already-exists-exception.ts
@@ -1,0 +1,9 @@
+import { ConflictException } from '@nestjs/common';
+
+import { IBaseErrorInfo } from '@common/base/application/exception/app-error-response.interface';
+
+export class PurchaseAlreadyExists extends ConflictException {
+  constructor(params: IBaseErrorInfo) {
+    super(params);
+  }
+}

--- a/src/module/purchase/application/exception/purchase-exception.messages.ts
+++ b/src/module/purchase/application/exception/purchase-exception.messages.ts
@@ -1,0 +1,6 @@
+export const COURSE_WITH_ID_MESSAGE = 'The course with id';
+export const COURSE_NOT_PUBLISHED_MESSAGE = 'is not published yet';
+export const CAN_NOT_BUY_OWN_COURSE_MESSAGE = "You can't buy your own course";
+export const PURCHASE_FOR_COURSE_MESSAGE = 'A purchase for the course with id';
+export const PURCHASE_ALREADY_EXISTS_MESSAGE = 'already exists with status';
+export const STATUS_TRANSITION_MESSAGE = 'Status transition from';

--- a/src/module/purchase/application/exception/self-purchase-not-allowed.exception.ts
+++ b/src/module/purchase/application/exception/self-purchase-not-allowed.exception.ts
@@ -1,0 +1,9 @@
+import { ForbiddenException } from '@nestjs/common';
+
+import { IBaseErrorInfo } from '@common/base/application/exception/app-error-response.interface';
+
+export class SelfPurchaseNotAllowedException extends ForbiddenException {
+  constructor(params: IBaseErrorInfo) {
+    super(params);
+  }
+}

--- a/src/module/purchase/application/mapper/purchase-dto.mapper.ts
+++ b/src/module/purchase/application/mapper/purchase-dto.mapper.ts
@@ -1,0 +1,92 @@
+import { IDtoMapper } from '@common/base/application/mapper/entity.mapper';
+
+import { CreatePurchaseDto } from '@module/purchase/application/dto/create-purchase.dto';
+import { PurchaseResponseDto } from '@module/purchase/application/dto/purchase-response.dto';
+import { UpdatePurchaseDto } from '@module/purchase/application/dto/update-purchase.dto';
+import { Purchase } from '@module/purchase/domain/purchase.entity';
+
+export class PurchaseDtoMapper
+  implements
+    IDtoMapper<
+      Purchase,
+      CreatePurchaseDto,
+      UpdatePurchaseDto,
+      PurchaseResponseDto
+    >
+{
+  fromCreateDtoToEntity(dto: CreatePurchaseDto): Purchase {
+    const {
+      userId,
+      courseId,
+      amount,
+      status,
+      externalId,
+      id,
+      createdAt,
+      deletedAt,
+      updatedAt,
+    } = dto;
+
+    return new Purchase(
+      userId,
+      courseId,
+      amount as number,
+      status,
+      externalId,
+      id,
+      createdAt,
+      updatedAt,
+      deletedAt,
+    );
+  }
+
+  fromUpdateDtoToEntity(entity: Purchase, dto: UpdatePurchaseDto): Purchase {
+    const {
+      userId,
+      courseId,
+      amount,
+      externalId,
+      id,
+      createdAt,
+      updatedAt,
+      deletedAt,
+    } = entity;
+
+    return new Purchase(
+      userId,
+      courseId,
+      amount,
+      dto.status,
+      dto.externalId ?? externalId,
+      id,
+      createdAt,
+      updatedAt,
+      deletedAt,
+    );
+  }
+
+  fromEntityToResponseDto(entity: Purchase): PurchaseResponseDto {
+    const {
+      userId,
+      courseId,
+      amount,
+      status,
+      externalId,
+      id,
+      createdAt,
+      updatedAt,
+    } = entity;
+
+    return new PurchaseResponseDto(
+      Purchase.getEntityName(),
+      userId,
+      courseId,
+      amount,
+      status,
+      externalId,
+      id,
+      createdAt,
+      updatedAt,
+    );
+  }
+}

--- a/src/module/purchase/application/mapper/purchase.mapper.ts
+++ b/src/module/purchase/application/mapper/purchase.mapper.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@nestjs/common';
+
+import { IEntityMapper } from '@common/base/application/mapper/entity.mapper';
+
+import { Purchase } from '@module/purchase/domain/purchase.entity';
+import { PurchaseEntity } from '@module/purchase/infrastructure/database/purchase.entity';
+
+@Injectable()
+export class PurchaseMapper implements IEntityMapper<Purchase, PurchaseEntity> {
+  toDomainEntity(entity: PurchaseEntity): Purchase {
+    const {
+      userId,
+      courseId,
+      amount,
+      status,
+      externalId,
+      id,
+      createdAt,
+      updatedAt,
+      deletedAt,
+    } = entity;
+
+    return new Purchase(
+      userId,
+      courseId,
+      amount,
+      status,
+      externalId,
+      id,
+      createdAt?.toISOString(),
+      updatedAt?.toISOString(),
+      deletedAt?.toISOString(),
+    );
+  }
+
+  toPersistenceEntity(domain: Purchase): PurchaseEntity {
+    const { userId, courseId, amount, status, externalId, id } = domain;
+
+    return new PurchaseEntity(userId, courseId, amount, status, externalId, id);
+  }
+}

--- a/src/module/purchase/application/repository/purchase-repository.interface.ts
+++ b/src/module/purchase/application/repository/purchase-repository.interface.ts
@@ -1,0 +1,14 @@
+import BaseRepository from '@common/base/infrastructure/database/base.repository';
+
+import { Purchase } from '@module/purchase/domain/purchase.entity';
+import { PurchaseEntity } from '@module/purchase/infrastructure/database/purchase.entity';
+
+export const PURCHASE_REPOSITORY_KEY = 'purchase_repository';
+
+export interface IPurchaseRepository
+  extends Omit<
+    BaseRepository<Purchase, PurchaseEntity>,
+    'deleteOneByIdOrFail'
+  > {
+  findUserPurchase(userId: string, courseId: string): Promise<Purchase | null>;
+}

--- a/src/module/purchase/application/service/purchase-CRUD-service.interface.ts
+++ b/src/module/purchase/application/service/purchase-CRUD-service.interface.ts
@@ -1,0 +1,20 @@
+import { ICRUDService } from '@common/base/application/service/crud-service.interface';
+
+import { CreatePurchaseDto } from '@module/purchase/application/dto/create-purchase.dto';
+import { PurchaseResponseDto } from '@module/purchase/application/dto/purchase-response.dto';
+import { UpdatePurchaseDto } from '@module/purchase/application/dto/update-purchase.dto';
+import { Purchase } from '@module/purchase/domain/purchase.entity';
+
+export const PURCHASE_CRUD_SERVICE_KEY = 'purchase_crud_service';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface IPurchaseCRUDService
+  extends Omit<
+    ICRUDService<
+      Purchase,
+      PurchaseResponseDto,
+      CreatePurchaseDto,
+      UpdatePurchaseDto
+    >,
+    'deleteOneByIdOrFail'
+  > {}

--- a/src/module/purchase/application/service/purchase-CRUD.service.ts
+++ b/src/module/purchase/application/service/purchase-CRUD.service.ts
@@ -1,0 +1,142 @@
+import { Inject, Injectable } from '@nestjs/common';
+
+import { PublishStatus } from '@common/base/application/enum/publish-status.enum';
+import { IS_NOT_VALID_MESSAGE } from '@common/base/application/exception/base-exception.messages';
+import { BaseCRUDService } from '@common/base/application/service/base-crud.service';
+import BaseRepository from '@common/base/infrastructure/database/base.repository';
+
+import {
+  COURSE_REPOSITORY_KEY,
+  ICourseRepository,
+} from '@module/course/application/repository/repository.interface';
+import { CreatePurchaseDto } from '@module/purchase/application/dto/create-purchase.dto';
+import { PurchaseResponseDto } from '@module/purchase/application/dto/purchase-response.dto';
+import { UpdatePurchaseDto } from '@module/purchase/application/dto/update-purchase.dto';
+import { CourseNotPublishedException } from '@module/purchase/application/exception/course-not-published.exception';
+import { InvalidPurchaseException } from '@module/purchase/application/exception/invalid-purchase.exception';
+import { PurchaseAlreadyExists } from '@module/purchase/application/exception/purchase-already-exists-exception';
+import {
+  CAN_NOT_BUY_OWN_COURSE_MESSAGE,
+  COURSE_NOT_PUBLISHED_MESSAGE,
+  COURSE_WITH_ID_MESSAGE,
+  PURCHASE_ALREADY_EXISTS_MESSAGE,
+  PURCHASE_FOR_COURSE_MESSAGE,
+  STATUS_TRANSITION_MESSAGE,
+} from '@module/purchase/application/exception/purchase-exception.messages';
+import { SelfPurchaseNotAllowedException } from '@module/purchase/application/exception/self-purchase-not-allowed.exception';
+import { PurchaseDtoMapper } from '@module/purchase/application/mapper/purchase-dto.mapper';
+import {
+  IPurchaseRepository,
+  PURCHASE_REPOSITORY_KEY,
+} from '@module/purchase/application/repository/purchase-repository.interface';
+import { IPurchaseCRUDService } from '@module/purchase/application/service/purchase-CRUD-service.interface';
+import { Purchase } from '@module/purchase/domain/purchase.entity';
+import { PurchaseStatus } from '@module/purchase/domain/purchase.status.enum';
+import { PurchaseEntity } from '@module/purchase/infrastructure/database/purchase.entity';
+
+@Injectable()
+export class PurchaseCRUDService
+  extends BaseCRUDService<
+    Purchase,
+    PurchaseEntity,
+    CreatePurchaseDto,
+    UpdatePurchaseDto,
+    PurchaseResponseDto
+  >
+  implements IPurchaseCRUDService
+{
+  declare deleteOneByIdOrFail: never;
+
+  constructor(
+    @Inject(PURCHASE_REPOSITORY_KEY)
+    private readonly purchaseRepository: IPurchaseRepository,
+    private readonly purchaseDtoMapper: PurchaseDtoMapper,
+    @Inject(COURSE_REPOSITORY_KEY)
+    private readonly courseRepository: ICourseRepository,
+  ) {
+    super(
+      purchaseRepository as unknown as BaseRepository<Purchase, PurchaseEntity>,
+      purchaseDtoMapper,
+      Purchase.getEntityName(),
+    );
+  }
+
+  async saveOne(createDto: CreatePurchaseDto): Promise<PurchaseResponseDto> {
+    const { courseId, userId } = createDto;
+    const course = await this.courseRepository.getOneByIdOrFail(courseId);
+    const existingPurchase = await this.purchaseRepository.findUserPurchase(
+      userId,
+      courseId,
+    );
+
+    this.validatePurchase(
+      courseId,
+      userId,
+      course.instructorId,
+      existingPurchase,
+      course.status,
+    );
+
+    createDto.amount = course.price!;
+    return await super.saveOne(createDto);
+  }
+
+  async updateOneByIdOrFail(
+    id: string,
+    updateDto: UpdatePurchaseDto,
+  ): Promise<PurchaseResponseDto> {
+    const purchaseToUpdate = await this.purchaseRepository.getOneByIdOrFail(id);
+    this.validateStatusTransition(purchaseToUpdate.status, updateDto.status);
+    const purchase = this.purchaseDtoMapper.fromUpdateDtoToEntity(
+      purchaseToUpdate,
+      updateDto,
+    );
+    const updatedPurchase = await this.purchaseRepository.saveOne(purchase);
+    const responseDto =
+      this.purchaseDtoMapper.fromEntityToResponseDto(updatedPurchase);
+    return responseDto;
+  }
+
+  private validatePurchase(
+    courseId: string,
+    userId: string,
+    instructorId: string,
+    existingPurchase: Purchase | null,
+    courseStatus?: PublishStatus,
+  ): void {
+    if (courseStatus !== PublishStatus.published) {
+      throw new CourseNotPublishedException({
+        message: `${COURSE_WITH_ID_MESSAGE} ${courseId} ${COURSE_NOT_PUBLISHED_MESSAGE}`,
+      });
+    } else if (instructorId === userId) {
+      throw new SelfPurchaseNotAllowedException({
+        message: CAN_NOT_BUY_OWN_COURSE_MESSAGE,
+      });
+    } else if (existingPurchase) {
+      throw new PurchaseAlreadyExists({
+        message: `${PURCHASE_FOR_COURSE_MESSAGE} ${courseId} ${PURCHASE_ALREADY_EXISTS_MESSAGE} ${existingPurchase.status}`,
+      });
+    }
+  }
+
+  private validateStatusTransition(
+    current: PurchaseStatus,
+    next: PurchaseStatus,
+  ): void {
+    const validTransitions: Record<PurchaseStatus, PurchaseStatus[]> = {
+      [PurchaseStatus.PENDING]: [
+        PurchaseStatus.COMPLETED,
+        PurchaseStatus.FAILED,
+      ],
+      [PurchaseStatus.COMPLETED]: [PurchaseStatus.REFUNDED],
+      [PurchaseStatus.FAILED]: [],
+      [PurchaseStatus.REFUNDED]: [],
+    };
+
+    if (!validTransitions[current].includes(next)) {
+      throw new InvalidPurchaseException({
+        message: `${STATUS_TRANSITION_MESSAGE} ${current} to ${next} ${IS_NOT_VALID_MESSAGE}`,
+      });
+    }
+  }
+}

--- a/src/module/purchase/domain/purchase.entity.ts
+++ b/src/module/purchase/domain/purchase.entity.ts
@@ -1,0 +1,31 @@
+import { Base } from '@common/base/domain/base.entity';
+
+import { PurchaseStatus } from '@module/purchase/domain/purchase.status.enum';
+
+export class Purchase extends Base {
+  userId: string;
+  courseId: string;
+  amount: number;
+  status: PurchaseStatus;
+  externalId?: string;
+
+  constructor(
+    userId: string,
+    courseId: string,
+    amount: number,
+    status: PurchaseStatus,
+    externalId?: string,
+    id?: string,
+    createdAt?: string,
+    updatedAt?: string,
+    deletedAt?: string,
+  ) {
+    super(id, createdAt, updatedAt, deletedAt);
+
+    this.userId = userId;
+    this.courseId = courseId;
+    this.amount = amount;
+    this.status = status;
+    this.externalId = externalId;
+  }
+}

--- a/src/module/purchase/domain/purchase.status.enum.ts
+++ b/src/module/purchase/domain/purchase.status.enum.ts
@@ -1,0 +1,6 @@
+export enum PurchaseStatus {
+  PENDING = 'pending',
+  COMPLETED = 'completed',
+  FAILED = 'failed',
+  REFUNDED = 'refunded',
+}

--- a/src/module/purchase/infrastructure/database/purchase.entity.ts
+++ b/src/module/purchase/infrastructure/database/purchase.entity.ts
@@ -1,0 +1,49 @@
+import { Column, Entity } from 'typeorm';
+
+import { BaseEntity } from '@common/base/infrastructure/database/base.entity';
+
+import { PurchaseStatus } from '@module/purchase/domain/purchase.status.enum';
+
+@Entity('purchase')
+export class PurchaseEntity extends BaseEntity {
+  @Column({ type: 'uuid' })
+  userId: string;
+
+  @Column({ type: 'uuid' })
+  courseId: string;
+
+  @Column({
+    type: 'decimal',
+    precision: 10,
+    scale: 2,
+    nullable: true,
+    transformer: {
+      to: (value: number | null) => value,
+      from: (value: string | null) => (value ? parseFloat(value) : null),
+    },
+  })
+  amount: number;
+
+  @Column({ type: 'varchar' })
+  status: PurchaseStatus;
+
+  @Column({ type: 'varchar', nullable: true })
+  externalId?: string;
+
+  constructor(
+    userId: string,
+    courseId: string,
+    amount: number,
+    status: PurchaseStatus,
+    externalId?: string,
+    id?: string,
+  ) {
+    super(id);
+
+    this.userId = userId;
+    this.courseId = courseId;
+    this.amount = amount;
+    this.status = status;
+    this.externalId = externalId;
+  }
+}

--- a/src/module/purchase/infrastructure/database/purchase.postgres.repository.ts
+++ b/src/module/purchase/infrastructure/database/purchase.postgres.repository.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, Repository } from 'typeorm';
+
+import BaseRepository from '@common/base/infrastructure/database/base.repository';
+
+import { PurchaseMapper } from '@module/purchase/application/mapper/purchase.mapper';
+import { IPurchaseRepository } from '@module/purchase/application/repository/purchase-repository.interface';
+import { Purchase } from '@module/purchase/domain/purchase.entity';
+import { PurchaseStatus } from '@module/purchase/domain/purchase.status.enum';
+import { PurchaseEntity } from '@module/purchase/infrastructure/database/purchase.entity';
+
+@Injectable()
+export class PurchasePostgresRepository
+  extends BaseRepository<Purchase, PurchaseEntity>
+  implements IPurchaseRepository
+{
+  declare deleteOneByIdOrFail: never;
+
+  constructor(
+    @InjectRepository(PurchaseEntity)
+    private readonly purchaseRepository: Repository<PurchaseEntity>,
+    private readonly purchaseMapper: PurchaseMapper,
+  ) {
+    super(purchaseRepository, purchaseMapper);
+  }
+
+  async findUserPurchase(
+    userId: string,
+    courseId: string,
+  ): Promise<Purchase | null> {
+    const purchaseEntity = await this.purchaseRepository.findOneBy({
+      userId,
+      courseId,
+      status: In([PurchaseStatus.COMPLETED, PurchaseStatus.PENDING]),
+    });
+
+    return purchaseEntity
+      ? this.purchaseMapper.toDomainEntity(purchaseEntity)
+      : null;
+  }
+}

--- a/src/module/purchase/interface/purchase.controller.ts
+++ b/src/module/purchase/interface/purchase.controller.ts
@@ -1,0 +1,57 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Inject,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+} from '@nestjs/common';
+
+import { CurrentUser } from '@module/iam/authentication/infrastructure/decorator/current-user.decorator';
+import { User } from '@module/iam/user/domain/user.entity';
+import { CreatePurchaseDtoRequest } from '@module/purchase/application/dto/create-purchase.dto';
+import { PurchaseResponseDto } from '@module/purchase/application/dto/purchase-response.dto';
+import { UpdatePurchaseDto } from '@module/purchase/application/dto/update-purchase.dto';
+import {
+  IPurchaseCRUDService,
+  PURCHASE_CRUD_SERVICE_KEY,
+} from '@module/purchase/application/service/purchase-CRUD-service.interface';
+
+@Controller('purchase')
+export class PurchaseController {
+  constructor(
+    @Inject(PURCHASE_CRUD_SERVICE_KEY)
+    private readonly purchaseService: IPurchaseCRUDService,
+  ) {}
+
+  @Get(':id')
+  async getOneById(
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<PurchaseResponseDto> {
+    return await this.purchaseService.getOneByIdOrFail(id);
+  }
+
+  @Post()
+  async saveOne(
+    @Body() createPurchaseDto: CreatePurchaseDtoRequest,
+    @CurrentUser() user: User,
+  ): Promise<PurchaseResponseDto> {
+    return await this.purchaseService.saveOne({
+      ...createPurchaseDto,
+      userId: user.id!,
+    });
+  }
+
+  @Patch(':id')
+  async updateOne(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() updatePurchaseDto: UpdatePurchaseDto,
+  ): Promise<PurchaseResponseDto> {
+    return await this.purchaseService.updateOneByIdOrFail(
+      id,
+      updatePurchaseDto,
+    );
+  }
+}

--- a/src/module/purchase/purchase.module.ts
+++ b/src/module/purchase/purchase.module.ts
@@ -1,0 +1,39 @@
+import { Module, Provider } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { CourseModule } from '@module/course/course.module';
+import { CourseEntity } from '@module/course/infrastructure/database/course.entity';
+import { PurchaseDtoMapper } from '@module/purchase/application/mapper/purchase-dto.mapper';
+import { PurchaseMapper } from '@module/purchase/application/mapper/purchase.mapper';
+import { PURCHASE_REPOSITORY_KEY } from '@module/purchase/application/repository/purchase-repository.interface';
+import { PURCHASE_CRUD_SERVICE_KEY } from '@module/purchase/application/service/purchase-CRUD-service.interface';
+import { PurchaseCRUDService } from '@module/purchase/application/service/purchase-CRUD.service';
+import { PurchaseEntity } from '@module/purchase/infrastructure/database/purchase.entity';
+import { PurchasePostgresRepository } from '@module/purchase/infrastructure/database/purchase.postgres.repository';
+import { PurchaseController } from '@module/purchase/interface/purchase.controller';
+
+const purchaseRepositoryProvider: Provider = {
+  provide: PURCHASE_REPOSITORY_KEY,
+  useClass: PurchasePostgresRepository,
+};
+
+const purchaseCRUDServiceProvider: Provider = {
+  provide: PURCHASE_CRUD_SERVICE_KEY,
+  useClass: PurchaseCRUDService,
+};
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([PurchaseEntity, CourseEntity]),
+    CourseModule,
+  ],
+  providers: [
+    purchaseRepositoryProvider,
+    purchaseCRUDServiceProvider,
+    PurchaseMapper,
+    PurchaseDtoMapper,
+  ],
+  controllers: [PurchaseController],
+  exports: [],
+})
+export class PurchaseModule {}

--- a/src/module/section/interface/section.controller.ts
+++ b/src/module/section/interface/section.controller.ts
@@ -68,7 +68,7 @@ export class SectionController {
     @Param('id', ParseUUIDPipe) id: string,
     @Body() updateDto: UpdateSectionDto,
   ): Promise<SectionResponseDto> {
-    return this.sectionService.updateOne(id, updateDto);
+    return this.sectionService.updateOneByIdOrFail(id, updateDto);
   }
 
   @Delete(':id')


### PR DESCRIPTION
# Summary

This PR introduces the `PurchaseModule` with `getOneByIdOrFail`, `saveOne` and `updateOneByIdOrFail` methods, including business logic for validating purchases saving.

# Details

- Implemented domain and typeorm entities for Purchases with a migration.
- Created DTOs to validate purchase's data requests and responses.
- Implemented mappers for conversions:
- - Between DTOs and domain entities.
- - Between TypeORM and domain entities.
- Added custom exceptions (e.g., `SelfPurchaseNotAllowedException`) for clearer error feedback.
- Developed the `PurchaseCRUDService` with business logic to prevent wrong purchases to be saved.
- Added the `PurchaseController` to handle purchase's routes.