### PR TITLE
feat: Add purchase - payment method relation

### DIFF
--- a/data/migrations/1754051996805-add-purchase-payment-method-relation.ts
+++ b/data/migrations/1754051996805-add-purchase-payment-method-relation.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddPurchasePaymentMethodRelation1754051996805 implements MigrationInterface {
+    name = 'AddPurchasePaymentMethodRelation1754051996805'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "purchase" ADD "payment_method_id" uuid NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "purchase" ADD CONSTRAINT "FK_2d44d35774ef22e1a580ca062b2" FOREIGN KEY ("payment_method_id") REFERENCES "payment_method"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "purchase" DROP CONSTRAINT "FK_2d44d35774ef22e1a580ca062b2"`);
+        await queryRunner.query(`ALTER TABLE "purchase" DROP COLUMN "payment_method_id"`);
+    }
+
+}

--- a/src/common/base/application/dto/query-params/get-all-options.interface.ts
+++ b/src/common/base/application/dto/query-params/get-all-options.interface.ts
@@ -9,7 +9,7 @@ export type SimpleProps<T> = {
 }[keyof T];
 
 type ComplexProps<T> = {
-  [K in keyof T]: T[K] extends object | object[] ? K : never;
+  [K in keyof T]: NonNullable<T[K]> extends object | object[] ? K : never;
 }[keyof T];
 
 export type Filter<T> = Partial<Pick<T, SimpleProps<T>>>;

--- a/src/common/base/application/service/crud-service.interface.ts
+++ b/src/common/base/application/service/crud-service.interface.ts
@@ -1,6 +1,9 @@
 import { CollectionDto } from '@common/base/application/dto/collection.dto';
 import { IDto, IResponseDto } from '@common/base/application/dto/dto.interface';
-import { IGetAllOptions } from '@common/base/application/dto/query-params/get-all-options.interface';
+import {
+  EntityRelations,
+  IGetAllOptions,
+} from '@common/base/application/dto/query-params/get-all-options.interface';
 import { SuccessOperationResponseDto } from '@common/base/application/dto/success-operation-response.dto';
 import IEntity from '@common/base/domain/entity.interface';
 
@@ -11,7 +14,10 @@ export interface ICRUDService<
   UpdateDto extends IDto,
 > {
   getAll(options?: IGetAllOptions<Entity>): Promise<CollectionDto<ResponseDto>>;
-  getOneByIdOrFail(id: string): Promise<ResponseDto>;
+  getOneByIdOrFail(
+    id: string,
+    include?: EntityRelations<Entity>,
+  ): Promise<ResponseDto>;
   saveOne(createDto: CreateDto): Promise<ResponseDto>;
   updateOneByIdOrFail(id: string, updateDto: UpdateDto): Promise<ResponseDto>;
   deleteOneByIdOrFail(id: string): Promise<SuccessOperationResponseDto>;

--- a/src/module/iam/authorization/infrastructure/casl/type/app-subjects.type.ts
+++ b/src/module/iam/authorization/infrastructure/casl/type/app-subjects.type.ts
@@ -4,6 +4,8 @@ import { User } from '@iam/user/domain/user.entity';
 
 import { Course } from '@course/domain/course.entity';
 
+import { Category } from '@category/domain/category.entity';
+
 import { Section } from '@section/domain/section.entity';
 
 import { Lesson } from '@lesson/domain/lesson.entity';
@@ -26,5 +28,7 @@ export type AppSubjects =
       | PaymentMethod
       | typeof Purchase
       | Purchase
+      | Category
+      | typeof Category
     >
   | 'all';

--- a/src/module/payment-method/application/mapper/payment-method-dto.mapper.ts
+++ b/src/module/payment-method/application/mapper/payment-method-dto.mapper.ts
@@ -1,3 +1,5 @@
+import { Injectable } from '@nestjs/common';
+
 import { fromStringToKebabCase } from '@common/base/application/mapper/base.mapper';
 import { IDtoMapper } from '@common/base/application/mapper/entity.mapper';
 
@@ -6,6 +8,7 @@ import { PaymentMethodResponseDto } from '@payment-method/application/dto/paymen
 import { UpdatePaymentMethodDto } from '@payment-method/application/dto/update-payment-method.dto';
 import { PaymentMethod } from '@payment-method/domain/payment-method.entity';
 
+@Injectable()
 export class PaymentMethodDtoMapper
   implements
     IDtoMapper<

--- a/src/module/payment-method/application/mapper/payment-method.mapper.ts
+++ b/src/module/payment-method/application/mapper/payment-method.mapper.ts
@@ -1,15 +1,24 @@
+import { Injectable } from '@nestjs/common';
+
 import { IEntityMapper } from '@common/base/application/mapper/entity.mapper';
 
 import { PaymentMethod } from '@payment-method/domain/payment-method.entity';
 import { PaymentMethodEntity } from '@payment-method/infrastructure/database/payment-method.entity';
 
+@Injectable()
 export class PaymentMethodMapper
   implements IEntityMapper<PaymentMethod, PaymentMethodEntity>
 {
   toDomainEntity(entity: PaymentMethodEntity): PaymentMethod {
-    const { name, id } = entity;
+    const { name, id, createdAt, updatedAt, deletedAt } = entity;
 
-    return new PaymentMethod(name, id);
+    return new PaymentMethod(
+      name,
+      id,
+      createdAt?.toISOString(),
+      updatedAt?.toISOString(),
+      deletedAt?.toISOString(),
+    );
   }
 
   toPersistenceEntity(domain: PaymentMethod): PaymentMethodEntity {

--- a/src/module/payment-method/domain/payment-method.entity.ts
+++ b/src/module/payment-method/domain/payment-method.entity.ts
@@ -3,8 +3,14 @@ import { Base } from '@common/base/domain/base.entity';
 export class PaymentMethod extends Base {
   name: string;
 
-  constructor(name: string, id?: string) {
-    super(id);
+  constructor(
+    name: string,
+    id?: string,
+    createdAt?: string,
+    updatedAt?: string,
+    deletedAt?: string,
+  ) {
+    super(id, createdAt, updatedAt, deletedAt);
     this.name = name;
   }
 }

--- a/src/module/payment-method/infrastructure/database/payment-method.entity.ts
+++ b/src/module/payment-method/infrastructure/database/payment-method.entity.ts
@@ -1,14 +1,25 @@
-import { Column, Entity } from 'typeorm';
+import { Column, Entity, OneToMany } from 'typeorm';
 
 import { BaseEntity } from '@common/base/infrastructure/database/base.entity';
+
+import { PurchaseEntity } from '@purchase/infrastructure/database/purchase.entity';
 
 @Entity('payment_method')
 export class PaymentMethodEntity extends BaseEntity {
   @Column({ type: 'varchar', length: 20, unique: true })
   name: string;
 
-  constructor(name: string, id?: string) {
-    super(id);
+  @OneToMany(() => PurchaseEntity, (purchase) => purchase.paymentMethod)
+  purchases?: PurchaseEntity[];
+
+  constructor(
+    name: string,
+    id?: string,
+    createdAt?: Date,
+    updatedAt?: Date,
+    deletedAt?: Date,
+  ) {
+    super(id, createdAt, updatedAt, deletedAt);
 
     this.name = name;
   }

--- a/src/module/payment-method/payment-method.module.ts
+++ b/src/module/payment-method/payment-method.module.ts
@@ -41,6 +41,7 @@ const policyHandlersProviders = [
     ...policyHandlersProviders,
   ],
   controllers: [PaymentMethodController],
+  exports: [PaymentMethodMapper],
 })
 export class PaymentMethodModule implements OnModuleInit {
   constructor(private readonly registry: AppSubjectPermissionStorage) {}

--- a/src/module/purchase/__test__/fixture/PaymentMethod.yml
+++ b/src/module/purchase/__test__/fixture/PaymentMethod.yml
@@ -1,0 +1,8 @@
+entity: payment_method
+items:
+  payment-method1:
+    id: '361cb833-1f51-4b21-b5e9-1089c5d09b09'
+    name: 'Stellar'
+  payment-method2:
+    id: '48c7bbe1-46d6-4e85-9dbf-610d52544ef7'
+    name: 'Stripe'

--- a/src/module/purchase/__test__/fixture/Purchase.yml
+++ b/src/module/purchase/__test__/fixture/Purchase.yml
@@ -6,9 +6,12 @@ items:
     courseId: 'ba7fc4eb-e4f7-47a9-b963-f1e733d39748'
     status: pending
     amount: 49.99
+    paymentMethodId: '361cb833-1f51-4b21-b5e9-1089c5d09b09'
   purchase1:
     id: 'a5978602-defc-4415-ae50-33ce6902e113'
     userId: '5e822193-13ca-4846-9b60-9f2f38d7eefa'
     courseId: '57732eea-ce64-4e9b-80c6-63a08ee82764'
     status: completed
     amount: 39.99
+    paymentMethodId: '361cb833-1f51-4b21-b5e9-1089c5d09b09'
+    paymentTransactionId: 'payment-transaction-1'

--- a/src/module/purchase/application/dto/purchase-response.dto.ts
+++ b/src/module/purchase/application/dto/purchase-response.dto.ts
@@ -1,14 +1,23 @@
 import { BaseResponseDto } from '@common/base/application/dto/base.response.dto';
 
+import { PaymentMethod } from '@payment-method/domain/payment-method.entity';
+
 import { PurchaseStatus } from '@purchase/domain/purchase.status.enum';
+
+export type PaymentMethodPurchaseResponseDto = Pick<
+  PaymentMethod,
+  'id' | 'name'
+>;
 
 export class PurchaseResponseDto extends BaseResponseDto {
   userId: string;
   courseId: string;
   amount: number;
   status: PurchaseStatus;
+  paymentMethodId: string;
   paymentTransactionId?: string;
   refundTransactionId?: string;
+  paymentMethod?: PaymentMethodPurchaseResponseDto;
   createdAt?: string;
   updatedAt?: string;
 
@@ -18,8 +27,10 @@ export class PurchaseResponseDto extends BaseResponseDto {
     courseId: string,
     amount: number,
     status: PurchaseStatus,
+    paymentMethodId: string,
     paymentTransactionId?: string,
     refundTransactionId?: string,
+    paymentMethod?: PaymentMethodPurchaseResponseDto,
     id?: string,
     createdAt?: string,
     updatedAt?: string,
@@ -30,8 +41,10 @@ export class PurchaseResponseDto extends BaseResponseDto {
     this.courseId = courseId;
     this.amount = amount;
     this.status = status;
+    this.paymentMethodId = paymentMethodId;
     this.paymentTransactionId = paymentTransactionId;
     this.refundTransactionId = refundTransactionId;
+    this.paymentMethod = paymentMethod;
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
   }

--- a/src/module/purchase/application/dto/purchase.dto.ts
+++ b/src/module/purchase/application/dto/purchase.dto.ts
@@ -11,6 +11,8 @@ import {
 
 import { BaseDto } from '@common/base/application/dto/base.dto';
 
+import { PaymentMethod } from '@payment-method/domain/payment-method.entity';
+
 import { PurchaseStatus } from '@purchase/domain/purchase.status.enum';
 
 export class PurchaseDto extends BaseDto {
@@ -34,6 +36,10 @@ export class PurchaseDto extends BaseDto {
   amount!: number;
 
   @IsNotEmpty()
+  @IsUUID()
+  paymentMethodId!: string;
+
+  @IsNotEmpty()
   @IsEnum(PurchaseStatus)
   status!: PurchaseStatus;
 
@@ -44,4 +50,6 @@ export class PurchaseDto extends BaseDto {
   @IsOptional()
   @IsString()
   refundTransactionId?: string;
+
+  paymentMethod?: PaymentMethod;
 }

--- a/src/module/purchase/application/dto/update-purchase-status.dto.ts
+++ b/src/module/purchase/application/dto/update-purchase-status.dto.ts
@@ -1,0 +1,7 @@
+import { OmitType } from '@nestjs/mapped-types';
+
+import { UpdatePurchaseDto } from '@purchase/application/dto/update-purchase.dto';
+
+export class UpdatePurchaseStatusDto extends OmitType(UpdatePurchaseDto, [
+  'paymentMethodId',
+]) {}

--- a/src/module/purchase/application/dto/update-purchase.dto.ts
+++ b/src/module/purchase/application/dto/update-purchase.dto.ts
@@ -1,4 +1,10 @@
-import { IsEnum, IsNotEmpty, IsString, ValidateIf } from 'class-validator';
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  ValidateIf,
+} from 'class-validator';
 
 import { PurchaseStatus } from '@purchase/domain/purchase.status.enum';
 
@@ -7,8 +13,14 @@ export class UpdatePurchaseDto {
   @IsEnum(PurchaseStatus)
   status!: PurchaseStatus;
 
-  @ValidateIf((o: UpdatePurchaseDto) =>
-    [PurchaseStatus.COMPLETED, PurchaseStatus.FAILED].includes(o.status),
+  @IsOptional()
+  @IsString()
+  paymentMethodId?: string;
+
+  @ValidateIf(
+    (o: UpdatePurchaseDto) =>
+      o.status !== undefined &&
+      [PurchaseStatus.COMPLETED, PurchaseStatus.FAILED].includes(o.status),
   )
   @IsNotEmpty()
   @IsString()

--- a/src/module/purchase/application/mapper/purchase-dto.mapper.ts
+++ b/src/module/purchase/application/mapper/purchase-dto.mapper.ts
@@ -1,10 +1,18 @@
+import { Injectable } from '@nestjs/common';
+
 import { IDtoMapper } from '@common/base/application/mapper/entity.mapper';
 
+import { PaymentMethod } from '@payment-method/domain/payment-method.entity';
+
 import { CreatePurchaseDto } from '@purchase/application/dto/create-purchase.dto';
-import { PurchaseResponseDto } from '@purchase/application/dto/purchase-response.dto';
+import {
+  PaymentMethodPurchaseResponseDto,
+  PurchaseResponseDto,
+} from '@purchase/application/dto/purchase-response.dto';
 import { UpdatePurchaseDto } from '@purchase/application/dto/update-purchase.dto';
 import { Purchase } from '@purchase/domain/purchase.entity';
 
+@Injectable()
 export class PurchaseDtoMapper
   implements
     IDtoMapper<
@@ -20,8 +28,10 @@ export class PurchaseDtoMapper
       courseId,
       amount,
       status,
+      paymentMethodId,
       paymentTransactionId,
       refundTransactionId,
+      paymentMethod,
       id,
       createdAt,
       deletedAt,
@@ -33,8 +43,10 @@ export class PurchaseDtoMapper
       courseId,
       amount as number,
       status,
+      paymentMethodId,
       paymentTransactionId,
       refundTransactionId,
+      paymentMethod,
       id,
       createdAt,
       updatedAt,
@@ -47,8 +59,11 @@ export class PurchaseDtoMapper
       userId,
       courseId,
       amount,
+      status,
+      paymentMethodId,
       paymentTransactionId,
       refundTransactionId,
+      paymentMethod,
       id,
       createdAt,
       updatedAt,
@@ -59,9 +74,11 @@ export class PurchaseDtoMapper
       userId,
       courseId,
       amount,
-      dto.status,
+      dto.status ?? status,
+      dto.paymentMethodId ?? paymentMethodId,
       dto.paymentTransactionId ?? paymentTransactionId,
       dto.refundTransactionId ?? refundTransactionId,
+      paymentMethod,
       id,
       createdAt,
       updatedAt,
@@ -75,8 +92,10 @@ export class PurchaseDtoMapper
       courseId,
       amount,
       status,
+      paymentMethodId,
       paymentTransactionId,
       refundTransactionId,
+      paymentMethod,
       id,
       createdAt,
       updatedAt,
@@ -88,11 +107,24 @@ export class PurchaseDtoMapper
       courseId,
       amount,
       status,
+      paymentMethodId,
       paymentTransactionId,
       refundTransactionId,
+      paymentMethod
+        ? this.buildPaymentMethodPurchaseDto(paymentMethod)
+        : undefined,
       id,
       createdAt,
       updatedAt,
     );
+  }
+
+  private buildPaymentMethodPurchaseDto(
+    paymentMethod: PaymentMethod,
+  ): PaymentMethodPurchaseResponseDto {
+    return {
+      id: paymentMethod.id,
+      name: paymentMethod.name,
+    };
   }
 }

--- a/src/module/purchase/application/mapper/purchase.mapper.ts
+++ b/src/module/purchase/application/mapper/purchase.mapper.ts
@@ -2,19 +2,25 @@ import { Injectable } from '@nestjs/common';
 
 import { IEntityMapper } from '@common/base/application/mapper/entity.mapper';
 
+import { PaymentMethodMapper } from '@payment-method/application/mapper/payment-method.mapper';
+
 import { Purchase } from '@purchase/domain/purchase.entity';
 import { PurchaseEntity } from '@purchase/infrastructure/database/purchase.entity';
 
 @Injectable()
 export class PurchaseMapper implements IEntityMapper<Purchase, PurchaseEntity> {
+  constructor(private readonly paymentMethodMapper: PaymentMethodMapper) {}
+
   toDomainEntity(entity: PurchaseEntity): Purchase {
     const {
       userId,
       courseId,
       amount,
       status,
+      paymentMethodId,
       paymentTransactionId,
       refundTransactionId,
+      paymentMethod,
       id,
       createdAt,
       updatedAt,
@@ -26,8 +32,12 @@ export class PurchaseMapper implements IEntityMapper<Purchase, PurchaseEntity> {
       courseId,
       amount,
       status,
+      paymentMethodId,
       paymentTransactionId,
       refundTransactionId,
+      paymentMethod
+        ? this.paymentMethodMapper.toDomainEntity(paymentMethod)
+        : undefined,
       id,
       createdAt?.toISOString(),
       updatedAt?.toISOString(),
@@ -41,6 +51,7 @@ export class PurchaseMapper implements IEntityMapper<Purchase, PurchaseEntity> {
       courseId,
       amount,
       status,
+      paymentMethodId,
       paymentTransactionId,
       refundTransactionId,
       id,
@@ -51,6 +62,7 @@ export class PurchaseMapper implements IEntityMapper<Purchase, PurchaseEntity> {
       courseId,
       amount,
       status,
+      paymentMethodId,
       paymentTransactionId,
       refundTransactionId,
       id,

--- a/src/module/purchase/application/service/purchase-CRUD-service.interface.ts
+++ b/src/module/purchase/application/service/purchase-CRUD-service.interface.ts
@@ -2,12 +2,12 @@ import { ICRUDService } from '@common/base/application/service/crud-service.inte
 
 import { CreatePurchaseDto } from '@purchase/application/dto/create-purchase.dto';
 import { PurchaseResponseDto } from '@purchase/application/dto/purchase-response.dto';
+import { UpdatePurchaseStatusDto } from '@purchase/application/dto/update-purchase-status.dto';
 import { UpdatePurchaseDto } from '@purchase/application/dto/update-purchase.dto';
 import { Purchase } from '@purchase/domain/purchase.entity';
 
 export const PURCHASE_CRUD_SERVICE_KEY = 'purchase_crud_service';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface IPurchaseCRUDService
   extends Omit<
     ICRUDService<
@@ -16,5 +16,10 @@ export interface IPurchaseCRUDService
       CreatePurchaseDto,
       UpdatePurchaseDto
     >,
-    'deleteOneByIdOrFail'
-  > {}
+    'deleteOneByIdOrFail' | 'updateOneByIdOrFail'
+  > {
+  updateStatusByIdOrFail(
+    id: string,
+    updatePurchaseStatusDto: UpdatePurchaseStatusDto,
+  ): Promise<PurchaseResponseDto>;
+}

--- a/src/module/purchase/application/service/purchase-CRUD.service.ts
+++ b/src/module/purchase/application/service/purchase-CRUD.service.ts
@@ -12,6 +12,7 @@ import {
 
 import { CreatePurchaseDto } from '@purchase/application/dto/create-purchase.dto';
 import { PurchaseResponseDto } from '@purchase/application/dto/purchase-response.dto';
+import { UpdatePurchaseStatusDto } from '@purchase/application/dto/update-purchase-status.dto';
 import { UpdatePurchaseDto } from '@purchase/application/dto/update-purchase.dto';
 import { CourseNotPublishedException } from '@purchase/application/exception/course-not-published.exception';
 import { InvalidPurchaseException } from '@purchase/application/exception/invalid-purchase.exception';
@@ -47,6 +48,7 @@ export class PurchaseCRUDService
   implements IPurchaseCRUDService
 {
   declare deleteOneByIdOrFail: never;
+  declare updateOneByIdOrFail: never;
 
   constructor(
     @Inject(PURCHASE_REPOSITORY_KEY)
@@ -82,19 +84,25 @@ export class PurchaseCRUDService
     return await super.saveOne(createDto);
   }
 
-  async updateOneByIdOrFail(
+  async updateStatusByIdOrFail(
     id: string,
-    updateDto: UpdatePurchaseDto,
+    updatePurchaseStatusDto: UpdatePurchaseStatusDto,
   ): Promise<PurchaseResponseDto> {
     const purchaseToUpdate = await this.purchaseRepository.getOneByIdOrFail(id);
-    this.validateStatusTransition(purchaseToUpdate.status, updateDto.status);
+
+    this.validateStatusTransition(
+      purchaseToUpdate.status,
+      updatePurchaseStatusDto.status,
+    );
+
     const purchase = this.purchaseDtoMapper.fromUpdateDtoToEntity(
       purchaseToUpdate,
-      updateDto,
+      updatePurchaseStatusDto,
     );
     const updatedPurchase = await this.purchaseRepository.saveOne(purchase);
     const responseDto =
       this.purchaseDtoMapper.fromEntityToResponseDto(updatedPurchase);
+
     return responseDto;
   }
 

--- a/src/module/purchase/domain/purchase.entity.ts
+++ b/src/module/purchase/domain/purchase.entity.ts
@@ -1,5 +1,7 @@
 import { Base } from '@common/base/domain/base.entity';
 
+import { PaymentMethod } from '@payment-method/domain/payment-method.entity';
+
 import { PurchaseStatus } from '@purchase/domain/purchase.status.enum';
 
 export class Purchase extends Base {
@@ -7,16 +9,20 @@ export class Purchase extends Base {
   courseId: string;
   amount: number;
   status: PurchaseStatus;
+  paymentMethodId: string;
   paymentTransactionId?: string;
   refundTransactionId?: string;
+  paymentMethod?: PaymentMethod;
 
   constructor(
     userId: string,
     courseId: string,
     amount: number,
     status: PurchaseStatus,
+    paymentMethodId: string,
     paymentTransactionId?: string,
     refundTransactionId?: string,
+    paymentMethod?: PaymentMethod,
     id?: string,
     createdAt?: string,
     updatedAt?: string,
@@ -28,7 +34,9 @@ export class Purchase extends Base {
     this.courseId = courseId;
     this.amount = amount;
     this.status = status;
+    this.paymentMethodId = paymentMethodId;
     this.paymentTransactionId = paymentTransactionId;
     this.refundTransactionId = refundTransactionId;
+    this.paymentMethod = paymentMethod;
   }
 }

--- a/src/module/purchase/infrastructure/database/purchase.entity.ts
+++ b/src/module/purchase/infrastructure/database/purchase.entity.ts
@@ -1,6 +1,8 @@
-import { Column, Entity } from 'typeorm';
+import { Column, Entity, ManyToOne } from 'typeorm';
 
 import { BaseEntity } from '@common/base/infrastructure/database/base.entity';
+
+import { PaymentMethodEntity } from '@payment-method/infrastructure/database/payment-method.entity';
 
 import { PurchaseStatus } from '@purchase/domain/purchase.status.enum';
 
@@ -27,17 +29,27 @@ export class PurchaseEntity extends BaseEntity {
   @Column({ type: 'varchar' })
   status: PurchaseStatus;
 
+  @Column({ type: 'varchar' })
+  paymentMethodId: string;
+
   @Column({ type: 'varchar', nullable: true })
   paymentTransactionId?: string;
 
   @Column({ type: 'varchar', nullable: true })
   refundTransactionId?: string;
 
+  @ManyToOne(
+    () => PaymentMethodEntity,
+    (paymentMethod) => paymentMethod.purchases,
+  )
+  paymentMethod?: PaymentMethodEntity;
+
   constructor(
     userId: string,
     courseId: string,
     amount: number,
     status: PurchaseStatus,
+    paymentMethodId: string,
     paymentTransactionId?: string,
     refundTransactionId?: string,
     id?: string,
@@ -48,6 +60,7 @@ export class PurchaseEntity extends BaseEntity {
     this.courseId = courseId;
     this.amount = amount;
     this.status = status;
+    this.paymentMethodId = paymentMethodId;
     this.paymentTransactionId = paymentTransactionId;
     this.refundTransactionId = refundTransactionId;
   }

--- a/src/module/purchase/interface/purchase.controller.ts
+++ b/src/module/purchase/interface/purchase.controller.ts
@@ -17,7 +17,7 @@ import { User } from '@iam/user/domain/user.entity';
 
 import { CreatePurchaseDtoRequest } from '@purchase/application/dto/create-purchase.dto';
 import { PurchaseResponseDto } from '@purchase/application/dto/purchase-response.dto';
-import { UpdatePurchaseDto } from '@purchase/application/dto/update-purchase.dto';
+import { UpdatePurchaseStatusDto } from '@purchase/application/dto/update-purchase-status.dto';
 import { ReadPurchasePolicyHandler } from '@purchase/application/policy/read-purchase-policy.handler';
 import { UpdatePurchasePolicyHandler } from '@purchase/application/policy/update-purchase-policy.handler';
 import {
@@ -38,7 +38,7 @@ export class PurchaseController {
   async getOneById(
     @Param('id', ParseUUIDPipe) id: string,
   ): Promise<PurchaseResponseDto> {
-    return await this.purchaseService.getOneByIdOrFail(id);
+    return await this.purchaseService.getOneByIdOrFail(id, ['paymentMethod']);
   }
 
   @Post()
@@ -52,13 +52,13 @@ export class PurchaseController {
     });
   }
 
-  @Patch(':id')
+  @Patch(':id/status')
   @Policies(UpdatePurchasePolicyHandler)
   async updateOne(
     @Param('id', ParseUUIDPipe) id: string,
-    @Body() updatePurchaseDto: UpdatePurchaseDto,
+    @Body() updatePurchaseDto: UpdatePurchaseStatusDto,
   ): Promise<PurchaseResponseDto> {
-    return await this.purchaseService.updateOneByIdOrFail(
+    return await this.purchaseService.updateStatusByIdOrFail(
       id,
       updatePurchaseDto,
     );

--- a/src/module/purchase/purchase.module.ts
+++ b/src/module/purchase/purchase.module.ts
@@ -7,6 +7,8 @@ import { AppSubjectPermissionStorage } from '@iam/authorization/infrastructure/c
 import { CourseModule } from '@course/course.module';
 import { CourseEntity } from '@course/infrastructure/database/course.entity';
 
+import { PaymentMethodModule } from '@payment-method/payment-method.module';
+
 import { PurchaseDtoMapper } from '@purchase/application/mapper/purchase-dto.mapper';
 import { PurchaseMapper } from '@purchase/application/mapper/purchase.mapper';
 import { ReadPurchasePolicyHandler } from '@purchase/application/policy/read-purchase-policy.handler';
@@ -40,6 +42,7 @@ const policyHandlersProviders = [
     TypeOrmModule.forFeature([PurchaseEntity, CourseEntity]),
     CourseModule,
     AuthorizationModule.forFeature(),
+    PaymentMethodModule,
   ],
   providers: [
     purchaseRepositoryProvider,


### PR DESCRIPTION
# Summary

This PR introduces the a relation between `Purchase` and `PaymentMethod` relations, as it will be a required field for creating a purchase entity. Also, this requires to refactor the `update` route, to just update the status of the purchase.

# Details

- Implemented the relation between `Purchase` and `PaymentMethod`.
- Created a migration file with the relation.
- Updated `Purchase` DTOs and mappers with the relation.
- Refactored the `PATCH - /purchase/:id` route into `PATCH - /purchase/:id/status`, to just update the status of the purchase.
- Implemented a `UpdatePurchaseStatusDto` used on the `PATCH - /purchase/:id/status` route.