### PR TITLE
refactor: Improve the finding exceptions to be more specific

### DIFF
--- a/src/common/base/infrastructure/database/base.repository.ts
+++ b/src/common/base/infrastructure/database/base.repository.ts
@@ -28,13 +28,16 @@ abstract class BaseRepository<
     DomainEntity,
     PersistenceEntity
   >;
+  protected readonly entityType: string;
 
   constructor(
     repository: Repository<PersistenceEntity>,
     entityMapper: IEntityMapper<DomainEntity, PersistenceEntity>,
+    entityType: string,
   ) {
     this.repository = repository;
     this.entityMapper = entityMapper;
+    this.entityType = entityType;
   }
 
   async getAll(
@@ -82,7 +85,7 @@ abstract class BaseRepository<
     const entity = await this.getOneById(id, include);
 
     if (!entity) {
-      throw new EntityNotFoundException(id);
+      throw new EntityNotFoundException('id', id, this.entityType);
     }
 
     return entity;
@@ -101,7 +104,7 @@ abstract class BaseRepository<
     } as FindOneOptions<PersistenceEntity>);
 
     if (!entityToDelete) {
-      throw new EntityNotFoundException(id);
+      throw new EntityNotFoundException('id', id, this.entityType);
     }
 
     await this.repository.softDelete({

--- a/src/common/base/infrastructure/exception/entity-already-excists.exception.ts
+++ b/src/common/base/infrastructure/exception/entity-already-excists.exception.ts
@@ -1,8 +1,8 @@
 import { ConflictException } from '@nestjs/common';
 
 class EntityAlreadyExistsException extends ConflictException {
-  constructor(key: string, value: string) {
-    super(`Entity with ${key} '${value}' already exists`);
+  constructor(key: string, value: string, type?: string) {
+    super(`${type || 'Entity'} with ${key} '${value}' already exists`);
   }
 }
 

--- a/src/common/base/infrastructure/exception/not.found.exception.ts
+++ b/src/common/base/infrastructure/exception/not.found.exception.ts
@@ -1,8 +1,8 @@
 import { NotFoundException } from '@nestjs/common';
 
 class EntityNotFoundException extends NotFoundException {
-  constructor(id: string) {
-    super(`Entity with id ${id} not found`);
+  constructor(key: string, value: string, type?: string) {
+    super(`${type || 'Entity'} with ${key} ${value} not found`);
   }
 }
 export default EntityNotFoundException;

--- a/src/module/category/__test__/category.e2e.spec.ts
+++ b/src/module/category/__test__/category.e2e.spec.ts
@@ -317,7 +317,7 @@ describe('Category Module', () => {
         .then(({ body }) => {
           const expectedResponse = expect.objectContaining({
             error: {
-              detail: `Entity with id ${nonExistingCategoryId} not found`,
+              detail: `Category with id ${nonExistingCategoryId} not found`,
               source: {
                 pointer: `${endpoint}/${nonExistingCategoryId}`,
               },
@@ -428,7 +428,7 @@ describe('Category Module', () => {
         .then(({ body }) => {
           const expectedResponse = expect.objectContaining({
             error: {
-              detail: `Entity with id ${nonExistingCategoryId} not found`,
+              detail: `Category with id ${nonExistingCategoryId} not found`,
               source: {
                 pointer: `${endpoint}/${nonExistingCategoryId}`,
               },
@@ -593,7 +593,7 @@ describe('Category Module', () => {
         .then(({ body }) => {
           const expectedResponse = expect.objectContaining({
             error: {
-              detail: `Entity with id ${nonExistingCategoryId} not found`,
+              detail: `Category with id ${nonExistingCategoryId} not found`,
               source: {
                 pointer: endpoint,
               },
@@ -729,7 +729,7 @@ describe('Category Module', () => {
         .then(({ body }) => {
           const expectedResponse = expect.objectContaining({
             error: {
-              detail: `Entity with id ${nonExistingCategoryId} not found`,
+              detail: `Category with id ${nonExistingCategoryId} not found`,
               source: {
                 pointer: `${endpoint}/${nonExistingCategoryId}`,
               },
@@ -888,7 +888,7 @@ describe('Category Module', () => {
         .then(({ body }) => {
           const expectedResponse = expect.objectContaining({
             error: {
-              detail: `Entity with id ${nonExistingCategoryId} not found`,
+              detail: `Category with id ${nonExistingCategoryId} not found`,
               source: {
                 pointer: `${endpoint}/${categoryId}`,
               },
@@ -1003,7 +1003,7 @@ describe('Category Module', () => {
         .then(({ body }) => {
           const expectedResponse = expect.objectContaining({
             error: {
-              detail: `Entity with id ${categoryId} not found`,
+              detail: `Category with id ${categoryId} not found`,
               source: {
                 pointer: `${endpoint}/${categoryId}`,
               },
@@ -1025,7 +1025,7 @@ describe('Category Module', () => {
         .then(({ body }) => {
           const expectedResponse = expect.objectContaining({
             error: {
-              detail: `Entity with id ${nonExistingCategoryId} not found`,
+              detail: `Category with id ${nonExistingCategoryId} not found`,
               source: {
                 pointer: `${endpoint}/${nonExistingCategoryId}`,
               },

--- a/src/module/category/infrastructure/database/category.postgres.repository.ts
+++ b/src/module/category/infrastructure/database/category.postgres.repository.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { titleCase } from 'change-case-all';
 import { IsNull, Repository, TreeRepository } from 'typeorm';
 
 import { ICollection } from '@common/base/application/dto/collection.interface';
@@ -28,7 +29,11 @@ export class CategoryPostgresRepository
     private readonly treeRepository: TreeRepository<CategoryEntity>,
     private readonly categoryMapper: CategoryMapper,
   ) {
-    super(categoryRepository, categoryMapper);
+    super(
+      categoryRepository,
+      categoryMapper,
+      titleCase(CategoryEntity.name.replace('Entity', '')),
+    );
   }
 
   async getCategoriesRoot(): Promise<ICollection<Category>> {
@@ -45,7 +50,7 @@ export class CategoryPostgresRepository
     const category = await this.getOneById(id);
 
     if (!category) {
-      throw new EntityNotFoundException(id);
+      throw new EntityNotFoundException('id', id, this.entityType);
     }
 
     const children = await this.findChildren(id);
@@ -68,7 +73,7 @@ export class CategoryPostgresRepository
     const category = await this.getOneEntityById(id);
 
     if (!category) {
-      throw new EntityNotFoundException(id);
+      throw new EntityNotFoundException('id', id, this.entityType);
     }
 
     const categoryWithAncestors =
@@ -100,7 +105,7 @@ export class CategoryPostgresRepository
     });
 
     if (!category) {
-      throw new EntityNotFoundException(id);
+      throw new EntityNotFoundException('id', id, this.entityType);
     }
 
     const categoryWithDescendants =

--- a/src/module/course/__test__/course.e2e.spec.ts
+++ b/src/module/course/__test__/course.e2e.spec.ts
@@ -330,7 +330,7 @@ describe('Course Module', () => {
         .then(({ body }) => {
           const expectedResponse = expect.objectContaining({
             error: {
-              detail: `Entity with id ${nonExistingCourseId} not found`,
+              detail: `Course with id ${nonExistingCourseId} not found`,
               source: {
                 pointer: `${endpoint}/${nonExistingCourseId}`,
               },
@@ -875,7 +875,7 @@ describe('Course Module', () => {
         .then(({ body }) => {
           const expectedResponse = expect.objectContaining({
             error: {
-              detail: `Entity with id ${nonExistingCourseId} not found`,
+              detail: `Course with id ${nonExistingCourseId} not found`,
               source: {
                 pointer: `${endpoint}/${nonExistingCourseId}`,
               },
@@ -1088,7 +1088,7 @@ describe('Course Module', () => {
         .then(({ body }) => {
           const expectedResponse = expect.objectContaining({
             error: {
-              detail: `Entity with id ${nonExistingCourseId} not found`,
+              detail: `Course with id ${nonExistingCourseId} not found`,
               source: {
                 pointer: `${endpoint}/${nonExistingCourseId}`,
               },

--- a/src/module/course/infrastructure/database/course.postrges.repository.ts
+++ b/src/module/course/infrastructure/database/course.postrges.repository.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { titleCase } from 'change-case-all';
 import { Repository, TreeRepository } from 'typeorm';
 
 import BaseRepository from '@common/base/infrastructure/database/base.repository';
@@ -24,7 +25,11 @@ export class CoursePostgresRepository
     @Inject(CATEGORY_TREE_REPOSITORY_KEY)
     private readonly categoryTreeRepository: TreeRepository<CategoryEntity>,
   ) {
-    super(repository, courseMapper);
+    super(
+      repository,
+      courseMapper,
+      titleCase(CourseEntity.name.replace('Entity', '')),
+    );
   }
 
   async getOneById(
@@ -54,7 +59,7 @@ export class CoursePostgresRepository
     const entity = await this.getOneById(id, include);
 
     if (!entity) {
-      throw new EntityNotFoundException(id);
+      throw new EntityNotFoundException('id', id, this.entityType);
     }
 
     return entity;
@@ -77,7 +82,7 @@ export class CoursePostgresRepository
     });
 
     if (!course) {
-      throw new EntityNotFoundException(id);
+      throw new EntityNotFoundException('id', id, this.entityType);
     }
 
     await this.repository.softRemove(course);

--- a/src/module/lesson/__test__/lesson.e2e.spec.ts
+++ b/src/module/lesson/__test__/lesson.e2e.spec.ts
@@ -194,7 +194,7 @@ describe('Lesson Module', () => {
         .then(({ body }) => {
           const expectedResponse = expect.objectContaining({
             error: {
-              detail: `Entity with id ${nonExistingId} not found`,
+              detail: `Lesson with id ${nonExistingId} not found`,
               source: {
                 pointer: `${endpoint}/${existingIds.course.first}/section/${existingIds.section.first}/lesson/${nonExistingId}`,
               },
@@ -470,7 +470,7 @@ describe('Lesson Module', () => {
         .then(({ body }) => {
           const expectedResponse = expect.objectContaining({
             error: {
-              detail: `Entity with id ${nonExistingSectionId} not found`,
+              detail: `Section with id ${nonExistingSectionId} not found`,
               source: {
                 pointer: `${endpoint}/${existingIds.course.first}/section/${nonExistingSectionId}/lesson`,
               },
@@ -610,7 +610,7 @@ describe('Lesson Module', () => {
         .then(({ body }) => {
           const expectedResponse = expect.objectContaining({
             error: {
-              detail: `Entity with id ${nonExistingId} not found`,
+              detail: `Lesson with id ${nonExistingId} not found`,
               source: {
                 pointer: `${endpoint}/${existingIds.course.first}/section/${existingIds.section.first}/lesson/${nonExistingId}`,
               },
@@ -838,7 +838,7 @@ describe('Lesson Module', () => {
         .then(({ body }) => {
           const expectedResponse = expect.objectContaining({
             error: {
-              detail: `Entity with id ${lessonId} not found`,
+              detail: `Lesson with id ${lessonId} not found`,
               source: {
                 pointer: `${endpoint}/${existingIds.course.first}/section/${existingIds.section.first}/lesson/${lessonId}`,
               },
@@ -862,7 +862,7 @@ describe('Lesson Module', () => {
         .then(({ body }) => {
           const expectedResponse = expect.objectContaining({
             error: {
-              detail: `Entity with id ${nonExistingId} not found`,
+              detail: `Lesson with id ${nonExistingId} not found`,
               source: {
                 pointer: `${endpoint}/${existingIds.course.first}/section/${existingIds.section.first}/lesson/${nonExistingId}`,
               },

--- a/src/module/lesson/infrastructure/database/lesson.postgres.repository.ts
+++ b/src/module/lesson/infrastructure/database/lesson.postgres.repository.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { titleCase } from 'change-case-all';
 import { Repository } from 'typeorm';
 
 import BaseRepository from '@common/base/infrastructure/database/base.repository';
@@ -18,6 +19,10 @@ export class LessonPostgresRepository
     @InjectRepository(LessonEntity) repository: Repository<LessonEntity>,
     private readonly lessonMapper: LessonMapper,
   ) {
-    super(repository, lessonMapper);
+    super(
+      repository,
+      lessonMapper,
+      titleCase(LessonEntity.name.replace('Entity', '')),
+    );
   }
 }

--- a/src/module/payment-method/__test__/payment-method.e2e.spec.ts
+++ b/src/module/payment-method/__test__/payment-method.e2e.spec.ts
@@ -252,7 +252,7 @@ describe('PaymentMethod Module', () => {
         .then(({ body }) => {
           const expectedResponse = expect.objectContaining({
             error: {
-              detail: `Entity with id ${nonExistingPaymentMethodId} not found`,
+              detail: `PaymentMethod with id ${nonExistingPaymentMethodId} not found`,
               source: {
                 pointer: `${endpoint}/${nonExistingPaymentMethodId}`,
               },
@@ -375,7 +375,7 @@ describe('PaymentMethod Module', () => {
           }) => {
             const expectedResponse = expect.objectContaining({
               error: {
-                detail: `Entity with name '${createPaymentMethod.name}' already exists`,
+                detail: `PaymentMethod with name '${createPaymentMethod.name}' already exists`,
                 source: {
                   pointer: endpoint,
                 },
@@ -551,7 +551,7 @@ describe('PaymentMethod Module', () => {
         .then(({ body }) => {
           const expectedResponse = expect.objectContaining({
             error: {
-              detail: `Entity with id ${nonExistingPaymentMethodId} not found`,
+              detail: `PaymentMethod with id ${nonExistingPaymentMethodId} not found`,
               source: {
                 pointer: `${endpoint}/${nonExistingPaymentMethodId}`,
               },
@@ -745,7 +745,7 @@ describe('PaymentMethod Module', () => {
         .then(({ body }) => {
           const expectedResponse = expect.objectContaining({
             error: {
-              detail: `Entity with id ${nonExistingPaymentMethodId} not found`,
+              detail: `PaymentMethod with id ${nonExistingPaymentMethodId} not found`,
               source: {
                 pointer: `${endpoint}/${nonExistingPaymentMethodId}`,
               },

--- a/src/module/payment-method/infrastructure/database/payment-method.postgres.repository.ts
+++ b/src/module/payment-method/infrastructure/database/payment-method.postgres.repository.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { titleCase } from 'change-case-all';
 import { Repository } from 'typeorm';
 
 import BaseRepository from '@common/base/infrastructure/database/base.repository';
@@ -20,7 +21,11 @@ export class PaymentMethodPostgresRepository
     protected readonly repository: Repository<PaymentMethodEntity>,
     private readonly paymentMethodMapper: PaymentMethodMapper,
   ) {
-    super(repository, paymentMethodMapper);
+    super(
+      repository,
+      paymentMethodMapper,
+      titleCase(PaymentMethodEntity.name.replace('Entity', '')),
+    );
   }
 
   async saveOne(entity: PaymentMethod): Promise<PaymentMethod> {
@@ -28,7 +33,7 @@ export class PaymentMethodPostgresRepository
     const paymentMethod = await this.findEntityByName(name);
 
     if (paymentMethod) {
-      throw new EntityAlreadyExistsException('name', name);
+      throw new EntityAlreadyExistsException('name', name, this.entityType);
     }
 
     return this.repository.save(entity);

--- a/src/module/purchase/__test__/purchase.e2e.spec.ts
+++ b/src/module/purchase/__test__/purchase.e2e.spec.ts
@@ -131,7 +131,7 @@ describe('Purchase Module', () => {
         .then(({ body }) => {
           const expectedResponse = expect.objectContaining({
             error: {
-              detail: `Entity with id ${nonExistingPurchaseId} not found`,
+              detail: `Purchase with id ${nonExistingPurchaseId} not found`,
               source: {
                 pointer: `${endpoint}/${nonExistingPurchaseId}`,
               },
@@ -250,7 +250,7 @@ describe('Purchase Module', () => {
         .then(({ body }) => {
           const expectedResponse = expect.objectContaining({
             error: {
-              detail: `Entity with id ${nonExistingCourseId} not found`,
+              detail: `Course with id ${nonExistingCourseId} not found`,
               source: {
                 pointer: endpoint,
               },
@@ -333,7 +333,7 @@ describe('Purchase Module', () => {
         .then(({ body }) => {
           const expectedResponse = expect.objectContaining({
             error: {
-              detail: `Entity with id ${nonExistingPaymentMethodId} not found`,
+              detail: `PaymentMethod with id ${nonExistingPaymentMethodId} not found`,
               source: {
                 pointer: endpoint,
               },
@@ -404,7 +404,7 @@ describe('Purchase Module', () => {
         .then(({ body }) => {
           const expectedResponse = expect.objectContaining({
             error: {
-              detail: `Entity with id ${nonExistingPurchaseId} not found`,
+              detail: `Purchase with id ${nonExistingPurchaseId} not found`,
               source: {
                 pointer: `${endpoint}/${nonExistingPurchaseId}/status`,
               },
@@ -555,7 +555,7 @@ describe('Purchase Module', () => {
         .then(({ body }) => {
           const expectedResponse = expect.objectContaining({
             error: {
-              detail: `Entity with id ${nonExistingPaymentMethodId} not found`,
+              detail: `PaymentMethod with id ${nonExistingPaymentMethodId} not found`,
               source: {
                 pointer: `${endpoint}/${existingPurchaseId}/payment-method`,
               },

--- a/src/module/purchase/infrastructure/database/purchase.postgres.repository.ts
+++ b/src/module/purchase/infrastructure/database/purchase.postgres.repository.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { titleCase } from 'change-case-all';
 import { In, Repository } from 'typeorm';
 
 import BaseRepository from '@common/base/infrastructure/database/base.repository';
@@ -22,7 +23,11 @@ export class PurchasePostgresRepository
     private readonly purchaseRepository: Repository<PurchaseEntity>,
     private readonly purchaseMapper: PurchaseMapper,
   ) {
-    super(purchaseRepository, purchaseMapper);
+    super(
+      purchaseRepository,
+      purchaseMapper,
+      titleCase(PurchaseEntity.name.replace('Entity', '')),
+    );
   }
 
   async findUserPurchase(

--- a/src/module/section/__test__/section.e2e.spec.ts
+++ b/src/module/section/__test__/section.e2e.spec.ts
@@ -154,7 +154,7 @@ describe('Course Module', () => {
         .then(({ body }) => {
           const expectedResponse = expect.objectContaining({
             error: {
-              detail: `Entity with id ${nonExistingCourseId} not found`,
+              detail: `Course with id ${nonExistingCourseId} not found`,
               source: {
                 pointer: `${endpoint}/${nonExistingCourseId}/section`,
               },
@@ -312,7 +312,7 @@ describe('Course Module', () => {
         .then(({ body }) => {
           const expectedResponse = expect.objectContaining({
             error: {
-              detail: `Entity with id ${nonExistingSectionId} not found`,
+              detail: `Section with id ${nonExistingSectionId} not found`,
               source: {
                 pointer: `${endpoint}/${existingCourseId}/section/${nonExistingSectionId}`,
               },
@@ -718,7 +718,7 @@ describe('Course Module', () => {
         .then(({ body }) => {
           const expectedResponse = expect.objectContaining({
             error: {
-              detail: `Entity with id ${sectionId} not found`,
+              detail: `Section with id ${sectionId} not found`,
               source: {
                 pointer: `${endpoint}/${existingCourseId}/section/${sectionId}`,
               },
@@ -742,7 +742,7 @@ describe('Course Module', () => {
         .then(({ body }) => {
           const expectedResponse = expect.objectContaining({
             error: {
-              detail: `Entity with id ${nonExistingSectionId} not found`,
+              detail: `Section with id ${nonExistingSectionId} not found`,
               source: {
                 pointer: `${endpoint}/${existingCourseId}/section/${nonExistingSectionId}`,
               },

--- a/src/module/section/infrastructure/database/section.postgres.repository.ts
+++ b/src/module/section/infrastructure/database/section.postgres.repository.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { titleCase } from 'change-case-all';
 import { Repository } from 'typeorm';
 
 import BaseRepository from '@common/base/infrastructure/database/base.repository';
@@ -19,7 +20,11 @@ export class SectionPostgresRepository
     @InjectRepository(SectionEntity) repository: Repository<SectionEntity>,
     private readonly sectionMapper: SectionMapper,
   ) {
-    super(repository, sectionMapper);
+    super(
+      repository,
+      sectionMapper,
+      titleCase(SectionEntity.name.replace('Entity', '')),
+    );
   }
 
   async deleteOneByIdOrFail(id: string): Promise<void> {
@@ -29,7 +34,7 @@ export class SectionPostgresRepository
     });
 
     if (!section) {
-      throw new EntityNotFoundException(id);
+      throw new EntityNotFoundException('id', id, this.entityType);
     }
 
     await this.repository.softRemove(section);


### PR DESCRIPTION
# Summary

This PR refactors the mechanism of throwing a entity not found/already exists exception, in order to include the entity name of the error's message.