### PR TITLE
feat: Add purchase permissions

### DIFF
--- a/src/module/iam/authorization/infrastructure/casl/type/app-subjects.type.ts
+++ b/src/module/iam/authorization/infrastructure/casl/type/app-subjects.type.ts
@@ -4,6 +4,7 @@ import { Course } from '@module/course/domain/course.entity';
 import { User } from '@module/iam/user/domain/user.entity';
 import { Lesson } from '@module/lesson/domain/lesson.entity';
 import { PaymentMethod } from '@module/payment-method/domain/payment-method.entity';
+import { Purchase } from '@module/purchase/domain/purchase.entity';
 import { Section } from '@module/section/domain/section.entity';
 
 export type AppSubjects =
@@ -18,5 +19,7 @@ export type AppSubjects =
       | Lesson
       | typeof PaymentMethod
       | PaymentMethod
+      | typeof Purchase
+      | Purchase
     >
   | 'all';

--- a/src/module/purchase/__test__/fixture/User.yml
+++ b/src/module/purchase/__test__/fixture/User.yml
@@ -1,5 +1,12 @@
 entity: user
 items:
+  super-admin-user:
+    firstName: super-admin-name
+    lastName: super-admin-surname
+    email: 'test_super_admin@email.co'
+    avatarUrl: '{{internet.url}}'
+    externalId: '00000000-0000-0000-0000-00000000000X'
+    roles: regular,admin,superAdmin
   admin-user:
     id: a90108bf-42c6-481f-a63f-4b51fed1300c
     firstName: admin-name

--- a/src/module/purchase/application/policy/read-purchase-policy.handler.ts
+++ b/src/module/purchase/application/policy/read-purchase-policy.handler.ts
@@ -1,0 +1,48 @@
+import { ForbiddenException, Inject, Injectable } from '@nestjs/common';
+import { Request } from 'express';
+
+import { BasePolicyHandler } from '@module/iam/authorization/application/policy/base-policy.handler';
+import { AuthorizationService } from '@module/iam/authorization/application/service/authorization.service';
+import { AppAction } from '@module/iam/authorization/domain/app.action.enum';
+import { IPolicyHandler } from '@module/iam/authorization/infrastructure/policy/handler/policy-handler.interface';
+import { PolicyHandlerStorage } from '@module/iam/authorization/infrastructure/policy/storage/policies-handler.storage';
+import {
+  IPurchaseRepository,
+  PURCHASE_REPOSITORY_KEY,
+} from '@module/purchase/application/repository/purchase-repository.interface';
+
+@Injectable()
+export class ReadPurchasePolicyHandler
+  extends BasePolicyHandler
+  implements IPolicyHandler
+{
+  private readonly action = AppAction.Read;
+
+  constructor(
+    private readonly policyHandlerStorage: PolicyHandlerStorage,
+    private readonly authorizationService: AuthorizationService,
+    @Inject(PURCHASE_REPOSITORY_KEY)
+    private readonly purchaseRepository: IPurchaseRepository,
+  ) {
+    super();
+    this.policyHandlerStorage.add(ReadPurchasePolicyHandler, this);
+  }
+
+  async handle(request: Request): Promise<void> {
+    const user = this.getCurrentUser(request);
+    const purchaseId = request.params.id;
+    const purchase = await this.purchaseRepository.getOneByIdOrFail(purchaseId);
+
+    const isAllowed = this.authorizationService.isAllowed(
+      user,
+      this.action,
+      purchase,
+    );
+
+    if (!isAllowed) {
+      throw new ForbiddenException(
+        `You are not allowed to ${this.action.toUpperCase()} this resource`,
+      );
+    }
+  }
+}

--- a/src/module/purchase/application/policy/update-purchase-policy.handler.ts
+++ b/src/module/purchase/application/policy/update-purchase-policy.handler.ts
@@ -1,0 +1,41 @@
+import { ForbiddenException, Injectable } from '@nestjs/common';
+import { Request } from 'express';
+
+import { BasePolicyHandler } from '@module/iam/authorization/application/policy/base-policy.handler';
+import { AuthorizationService } from '@module/iam/authorization/application/service/authorization.service';
+import { AppAction } from '@module/iam/authorization/domain/app.action.enum';
+import { IPolicyHandler } from '@module/iam/authorization/infrastructure/policy/handler/policy-handler.interface';
+import { PolicyHandlerStorage } from '@module/iam/authorization/infrastructure/policy/storage/policies-handler.storage';
+import { Purchase } from '@module/purchase/domain/purchase.entity';
+
+@Injectable()
+export class UpdatePurchasePolicyHandler
+  extends BasePolicyHandler
+  implements IPolicyHandler
+{
+  private readonly action = AppAction.Update;
+
+  constructor(
+    private readonly policyHandlerStorage: PolicyHandlerStorage,
+    private readonly authorizationService: AuthorizationService,
+  ) {
+    super();
+    this.policyHandlerStorage.add(UpdatePurchasePolicyHandler, this);
+  }
+
+  handle(request: Request): void {
+    const user = this.getCurrentUser(request);
+
+    const isAllowed = this.authorizationService.isAllowed(
+      user,
+      this.action,
+      Purchase,
+    );
+
+    if (!isAllowed) {
+      throw new ForbiddenException(
+        `You are not allowed to ${this.action.toUpperCase()} this resource`,
+      );
+    }
+  }
+}

--- a/src/module/purchase/domain/purchase.permissions.ts
+++ b/src/module/purchase/domain/purchase.permissions.ts
@@ -1,0 +1,20 @@
+import { AppRole } from '@module/iam/authorization/domain/app-role.enum';
+import { AppAction } from '@module/iam/authorization/domain/app.action.enum';
+import { IPermissionsDefinition } from '@module/iam/authorization/infrastructure/policy/type/permissions-definition.interface';
+import { Purchase } from '@module/purchase/domain/purchase.entity';
+
+export const purchasePermissions: IPermissionsDefinition = {
+  [AppRole.Regular](user, { can }) {
+    can(AppAction.Read, Purchase, {
+      userId: user.id,
+    });
+  },
+  [AppRole.Admin](user, { can }) {
+    can(AppAction.Read, Purchase, {
+      userId: user.id,
+    });
+  },
+  [AppRole.SuperAdmin](_, { can }) {
+    can(AppAction.Manage, Purchase);
+  },
+};

--- a/src/module/purchase/interface/purchase.controller.ts
+++ b/src/module/purchase/interface/purchase.controller.ts
@@ -7,19 +7,25 @@ import {
   ParseUUIDPipe,
   Patch,
   Post,
+  UseGuards,
 } from '@nestjs/common';
 
 import { CurrentUser } from '@module/iam/authentication/infrastructure/decorator/current-user.decorator';
+import { Policies } from '@module/iam/authorization/infrastructure/policy/decorator/policy.decorator';
+import { PoliciesGuard } from '@module/iam/authorization/infrastructure/policy/guard/policy.guard';
 import { User } from '@module/iam/user/domain/user.entity';
 import { CreatePurchaseDtoRequest } from '@module/purchase/application/dto/create-purchase.dto';
 import { PurchaseResponseDto } from '@module/purchase/application/dto/purchase-response.dto';
 import { UpdatePurchaseDto } from '@module/purchase/application/dto/update-purchase.dto';
+import { ReadPurchasePolicyHandler } from '@module/purchase/application/policy/read-purchase-policy.handler';
+import { UpdatePurchasePolicyHandler } from '@module/purchase/application/policy/update-purchase-policy.handler';
 import {
   IPurchaseCRUDService,
   PURCHASE_CRUD_SERVICE_KEY,
 } from '@module/purchase/application/service/purchase-CRUD-service.interface';
 
 @Controller('purchase')
+@UseGuards(PoliciesGuard)
 export class PurchaseController {
   constructor(
     @Inject(PURCHASE_CRUD_SERVICE_KEY)
@@ -27,6 +33,7 @@ export class PurchaseController {
   ) {}
 
   @Get(':id')
+  @Policies(ReadPurchasePolicyHandler)
   async getOneById(
     @Param('id', ParseUUIDPipe) id: string,
   ): Promise<PurchaseResponseDto> {
@@ -45,6 +52,7 @@ export class PurchaseController {
   }
 
   @Patch(':id')
+  @Policies(UpdatePurchasePolicyHandler)
   async updateOne(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() updatePurchaseDto: UpdatePurchaseDto,


### PR DESCRIPTION
# Summary

This PR updates the `PurchaseModule` with permission definitions and policy handlers for `READ` and `UPDATE` actions.

# Details

- Added permission definitions for the `Purchase` entitity, based on users roles.
- Implemented a `ReadPurchasePolicyHandler` and a `UpdatePurchasePolicyHandler` to validate the access of the user.
- Updated the `PurchaseController` with the new permissions.
- Added tests to verify the functionality of the permissions.