### PR TITLE
feat: add initial payment module

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -18,6 +18,7 @@
     "^@section/(.*)$",
     "^@lesson/(.*)$",
     "^@payment-method/(.*)$",
+    "^@payment/(.*)$",
     "^@purchase/(.*)$",
     "^@module/(.*)$",
     "^@test/(.*)$",

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -29,6 +29,7 @@ export default async (): Promise<Config> => {
       '^@lesson/(.*)$': '<rootDir>/module/lesson/$1',
       '^@payment-method/(.*)$': '<rootDir>/module/payment-method/$1',
       '^@purchase/(.*)$': '<rootDir>/module/purchase/$1',
+      '^@payment/(.*)$': '<rootDir>/module/payment/$1',
       '^@module/(.*)$': '<rootDir>/module/$1',
       '^@test/(.*)$': '<rootDir>/test/$1',
       '^@root/(.*)$': '<rootDir>/../$1',

--- a/src/module/app.module.ts
+++ b/src/module/app.module.ts
@@ -22,6 +22,8 @@ import { LessonModule } from '@lesson/lesson.module';
 
 import { PaymentMethodModule } from '@payment-method/payment-method.module';
 
+import { PaymentModule } from '@payment/payment.module';
+
 import { PurchaseModule } from '@purchase/purchase.module';
 
 @Global()
@@ -45,6 +47,7 @@ import { PurchaseModule } from '@purchase/purchase.module';
     PaymentMethodModule,
     CategoryModule,
     PurchaseModule,
+    PaymentModule,
   ],
   providers: [LinkBuilderService, SlugService],
   exports: [LinkBuilderService, SlugService],

--- a/src/module/payment/application/interface/payment-provider.interface.ts
+++ b/src/module/payment/application/interface/payment-provider.interface.ts
@@ -1,0 +1,11 @@
+import { IPaymentResponse } from '@payment/application/interface/payment-response.interface';
+import { IBuyer } from '@payment/application/service/payment-service.interface';
+
+export interface IPaymentProvider {
+  createPayment(
+    currency: string,
+    amount: number,
+    userId: string,
+    buyer?: IBuyer,
+  ): Promise<IPaymentResponse>;
+}

--- a/src/module/payment/application/interface/payment-response.interface.ts
+++ b/src/module/payment/application/interface/payment-response.interface.ts
@@ -1,0 +1,4 @@
+export interface IPaymentResponse {
+  externalPaymentId: string;
+  paymentUrl?: string;
+}

--- a/src/module/payment/application/service/payment-service.interface.ts
+++ b/src/module/payment/application/service/payment-service.interface.ts
@@ -1,0 +1,16 @@
+import { IPaymentResponse } from '@payment/application/interface/payment-response.interface';
+import { PaymentMethod } from '@payment/domain/payment-method.enum';
+
+export interface IPaymentService {
+  createPayment(
+    providerName: PaymentMethod,
+    amount: number,
+    userId: string,
+    buyer?: IBuyer,
+  ): Promise<IPaymentResponse>;
+}
+
+export interface IBuyer {
+  name?: string;
+  email?: string;
+}

--- a/src/module/payment/application/service/payment.service.ts
+++ b/src/module/payment/application/service/payment.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@nestjs/common';
+
+import { IPaymentResponse } from '@payment/application/interface/payment-response.interface';
+import {
+  IBuyer,
+  IPaymentService,
+} from '@payment/application/service/payment-service.interface';
+import { PaymentMethod } from '@payment/domain/payment-method.enum';
+import { PaymentProviderStorage } from '@payment/infrastructure/storage/payment-provider.storage';
+
+@Injectable()
+export class PaymentService implements IPaymentService {
+  private readonly CURRENCY = 'USD';
+  constructor(
+    private readonly paymentProviderStorage: PaymentProviderStorage,
+  ) {}
+
+  async createPayment(
+    providerName: PaymentMethod,
+    amount: number,
+    userId: string,
+    buyer?: IBuyer,
+  ): Promise<IPaymentResponse> {
+    const paymentProvider = this.paymentProviderStorage.get(providerName);
+
+    return await paymentProvider.createPayment(
+      this.CURRENCY,
+      amount,
+      userId,
+      buyer,
+    );
+  }
+}

--- a/src/module/payment/domain/payment-method.enum.ts
+++ b/src/module/payment/domain/payment-method.enum.ts
@@ -1,0 +1,1 @@
+export enum PaymentMethod {}

--- a/src/module/payment/infrastructure/storage/payment-provider.storage.ts
+++ b/src/module/payment/infrastructure/storage/payment-provider.storage.ts
@@ -1,0 +1,25 @@
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
+
+import { IPaymentProvider } from '@payment/application/interface/payment-provider.interface';
+import { PaymentMethod } from '@payment/domain/payment-method.enum';
+
+@Injectable()
+export class PaymentProviderStorage {
+  private readonly collection = new Map<PaymentMethod, IPaymentProvider>();
+
+  add(providerName: PaymentMethod, handler: IPaymentProvider): void {
+    this.collection.set(providerName, handler);
+  }
+
+  get(providerName: PaymentMethod): IPaymentProvider {
+    const handler = this.collection.get(providerName);
+
+    if (!handler) {
+      throw new InternalServerErrorException(
+        `Can't find instance of payment provider "${providerName}".`,
+      );
+    }
+
+    return handler;
+  }
+}

--- a/src/module/payment/payment.module.ts
+++ b/src/module/payment/payment.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+
+import { PaymentProviderStorage } from '@payment/infrastructure/storage/payment-provider.storage';
+
+@Module({
+  providers: [PaymentProviderStorage],
+  exports: [PaymentProviderStorage],
+})
+export class PaymentModule {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,6 +31,7 @@
       "@lesson/*": ["src/module/lesson/*"],
       "@purchase/*": ["src/module/purchase/*"],
       "@payment-method/*": ["src/module/payment-method/*"],
+      "@payment/*": ["src/module/payment/*"],
       "@module/*": ["src/module/*"],
       "@test/*": ["src/test/*"],
       "@/*": ["src/*"],


### PR DESCRIPTION
# Summary

This PR introduces an initial `PaymentModule` with a provider storage and generic interfaces.

# Details

- Implemented a `PaymentProviderStorage` for using it to obtain/save a specific provider by an enum value.
- Created generic interfaces for the `PaymentService` and specific payment providers.