### PR TITLE
feat: Add route to update a purchase's payment method

### DIFF
--- a/src/module/payment-method/payment-method.module.ts
+++ b/src/module/payment-method/payment-method.module.ts
@@ -41,7 +41,7 @@ const policyHandlersProviders = [
     ...policyHandlersProviders,
   ],
   controllers: [PaymentMethodController],
-  exports: [PaymentMethodMapper],
+  exports: [PaymentMethodMapper, paymentMethodRepositoryProvider],
 })
 export class PaymentMethodModule implements OnModuleInit {
   constructor(private readonly registry: AppSubjectPermissionStorage) {}

--- a/src/module/purchase/__test__/fixture/Purchase.yml
+++ b/src/module/purchase/__test__/fixture/Purchase.yml
@@ -15,3 +15,10 @@ items:
     amount: 39.99
     paymentMethodId: '361cb833-1f51-4b21-b5e9-1089c5d09b09'
     paymentTransactionId: 'payment-transaction-1'
+  purchase2:
+    id: '7bd80f77-433d-4b57-9f00-28e29e93bad5'
+    userId: 'a90108bf-42c6-481f-a63f-4b51fed1300c'
+    courseId: '57732eea-ce64-4e9b-80c6-63a08ee82764'
+    status: pending
+    amount: 49.99
+    paymentMethodId: '361cb833-1f51-4b21-b5e9-1089c5d09b09'

--- a/src/module/purchase/__test__/purchase.e2e.spec.ts
+++ b/src/module/purchase/__test__/purchase.e2e.spec.ts
@@ -14,6 +14,7 @@ import { IS_NOT_VALID_MESSAGE } from '@common/base/application/exception/base-ex
 import { AppAction } from '@iam/authorization/domain/app.action.enum';
 
 import { CreatePurchaseDtoRequest } from '@purchase/application/dto/create-purchase.dto';
+import { UpdatePurchasePaymentMethodDto } from '@purchase/application/dto/update-purchase-payment-method.dto';
 import { UpdatePurchaseDto } from '@purchase/application/dto/update-purchase.dto';
 import {
   CAN_NOT_BUY_OWN_COURSE_MESSAGE,
@@ -315,10 +316,38 @@ describe('Purchase Module', () => {
           expect(body).toEqual(expectedResponse);
         });
     });
+
+    it('Should throw an error if the payment method does not exist', async () => {
+      const nonExistingPaymentMethodId = 'a078e065-e85b-45f0-8d6c-f68c54d8b3ee';
+
+      const createPurchaseDto = {
+        courseId: existingCourses.third.id,
+        paymentMethodId: nonExistingPaymentMethodId,
+      } as CreatePurchaseDtoRequest;
+
+      return await request(app.getHttpServer())
+        .post(endpoint)
+        .auth(regularToken, { type: 'bearer' })
+        .send(createPurchaseDto)
+        .expect(HttpStatus.NOT_FOUND)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `Entity with id ${nonExistingPaymentMethodId} not found`,
+              source: {
+                pointer: endpoint,
+              },
+              status: HttpStatus.NOT_FOUND.toString(),
+              title: 'Entity not found',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
   });
 
   describe('PATCH - /purchase/:id/status', () => {
-    it('Should update a purchase', async () => {
+    it('Should update a purchase status', async () => {
       const existingPurchaseId = 'e6c78b10-d9b0-4819-ac4e-a36ca36f8554';
       const paymentTransactionId = '00000000-0000-0000-0000-000000000000';
       const updatePurchaseDto = {
@@ -341,6 +370,7 @@ describe('Purchase Module', () => {
                 amount: expect.any(Number),
                 userId: expect.any(String),
                 courseId: expect.any(String),
+                createdAt: expect.any(String),
                 updatedAt: expect.any(String),
                 paymentTransactionId,
               }),
@@ -431,6 +461,130 @@ describe('Purchase Module', () => {
               detail: `You are not allowed to ${AppAction.Manage.toUpperCase()} this resource`,
               source: {
                 pointer: `${endpoint}/${existingPurchaseId}/status`,
+              },
+              status: HttpStatus.FORBIDDEN.toString(),
+              title: 'Forbidden',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+  });
+
+  describe('PATCH - /purchase/:id/payment-method', () => {
+    it('Should update a purchase payment method', async () => {
+      const newPaymentMethodId = '48c7bbe1-46d6-4e85-9dbf-610d52544ef7';
+      const existingPurchaseId = '7bd80f77-433d-4b57-9f00-28e29e93bad5';
+      const updatePurchasePaymentMethodDto = {
+        paymentMethodId: newPaymentMethodId,
+      } as UpdatePurchasePaymentMethodDto;
+
+      await request(app.getHttpServer())
+        .patch(`${endpoint}/${existingPurchaseId}/payment-method`)
+        .auth(adminToken, { type: 'bearer' })
+        .send(updatePurchasePaymentMethodDto)
+        .expect(HttpStatus.OK)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            data: expect.objectContaining({
+              id: existingPurchaseId,
+              type: Purchase.getEntityName(),
+              attributes: expect.objectContaining({
+                status: PurchaseStatus.PENDING,
+                amount: expect.any(Number),
+                userId: expect.any(String),
+                courseId: expect.any(String),
+                paymentMethodId: newPaymentMethodId,
+                paymentTransactionId: null,
+                refundTransactionId: null,
+                createdAt: expect.any(String),
+                updatedAt: expect.any(String),
+              }),
+            }),
+            links: expect.arrayContaining([
+              expect.objectContaining({
+                rel: 'self',
+                href: expect.stringContaining(
+                  `${endpoint}/${existingPurchaseId}/payment-method`,
+                ),
+                method: HttpMethod.PATCH,
+              }),
+            ]),
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+
+      return await request(app.getHttpServer())
+        .get(`${endpoint}/${existingPurchaseId}`)
+        .auth(superAdminToken, { type: 'bearer' })
+        .expect(HttpStatus.OK)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            data: expect.objectContaining({
+              id: existingPurchaseId,
+              type: Purchase.getEntityName(),
+              attributes: expect.objectContaining({
+                status: PurchaseStatus.PENDING,
+                amount: expect.any(Number),
+                userId: expect.any(String),
+                courseId: expect.any(String),
+                paymentMethodId: newPaymentMethodId,
+                paymentTransactionId: null,
+                refundTransactionId: null,
+                createdAt: expect.any(String),
+                updatedAt: expect.any(String),
+              }),
+            }),
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should throw an error if the payment method does not exist', async () => {
+      const nonExistingPaymentMethodId = '78ace669-9c6f-4fe3-84e9-a2b55291191c';
+      const existingPurchaseId = '7bd80f77-433d-4b57-9f00-28e29e93bad5';
+      const updatePurchasePaymentMethodDto = {
+        paymentMethodId: nonExistingPaymentMethodId,
+      } as UpdatePurchasePaymentMethodDto;
+
+      return await request(app.getHttpServer())
+        .patch(`${endpoint}/${existingPurchaseId}/payment-method`)
+        .auth(adminToken, { type: 'bearer' })
+        .send(updatePurchasePaymentMethodDto)
+        .expect(HttpStatus.NOT_FOUND)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `Entity with id ${nonExistingPaymentMethodId} not found`,
+              source: {
+                pointer: `${endpoint}/${existingPurchaseId}/payment-method`,
+              },
+              status: HttpStatus.NOT_FOUND.toString(),
+              title: 'Entity not found',
+            },
+          });
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
+    it('Should deny access to a user who is not the owner of the purchase', async () => {
+      const newPaymentMethodId = '48c7bbe1-46d6-4e85-9dbf-610d52544ef7';
+      const existingPurchaseId = '7bd80f77-433d-4b57-9f00-28e29e93bad5';
+      const updatePurchasePaymentMethodDto = {
+        paymentMethodId: newPaymentMethodId,
+      } as UpdatePurchasePaymentMethodDto;
+
+      await request(app.getHttpServer())
+        .patch(`${endpoint}/${existingPurchaseId}/payment-method`)
+        .auth(regularToken, { type: 'bearer' })
+        .send(updatePurchasePaymentMethodDto)
+        .expect(HttpStatus.FORBIDDEN)
+        .then(({ body }) => {
+          const expectedResponse = expect.objectContaining({
+            error: {
+              detail: `You are not allowed to ${AppAction.Update.toUpperCase()} this resource`,
+              source: {
+                pointer: `${endpoint}/${existingPurchaseId}/payment-method`,
               },
               status: HttpStatus.FORBIDDEN.toString(),
               title: 'Forbidden',

--- a/src/module/purchase/__test__/purchase.e2e.spec.ts
+++ b/src/module/purchase/__test__/purchase.e2e.spec.ts
@@ -428,7 +428,7 @@ describe('Purchase Module', () => {
         .then(({ body }) => {
           const expectedResponse = expect.objectContaining({
             error: {
-              detail: `You are not allowed to ${AppAction.Update.toUpperCase()} this resource`,
+              detail: `You are not allowed to ${AppAction.Manage.toUpperCase()} this resource`,
               source: {
                 pointer: `${endpoint}/${existingPurchaseId}/status`,
               },

--- a/src/module/purchase/application/dto/update-purchase-payment-method.dto.ts
+++ b/src/module/purchase/application/dto/update-purchase-payment-method.dto.ts
@@ -1,0 +1,8 @@
+import { PickType } from '@nestjs/mapped-types';
+
+import { UpdatePurchaseDto } from '@purchase/application/dto/update-purchase.dto';
+
+export class UpdatePurchasePaymentMethodDto extends PickType(
+  UpdatePurchaseDto,
+  ['paymentMethodId'],
+) {}

--- a/src/module/purchase/application/dto/update-purchase.dto.ts
+++ b/src/module/purchase/application/dto/update-purchase.dto.ts
@@ -1,8 +1,8 @@
 import {
   IsEnum,
   IsNotEmpty,
-  IsOptional,
   IsString,
+  IsUUID,
   ValidateIf,
 } from 'class-validator';
 
@@ -13,9 +13,9 @@ export class UpdatePurchaseDto {
   @IsEnum(PurchaseStatus)
   status!: PurchaseStatus;
 
-  @IsOptional()
-  @IsString()
-  paymentMethodId?: string;
+  @IsNotEmpty()
+  @IsUUID()
+  paymentMethodId!: string;
 
   @ValidateIf(
     (o: UpdatePurchaseDto) =>

--- a/src/module/purchase/application/mapper/purchase.mapper.ts
+++ b/src/module/purchase/application/mapper/purchase.mapper.ts
@@ -55,6 +55,9 @@ export class PurchaseMapper implements IEntityMapper<Purchase, PurchaseEntity> {
       paymentTransactionId,
       refundTransactionId,
       id,
+      createdAt,
+      updatedAt,
+      deletedAt,
     } = domain;
 
     return new PurchaseEntity(
@@ -66,6 +69,9 @@ export class PurchaseMapper implements IEntityMapper<Purchase, PurchaseEntity> {
       paymentTransactionId,
       refundTransactionId,
       id,
+      createdAt ? new Date(createdAt) : undefined,
+      updatedAt ? new Date(updatedAt) : undefined,
+      deletedAt ? new Date(deletedAt) : undefined,
     );
   }
 }

--- a/src/module/purchase/application/policy/manage-purchase-policy.handler.ts
+++ b/src/module/purchase/application/policy/manage-purchase-policy.handler.ts
@@ -10,18 +10,18 @@ import { PolicyHandlerStorage } from '@iam/authorization/infrastructure/policy/s
 import { Purchase } from '@purchase/domain/purchase.entity';
 
 @Injectable()
-export class UpdatePurchasePolicyHandler
+export class ManagePurchasePolicyHandler
   extends BasePolicyHandler
   implements IPolicyHandler
 {
-  private readonly action = AppAction.Update;
+  private readonly action = AppAction.Manage;
 
   constructor(
     private readonly policyHandlerStorage: PolicyHandlerStorage,
     private readonly authorizationService: AuthorizationService,
   ) {
     super();
-    this.policyHandlerStorage.add(UpdatePurchasePolicyHandler, this);
+    this.policyHandlerStorage.add(ManagePurchasePolicyHandler, this);
   }
 
   handle(request: Request): void {

--- a/src/module/purchase/application/policy/update-purchase-payment-method.policy.handler.ts
+++ b/src/module/purchase/application/policy/update-purchase-payment-method.policy.handler.ts
@@ -1,0 +1,53 @@
+import { ForbiddenException, Inject, Injectable } from '@nestjs/common';
+import { Request } from 'express';
+
+import { BasePolicyHandler } from '@iam/authorization/application/policy/base-policy.handler';
+import { AuthorizationService } from '@iam/authorization/application/service/authorization.service';
+import { AppAction } from '@iam/authorization/domain/app.action.enum';
+import { IPolicyHandler } from '@iam/authorization/infrastructure/policy/handler/policy-handler.interface';
+import { PolicyHandlerStorage } from '@iam/authorization/infrastructure/policy/storage/policies-handler.storage';
+
+import {
+  IPurchaseRepository,
+  PURCHASE_REPOSITORY_KEY,
+} from '@purchase/application/repository/purchase-repository.interface';
+
+@Injectable()
+export class UpdatePurchasePaymentMethodPolicyHandler
+  extends BasePolicyHandler
+  implements IPolicyHandler
+{
+  private readonly action = AppAction.Update;
+
+  constructor(
+    private readonly policyHandlerStorage: PolicyHandlerStorage,
+    private readonly authorizationService: AuthorizationService,
+    @Inject(PURCHASE_REPOSITORY_KEY)
+    private readonly purchaseRepository: IPurchaseRepository,
+  ) {
+    super();
+    this.policyHandlerStorage.add(
+      UpdatePurchasePaymentMethodPolicyHandler,
+      this,
+    );
+  }
+
+  async handle(request: Request): Promise<void> {
+    const user = this.getCurrentUser(request);
+
+    const purchaseId = request.params.id;
+    const purchase = await this.purchaseRepository.getOneByIdOrFail(purchaseId);
+
+    const isAllowed = this.authorizationService.isAllowed(
+      user,
+      this.action,
+      purchase,
+    );
+
+    if (!isAllowed) {
+      throw new ForbiddenException(
+        `You are not allowed to ${this.action.toUpperCase()} this resource`,
+      );
+    }
+  }
+}

--- a/src/module/purchase/application/service/purchase-CRUD-service.interface.ts
+++ b/src/module/purchase/application/service/purchase-CRUD-service.interface.ts
@@ -2,6 +2,7 @@ import { ICRUDService } from '@common/base/application/service/crud-service.inte
 
 import { CreatePurchaseDto } from '@purchase/application/dto/create-purchase.dto';
 import { PurchaseResponseDto } from '@purchase/application/dto/purchase-response.dto';
+import { UpdatePurchasePaymentMethodDto } from '@purchase/application/dto/update-purchase-payment-method.dto';
 import { UpdatePurchaseStatusDto } from '@purchase/application/dto/update-purchase-status.dto';
 import { UpdatePurchaseDto } from '@purchase/application/dto/update-purchase.dto';
 import { Purchase } from '@purchase/domain/purchase.entity';
@@ -21,5 +22,9 @@ export interface IPurchaseCRUDService
   updateStatusByIdOrFail(
     id: string,
     updatePurchaseStatusDto: UpdatePurchaseStatusDto,
+  ): Promise<PurchaseResponseDto>;
+  updatePaymentMethodByIdOrFail(
+    id: string,
+    updatePurchasePaymentMethodDto: UpdatePurchasePaymentMethodDto,
   ): Promise<PurchaseResponseDto>;
 }

--- a/src/module/purchase/domain/purchase.permissions.ts
+++ b/src/module/purchase/domain/purchase.permissions.ts
@@ -3,15 +3,26 @@ import { AppAction } from '@iam/authorization/domain/app.action.enum';
 import { IPermissionsDefinition } from '@iam/authorization/infrastructure/policy/type/permissions-definition.interface';
 
 import { Purchase } from '@purchase/domain/purchase.entity';
+import { PurchaseStatus } from '@purchase/domain/purchase.status.enum';
 
 export const purchasePermissions: IPermissionsDefinition = {
   [AppRole.Regular](user, { can }) {
     can(AppAction.Read, Purchase, {
       userId: user.id,
     });
+    can(AppAction.Create, Purchase);
+    can(AppAction.Update, Purchase, {
+      status: PurchaseStatus.PENDING,
+      userId: user.id,
+    });
   },
   [AppRole.Admin](user, { can }) {
     can(AppAction.Read, Purchase, {
+      userId: user.id,
+    });
+    can(AppAction.Create, Purchase);
+    can(AppAction.Update, Purchase, {
+      status: PurchaseStatus.PENDING,
       userId: user.id,
     });
   },

--- a/src/module/purchase/infrastructure/database/purchase.entity.ts
+++ b/src/module/purchase/infrastructure/database/purchase.entity.ts
@@ -53,8 +53,11 @@ export class PurchaseEntity extends BaseEntity {
     paymentTransactionId?: string,
     refundTransactionId?: string,
     id?: string,
+    createdAt?: Date,
+    updatedAt?: Date,
+    deletedAt?: Date,
   ) {
-    super(id);
+    super(id, createdAt, updatedAt, deletedAt);
 
     this.userId = userId;
     this.courseId = courseId;

--- a/src/module/purchase/interface/purchase.controller.ts
+++ b/src/module/purchase/interface/purchase.controller.ts
@@ -17,9 +17,11 @@ import { User } from '@iam/user/domain/user.entity';
 
 import { CreatePurchaseDtoRequest } from '@purchase/application/dto/create-purchase.dto';
 import { PurchaseResponseDto } from '@purchase/application/dto/purchase-response.dto';
+import { UpdatePurchasePaymentMethodDto } from '@purchase/application/dto/update-purchase-payment-method.dto';
 import { UpdatePurchaseStatusDto } from '@purchase/application/dto/update-purchase-status.dto';
 import { ManagePurchasePolicyHandler } from '@purchase/application/policy/manage-purchase-policy.handler';
 import { ReadPurchasePolicyHandler } from '@purchase/application/policy/read-purchase-policy.handler';
+import { UpdatePurchasePaymentMethodPolicyHandler } from '@purchase/application/policy/update-purchase-payment-method.policy.handler';
 import {
   IPurchaseCRUDService,
   PURCHASE_CRUD_SERVICE_KEY,
@@ -61,6 +63,18 @@ export class PurchaseController {
     return await this.purchaseService.updateStatusByIdOrFail(
       id,
       updatePurchaseDto,
+    );
+  }
+
+  @Patch(':id/payment-method')
+  @Policies(UpdatePurchasePaymentMethodPolicyHandler)
+  async updatePaymentMethod(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() updatePurchasePaymentMethodDto: UpdatePurchasePaymentMethodDto,
+  ): Promise<PurchaseResponseDto> {
+    return await this.purchaseService.updatePaymentMethodByIdOrFail(
+      id,
+      updatePurchasePaymentMethodDto,
     );
   }
 }

--- a/src/module/purchase/interface/purchase.controller.ts
+++ b/src/module/purchase/interface/purchase.controller.ts
@@ -18,8 +18,8 @@ import { User } from '@iam/user/domain/user.entity';
 import { CreatePurchaseDtoRequest } from '@purchase/application/dto/create-purchase.dto';
 import { PurchaseResponseDto } from '@purchase/application/dto/purchase-response.dto';
 import { UpdatePurchaseStatusDto } from '@purchase/application/dto/update-purchase-status.dto';
+import { ManagePurchasePolicyHandler } from '@purchase/application/policy/manage-purchase-policy.handler';
 import { ReadPurchasePolicyHandler } from '@purchase/application/policy/read-purchase-policy.handler';
-import { UpdatePurchasePolicyHandler } from '@purchase/application/policy/update-purchase-policy.handler';
 import {
   IPurchaseCRUDService,
   PURCHASE_CRUD_SERVICE_KEY,
@@ -53,7 +53,7 @@ export class PurchaseController {
   }
 
   @Patch(':id/status')
-  @Policies(UpdatePurchasePolicyHandler)
+  @Policies(ManagePurchasePolicyHandler)
   async updateOne(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() updatePurchaseDto: UpdatePurchaseStatusDto,

--- a/src/module/purchase/purchase.module.ts
+++ b/src/module/purchase/purchase.module.ts
@@ -11,8 +11,9 @@ import { PaymentMethodModule } from '@payment-method/payment-method.module';
 
 import { PurchaseDtoMapper } from '@purchase/application/mapper/purchase-dto.mapper';
 import { PurchaseMapper } from '@purchase/application/mapper/purchase.mapper';
+import { ManagePurchasePolicyHandler } from '@purchase/application/policy/manage-purchase-policy.handler';
 import { ReadPurchasePolicyHandler } from '@purchase/application/policy/read-purchase-policy.handler';
-import { UpdatePurchasePolicyHandler } from '@purchase/application/policy/update-purchase-policy.handler';
+import { UpdatePurchasePaymentMethodPolicyHandler } from '@purchase/application/policy/update-purchase-payment-method.policy.handler';
 import { PURCHASE_REPOSITORY_KEY } from '@purchase/application/repository/purchase-repository.interface';
 import { PURCHASE_CRUD_SERVICE_KEY } from '@purchase/application/service/purchase-CRUD-service.interface';
 import { PurchaseCRUDService } from '@purchase/application/service/purchase-CRUD.service';
@@ -34,7 +35,8 @@ const purchaseCRUDServiceProvider: Provider = {
 
 const policyHandlersProviders = [
   ReadPurchasePolicyHandler,
-  UpdatePurchasePolicyHandler,
+  ManagePurchasePolicyHandler,
+  UpdatePurchasePaymentMethodPolicyHandler,
 ];
 
 @Module({


### PR DESCRIPTION
# Summary

This PR introduces a route for updating a purchase's payment method.

# Details

- Refactored the update status policy handler into a manage policy handler, as it will only be accessible by super admins.
- Added a dto for validating the payment method id of the update.
- Updated the purchase police permissions with update rules.
- Implemented a policy handler for the purchase's payment method update.
- Added tests to verify the functionality of the new route.