### PR TITLE
feat: add paypal webhook service

### DIFF
--- a/src/config/env.d.ts
+++ b/src/config/env.d.ts
@@ -24,6 +24,7 @@ declare global {
       S3_BUCKET: string;
       PAYPAL_CLIENT_ID: string;
       PAYPAL_CLIENT_SECRET: string;
+      PAYPAL_WEBHOOK_ID: string;
     }
   }
 }

--- a/src/config/environment.config.ts
+++ b/src/config/environment.config.ts
@@ -28,5 +28,6 @@ export const environmentConfig = (): Record<string, any> => ({
   paypal: {
     clientId: process.env.PAYPAL_CLIENT_ID,
     clientSecret: process.env.PAYPAL_CLIENT_SECRET,
+    webhookId: process.env.PAYPAL_WEBHOOK_ID,
   },
 });

--- a/src/module/paypal/__test__/fixture/Category.yml
+++ b/src/module/paypal/__test__/fixture/Category.yml
@@ -1,0 +1,5 @@
+entity: category
+items:
+  category1:
+    id: '2d915994-8c06-425c-9a64-23a7b2b8603e'
+    name: 'Category 1'

--- a/src/module/paypal/__test__/fixture/Course.yml
+++ b/src/module/paypal/__test__/fixture/Course.yml
@@ -1,0 +1,46 @@
+entity: course
+items:
+  course1:
+    id: '29694b5e-c5d1-487e-a6e8-3f7aa6c4238c'
+    title: 'Introduction to Programming'
+    description: 'Learn the basics of programming with JavaScript'
+    price: 49.99
+    imageUrl: '{{internet.url}}/intro-programming.jpg'
+    status: published
+    slug: 'introduction-to-programming'
+    difficulty: beginner
+    instructor: '@admin-user'
+    category: '@category1'
+  course2:
+    id: '386ece9b-eaab-4a82-ac53-727579f67cd8'
+    title: 'Advanced Web Development'
+    description: 'Master React, Node.js and modern web architectures'
+    price: 89.99
+    imageUrl: '{{internet.url}}/advanced-web.jpg'
+    status: published
+    slug: 'advanced-web-development'
+    difficulty: advanced
+    instructor: '@admin-user'
+    category: '@category1'
+  course3:
+    id: 'bec20f92-fa5c-48d7-9736-880f8b704287'
+    title: 'Advanced Mathematics'
+    description: 'Master Calculus and Linear Algebra'
+    price: 89.99
+    imageUrl: '{{internet.url}}/advanced-web.jpg'
+    status: published
+    slug: 'advanced-mathematics'
+    difficulty: advanced
+    instructor: '@admin-user'
+    category: '@category1'
+  course4:
+    id: '30d153df-b6ab-47a7-97c7-bf2081fc6737'
+    title: 'Advanced English'
+    description: 'Master Grammar and Vocabulary'
+    price: 89.99
+    imageUrl: '{{internet.url}}/advanced-web.jpg'
+    status: published
+    slug: 'advanced-english'
+    difficulty: advanced
+    instructor: '@admin-user'
+    category: '@category1'

--- a/src/module/paypal/__test__/fixture/Purchase.yml
+++ b/src/module/paypal/__test__/fixture/Purchase.yml
@@ -1,0 +1,34 @@
+entity: purchase
+items:
+  purchase:
+    id: 'e6c78b10-d9b0-4819-ac4e-a36ca36f8554'
+    userId: '5e822193-13ca-4846-9b60-9f2f38d7eefa'
+    courseId: 'ba7fc4eb-e4f7-47a9-b963-f1e733d39748'
+    status: pending
+    amount: 49.99
+    paymentMethod: 'PayPal'
+    paymentOrderId: '8U481631H66031715'
+  purchase1:
+    id: 'c3d3c40b-c9c1-4b48-a806-63f78bf439bd'
+    userId: '5e822193-13ca-4846-9b60-9f2f38d7eefa'
+    courseId: '386ece9b-eaab-4a82-ac53-727579f67cd8'
+    status: pending
+    amount: 49.99
+    paymentMethod: 'PayPal'
+    paymentOrderId: '8U481631H66031716'
+  purchase2:
+    id: '379867ec-c038-438a-9ef0-d2abedcd4a52'
+    userId: '5e822193-13ca-4846-9b60-9f2f38d7eefa'
+    courseId: 'bec20f92-fa5c-48d7-9736-880f8b704287'
+    status: pending
+    amount: 49.99
+    paymentMethod: 'PayPal'
+    paymentOrderId: '8U481631H66031717'
+  purchase3:
+    id: '8ce5b26e-1264-4552-9e84-a3fd16d2b2b9'
+    userId: '5e822193-13ca-4846-9b60-9f2f38d7eefa'
+    courseId: '30d153df-b6ab-47a7-97c7-bf2081fc6737'
+    status: pending
+    amount: 49.99
+    paymentMethod: 'PayPal'
+    paymentOrderId: '8U481631H66031718'

--- a/src/module/paypal/__test__/fixture/User.yml
+++ b/src/module/paypal/__test__/fixture/User.yml
@@ -1,0 +1,18 @@
+entity: user
+items:
+  admin-user:
+    id: a90108bf-42c6-481f-a63f-4b51fed1300c
+    firstName: admin-name
+    lastName: admin-surname
+    email: 'test_admin@email.co'
+    avatarUrl: '{{internet.url}}'
+    externalId: '00000000-0000-0000-0000-00000000000Y'
+    roles: regular,admin
+  regular-user:
+    id: '5e822193-13ca-4846-9b60-9f2f38d7eefa'
+    firstName: regular-name
+    lastName: regular-surname
+    email: 'test_regular@email.co'
+    avatarUrl: '{{internet.url}}'
+    externalId: '00000000-0000-0000-0000-00000000000Z'
+    roles: regular

--- a/src/module/paypal/__test__/paypal.e2e.spec.ts
+++ b/src/module/paypal/__test__/paypal.e2e.spec.ts
@@ -1,0 +1,580 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { HttpStatus } from '@nestjs/common';
+import { NestExpressApplication } from '@nestjs/platform-express';
+import { IncomingHttpHeaders } from 'http';
+import request from 'supertest';
+
+import { setupApp } from '@config/app.config';
+import { datasourceOptions } from '@config/orm.config';
+
+import { loadFixtures } from '@data/util/fixture-loader';
+
+import { HttpMethod } from '@common/base/application/enum/http-method.enum';
+
+import { PayPalWebhookEvent } from '@paypal/application/enum/paypal-webhook-event.enum';
+import {
+  IPayPalCaptureResource,
+  IPayPalOrderResource,
+  IPaypalWebhookBody,
+} from '@paypal/application/interface/paypal-webhook-body.interface';
+import { IPayPalWebhookHeaders } from '@paypal/application/interface/paypal-webhook-headers.interface';
+import { WEBHOOK_EVENT_NAME } from '@paypal/domain/webhook-name';
+import { INVALID_PAYPAL_WEBHOOK } from '@paypal/infrastructure/exception/paypal-exception.messages';
+
+import {
+  IPurchaseRepository,
+  PURCHASE_REPOSITORY_KEY,
+} from '@purchase/application/repository/purchase-repository.interface';
+import { PurchaseStatus } from '@purchase/domain/purchase.status.enum';
+
+import {
+  paypalPaymentProviderMock,
+  testModuleBootstrapper,
+} from '@test/test.module.bootstrapper';
+
+describe('Paypal E2E tests', () => {
+  let app: NestExpressApplication;
+  let purchaseRepository: IPurchaseRepository;
+
+  beforeAll(async () => {
+    await loadFixtures(`${__dirname}/fixture`, datasourceOptions);
+    const moduleRef = await testModuleBootstrapper();
+    app = moduleRef.createNestApplication({ logger: false });
+    setupApp(app);
+    await app.init();
+
+    purchaseRepository = app.get<IPurchaseRepository>(PURCHASE_REPOSITORY_KEY);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  const endpoint = '/api/v1/paypal';
+
+  const mockPaypalHeaders = {
+    'paypal-auth-algorithm': 'HMAC-SHA256',
+    'paypal-auth-authorization': 'mock-authorization',
+    'paypal-auth-timestamp': 'mock-timestamp',
+    'paypal-auth-signature': 'mock-signature',
+    'paypal-auth-algo': 'HMAC-SHA256',
+    'paypal-cert-url': 'mock-cert-url',
+    'paypal-transmission-id': 'mock-transmission-id',
+    'paypal-transmission-sig': 'mock-transmission-sig',
+    'paypal-transmission-time': 'mock-transmission-time',
+    'paypal-auth-version': 'mock-auth-version',
+  } as IPayPalWebhookHeaders;
+
+  const mockCheckoutOrderApproved = {
+    event_type: PayPalWebhookEvent.CheckoutOrderApproved,
+    resource: {
+      id: 'order-id',
+      status: 'COMPLETED',
+    } as IPayPalOrderResource,
+  } as IPaypalWebhookBody;
+
+  describe('Guards', () => {
+    describe('PayPalWebhookGuard', () => {
+      it('Should grant access when the webhook signature is valid', async () => {
+        (
+          paypalPaymentProviderMock.verifyWebhookSignature as jest.Mock
+        ).mockResolvedValueOnce(true);
+
+        return await request(app.getHttpServer())
+          .post(`${endpoint}/webhook`)
+          .set(mockPaypalHeaders as unknown as IncomingHttpHeaders)
+          .send(mockCheckoutOrderApproved)
+          .expect(HttpStatus.OK);
+      });
+
+      it('Should throw an error when the webhook signature is invalid', async () => {
+        (
+          paypalPaymentProviderMock.verifyWebhookSignature as jest.Mock
+        ).mockResolvedValueOnce(false);
+
+        return await request(app.getHttpServer())
+          .post(`${endpoint}/webhook`)
+          .set(mockPaypalHeaders as unknown as IncomingHttpHeaders)
+          .send(mockCheckoutOrderApproved)
+          .expect(HttpStatus.FORBIDDEN)
+          .then(({ body }) => {
+            const expectedResponse = expect.objectContaining({
+              error: {
+                detail: INVALID_PAYPAL_WEBHOOK,
+                source: {
+                  pointer: expect.stringContaining(`${endpoint}/webhook`),
+                },
+                status: HttpStatus.FORBIDDEN.toString(),
+                title: 'Forbidden',
+              },
+            });
+            expect(body).toEqual(expectedResponse);
+          });
+      });
+    });
+  });
+
+  describe('POST - /webhook', () => {
+    describe('Webhook event CHECKOUT.ORDER.APPROVED', () => {
+      const body = {
+        event_type: PayPalWebhookEvent.CheckoutOrderApproved,
+        resource: {
+          id: 'order-id',
+          status: 'COMPLETED',
+        },
+      } as IPaypalWebhookBody;
+
+      it('Should return a successful webhook response dto', async () => {
+        return await request(app.getHttpServer())
+          .post(`${endpoint}/webhook`)
+          .set(mockPaypalHeaders as unknown as IncomingHttpHeaders)
+          .send(body)
+          .expect(HttpStatus.OK)
+          .then(({ body }) => {
+            const expectedResponse = expect.objectContaining({
+              data: expect.objectContaining({
+                type: WEBHOOK_EVENT_NAME,
+                attributes: expect.objectContaining({
+                  message: 'Order with id capture-id approved',
+                  processed: true,
+                  purchaseStatus: PurchaseStatus.PENDING,
+                }),
+              }),
+              links: expect.arrayContaining([
+                expect.objectContaining({
+                  method: HttpMethod.POST,
+                  rel: 'self',
+                  href: expect.stringContaining(`${endpoint}/webhook`),
+                }),
+              ]),
+            });
+
+            expect(body).toEqual(expectedResponse);
+          });
+      });
+    });
+
+    describe('Webhook event CHECKOUT.ORDER.DENIED', () => {
+      const webhookEvent = {
+        event_type: PayPalWebhookEvent.CheckoutOrderDeclined,
+        resource: {
+          id: '8U481631H66031715',
+          status: 'FAILED',
+        },
+      } as IPaypalWebhookBody;
+
+      it('Should return a successful webhook response dto updating the existing purchase', async () => {
+        const purchase = await purchaseRepository.findByPaymentOrderIdOrFail(
+          webhookEvent.resource.id,
+        );
+        expect(purchase.status).toBe(PurchaseStatus.PENDING);
+        expect(purchase.paymentTransactionId).toBeNull();
+
+        return await request(app.getHttpServer())
+          .post(`${endpoint}/webhook`)
+          .set(mockPaypalHeaders as unknown as IncomingHttpHeaders)
+          .send(webhookEvent)
+          .expect(HttpStatus.OK)
+          .then(async ({ body }) => {
+            const expectedResponse = expect.objectContaining({
+              data: expect.objectContaining({
+                type: WEBHOOK_EVENT_NAME,
+                attributes: expect.objectContaining({
+                  message: `Order with id ${webhookEvent.resource.id} declined`,
+                  processed: true,
+                  purchaseStatus: PurchaseStatus.FAILED,
+                }),
+              }),
+              links: expect.arrayContaining([
+                expect.objectContaining({
+                  method: HttpMethod.POST,
+                  rel: 'self',
+                  href: expect.stringContaining(`${endpoint}/webhook`),
+                }),
+              ]),
+            });
+
+            expect(body).toEqual(expectedResponse);
+
+            const updatedPurchase =
+              await purchaseRepository.findByPaymentOrderIdOrFail(
+                webhookEvent.resource.id,
+              );
+
+            expect(updatedPurchase.status).toBe(PurchaseStatus.FAILED);
+            expect(updatedPurchase.paymentTransactionId).toBeNull();
+          });
+      });
+
+      it('Should throw an error if the purchase does not exist', async () => {
+        const webhookEventWithNonExistingId = {
+          ...webhookEvent,
+          resource: {
+            ...webhookEvent.resource,
+            id: 'non-existing-id',
+          },
+        };
+        return await request(app.getHttpServer())
+          .post(`${endpoint}/webhook`)
+          .set(mockPaypalHeaders as unknown as IncomingHttpHeaders)
+          .send(webhookEventWithNonExistingId)
+          .expect(HttpStatus.NOT_FOUND)
+          .then(({ body }) => {
+            const expectedResponse = expect.objectContaining({
+              error: {
+                detail: `Purchase with paymentOrderId ${webhookEventWithNonExistingId.resource.id} not found`,
+                source: {
+                  pointer: expect.stringContaining(`${endpoint}/webhook`),
+                },
+                status: HttpStatus.NOT_FOUND.toString(),
+                title: 'Entity not found',
+              },
+            });
+            expect(body).toEqual(expectedResponse);
+          });
+      });
+    });
+
+    describe('Webhook event PAYMENT.CAPTURE.COMPLETED', () => {
+      const body = {
+        event_type: PayPalWebhookEvent.PaymentCaptureCompleted,
+        resource: {
+          disbursement_mode: 'DELAYED',
+          amount: {
+            currency_code: 'USD',
+            value: '57.00',
+          },
+          seller_protection: {
+            status: 'ELIGIBLE',
+            dispute_categories: [
+              'ITEM_NOT_RECEIVED',
+              'UNAUTHORIZED_TRANSACTION',
+            ],
+          },
+          create_time: '2022-08-26T18:29:50Z',
+          custom_id: 'd93e4fcb-d3af-137c-82fe-1a8101f1ad11',
+          supplementary_data: {
+            related_ids: {
+              order_id: '8U481631H66031716',
+            },
+          },
+          update_time: '2022-08-26T18:29:50Z',
+          final_capture: true,
+          invoice_id: '3942619:fdv09c49-a3g6-4cbf-1358-f6d241dacea2',
+          id: '42311647XV020574X',
+          status: 'COMPLETED',
+        },
+      } as IPaypalWebhookBody;
+      const paymentOrderId = (body.resource as IPayPalCaptureResource)
+        .supplementary_data?.related_ids?.order_id as string;
+      const captureId = body.resource.id;
+
+      it('Should return a successful webhook response dto updating the existing purchase', async () => {
+        const purchase =
+          await purchaseRepository.findByPaymentOrderIdOrFail(paymentOrderId);
+        expect(purchase.status).toBe(PurchaseStatus.PENDING);
+        expect(purchase.paymentTransactionId).toBeNull();
+
+        return await request(app.getHttpServer())
+          .post(`${endpoint}/webhook`)
+          .set(mockPaypalHeaders as unknown as IncomingHttpHeaders)
+          .send(body)
+          .expect(HttpStatus.OK)
+          .then(async ({ body }) => {
+            const expectedResponse = expect.objectContaining({
+              data: expect.objectContaining({
+                type: WEBHOOK_EVENT_NAME,
+                attributes: expect.objectContaining({
+                  message: `Order with id ${paymentOrderId} captured successfully with id ${captureId}`,
+                  processed: true,
+                  purchaseStatus: PurchaseStatus.COMPLETED,
+                }),
+              }),
+              links: expect.arrayContaining([
+                expect.objectContaining({
+                  method: HttpMethod.POST,
+                  rel: 'self',
+                  href: expect.stringContaining(`${endpoint}/webhook`),
+                }),
+              ]),
+            });
+
+            expect(body).toEqual(expectedResponse);
+
+            const updatedPurchase =
+              await purchaseRepository.findByPaymentOrderIdOrFail(
+                paymentOrderId,
+              );
+
+            expect(updatedPurchase.status).toBe(PurchaseStatus.COMPLETED);
+            expect(updatedPurchase.paymentTransactionId).toBe(captureId);
+          });
+      });
+
+      it('Should throw an error when the purchase does not exist', async () => {
+        const nonExistingOrderId = 'non-existing-order-id';
+        const bodyWithNonExistingOrderId = {
+          ...body,
+          resource: {
+            ...body.resource,
+            supplementary_data: {
+              ...(body.resource as IPayPalCaptureResource).supplementary_data,
+              related_ids: {
+                order_id: nonExistingOrderId,
+              },
+            },
+          },
+        };
+
+        return await request(app.getHttpServer())
+          .post(`${endpoint}/webhook`)
+          .set(mockPaypalHeaders as unknown as IncomingHttpHeaders)
+          .send(bodyWithNonExistingOrderId)
+          .expect(HttpStatus.NOT_FOUND)
+          .then(({ body }) => {
+            const expectedResponse = expect.objectContaining({
+              error: {
+                detail: `Purchase with paymentOrderId ${nonExistingOrderId} not found`,
+                source: {
+                  pointer: expect.stringContaining(`${endpoint}/webhook`),
+                },
+                status: HttpStatus.NOT_FOUND.toString(),
+                title: 'Entity not found',
+              },
+            });
+
+            expect(body).toEqual(expectedResponse);
+          });
+      });
+    });
+
+    describe('Webhook event PAYMENT.CAPTURE.DENIED', () => {
+      const body = {
+        event_type: PayPalWebhookEvent.PaymentCaptureDenied,
+        resource: {
+          disbursement_mode: 'DELAYED',
+          amount: {
+            currency_code: 'USD',
+            value: '57.00',
+          },
+          seller_protection: {
+            status: 'NOT_ELIGIBLE',
+            dispute_categories: [],
+          },
+          create_time: '2022-08-26T18:29:50Z',
+          custom_id: 'd93e4fcb-d3af-137c-82fe-1a8101f1ad11',
+          supplementary_data: {
+            related_ids: {
+              order_id: '8U481631H66031717',
+            },
+          },
+          update_time: '2022-08-26T18:29:50Z',
+          final_capture: false,
+          invoice_id: '3942619:fdv09c49-a3g6-4cbf-1358-f6d241dacea2',
+          id: '42311647XV020574X',
+          status: 'DECLINED',
+        },
+      } as IPaypalWebhookBody;
+
+      const paymentOrderId = (body.resource as IPayPalCaptureResource)
+        .supplementary_data?.related_ids?.order_id as string;
+      const captureId = body.resource.id;
+
+      it('Should return a failed webhook response dto and update purchase status to FAILED', async () => {
+        const purchase =
+          await purchaseRepository.findByPaymentOrderIdOrFail(paymentOrderId);
+        expect(purchase.status).not.toBe(PurchaseStatus.FAILED);
+        expect(purchase.paymentTransactionId).toBeNull();
+
+        return await request(app.getHttpServer())
+          .post(`${endpoint}/webhook`)
+          .set(mockPaypalHeaders as unknown as IncomingHttpHeaders)
+          .send(body)
+          .expect(HttpStatus.OK)
+          .then(async ({ body: responseBody }) => {
+            const expectedResponse = expect.objectContaining({
+              data: expect.objectContaining({
+                type: WEBHOOK_EVENT_NAME,
+                attributes: expect.objectContaining({
+                  message: `Order with id ${paymentOrderId} capture failed with id ${captureId}`,
+                  processed: true,
+                  purchaseStatus: PurchaseStatus.FAILED,
+                }),
+              }),
+              links: expect.arrayContaining([
+                expect.objectContaining({
+                  method: HttpMethod.POST,
+                  rel: 'self',
+                  href: expect.stringContaining(`${endpoint}/webhook`),
+                }),
+              ]),
+            });
+
+            expect(responseBody).toEqual(expectedResponse);
+
+            const updatedPurchase =
+              await purchaseRepository.findByPaymentOrderIdOrFail(
+                paymentOrderId,
+              );
+
+            expect(updatedPurchase.status).toBe(PurchaseStatus.FAILED);
+            expect(updatedPurchase.paymentTransactionId).toBe(captureId);
+          });
+      });
+
+      it('Should throw an error when the purchase does not exist for denied capture', async () => {
+        const nonExistingOrderId = 'non-existing-order-id-denied';
+        const bodyWithNonExistingOrderId = {
+          ...body,
+          resource: {
+            ...body.resource,
+            supplementary_data: {
+              ...(body.resource as IPayPalCaptureResource).supplementary_data,
+              related_ids: {
+                order_id: nonExistingOrderId,
+              },
+            },
+          },
+        };
+
+        return await request(app.getHttpServer())
+          .post(`${endpoint}/webhook`)
+          .set(mockPaypalHeaders as unknown as IncomingHttpHeaders)
+          .send(bodyWithNonExistingOrderId)
+          .expect(HttpStatus.NOT_FOUND)
+          .then(({ body: responseBody }) => {
+            const expectedResponse = expect.objectContaining({
+              error: {
+                detail: `Purchase with paymentOrderId ${nonExistingOrderId} not found`,
+                source: {
+                  pointer: expect.stringContaining(`${endpoint}/webhook`),
+                },
+                status: HttpStatus.NOT_FOUND.toString(),
+                title: 'Entity not found',
+              },
+            });
+
+            expect(responseBody).toEqual(expectedResponse);
+          });
+      });
+    });
+
+    describe('Webhook event PAYMENT.CAPTURE.CANCELLED', () => {
+      const body = {
+        event_type: PayPalWebhookEvent.PaymentCaptureCancelled,
+        resource: {
+          disbursement_mode: 'DELAYED',
+          amount: {
+            currency_code: 'USD',
+            value: '57.00',
+          },
+          seller_protection: {
+            status: 'ELIGIBLE',
+            dispute_categories: [
+              'ITEM_NOT_RECEIVED',
+              'UNAUTHORIZED_TRANSACTION',
+            ],
+          },
+          create_time: '2022-08-26T18:29:50Z',
+          custom_id: 'd93e4fcb-d3af-137c-82fe-1a8101f1ad11',
+          supplementary_data: {
+            related_ids: {
+              order_id: '8U481631H66031718',
+            },
+          },
+          update_time: '2022-08-26T18:29:50Z',
+          final_capture: false,
+          invoice_id: '3942619:fdv09c49-a3g6-4cbf-1358-f6d241dacea2',
+          id: '42311647XV020574X',
+          status: 'CANCELLED',
+        },
+      } as IPaypalWebhookBody;
+
+      const paymentOrderId = (body.resource as IPayPalCaptureResource)
+        .supplementary_data?.related_ids?.order_id as string;
+      const captureId = body.resource.id;
+
+      it('Should return a cancelled webhook response dto and update purchase status to CANCELLED', async () => {
+        const purchase =
+          await purchaseRepository.findByPaymentOrderIdOrFail(paymentOrderId);
+        expect(purchase.status).toBe(PurchaseStatus.PENDING);
+        expect(purchase.paymentTransactionId).toBeNull();
+
+        return await request(app.getHttpServer())
+          .post(`${endpoint}/webhook`)
+          .set(mockPaypalHeaders as unknown as IncomingHttpHeaders)
+          .send(body)
+          .expect(HttpStatus.OK)
+          .then(async ({ body: responseBody }) => {
+            const expectedResponse = expect.objectContaining({
+              data: expect.objectContaining({
+                type: WEBHOOK_EVENT_NAME,
+                attributes: expect.objectContaining({
+                  message: `Order with id ${paymentOrderId} cancelled with id ${captureId}`,
+                  processed: true,
+                  purchaseStatus: PurchaseStatus.CANCELLED,
+                }),
+              }),
+              links: expect.arrayContaining([
+                expect.objectContaining({
+                  method: HttpMethod.POST,
+                  rel: 'self',
+                  href: expect.stringContaining(`${endpoint}/webhook`),
+                }),
+              ]),
+            });
+
+            expect(responseBody).toEqual(expectedResponse);
+
+            const updatedPurchase =
+              await purchaseRepository.findByPaymentOrderIdOrFail(
+                paymentOrderId,
+              );
+
+            expect(updatedPurchase.status).toBe(PurchaseStatus.CANCELLED);
+            expect(updatedPurchase.paymentTransactionId).toBe(captureId);
+          });
+      });
+
+      it('Should throw an error when the purchase does not exist for cancelled capture', async () => {
+        const nonExistingOrderId = 'non-existing-order-id-cancelled';
+        const bodyWithNonExistingOrderId = {
+          ...body,
+          resource: {
+            ...body.resource,
+            supplementary_data: {
+              ...(body.resource as IPayPalCaptureResource).supplementary_data,
+              related_ids: {
+                order_id: nonExistingOrderId,
+              },
+            },
+          },
+        };
+
+        return await request(app.getHttpServer())
+          .post(`${endpoint}/webhook`)
+          .set(mockPaypalHeaders as unknown as IncomingHttpHeaders)
+          .send(bodyWithNonExistingOrderId)
+          .expect(HttpStatus.NOT_FOUND)
+          .then(({ body: responseBody }) => {
+            const expectedResponse = expect.objectContaining({
+              error: {
+                detail: `Purchase with paymentOrderId ${nonExistingOrderId} not found`,
+                source: {
+                  pointer: expect.stringContaining(`${endpoint}/webhook`),
+                },
+                status: HttpStatus.NOT_FOUND.toString(),
+                title: 'Entity not found',
+              },
+            });
+
+            expect(responseBody).toEqual(expectedResponse);
+          });
+      });
+    });
+  });
+});

--- a/src/module/paypal/application/dto/webhook-event-response.dto.ts
+++ b/src/module/paypal/application/dto/webhook-event-response.dto.ts
@@ -1,0 +1,22 @@
+import { BaseResponseDto } from '@common/base/application/dto/base.response.dto';
+
+import { PurchaseStatus } from '@purchase/domain/purchase.status.enum';
+
+export class WebhookEventResponseDto extends BaseResponseDto {
+  message: string;
+  processed: boolean;
+  purchaseStatus: PurchaseStatus;
+
+  constructor(
+    type: string,
+    message: string,
+    processed: boolean,
+    purchaseStatus: PurchaseStatus,
+  ) {
+    super(type);
+
+    this.message = message;
+    this.processed = processed;
+    this.purchaseStatus = purchaseStatus;
+  }
+}

--- a/src/module/paypal/application/interface/paypal-webhook-headers.interface.ts
+++ b/src/module/paypal/application/interface/paypal-webhook-headers.interface.ts
@@ -1,0 +1,8 @@
+export interface IPayPalWebhookHeaders {
+  'paypal-transmission-id': string;
+  'paypal-transmission-time': string;
+  'paypal-transmission-sig': string;
+  'paypal-cert-url': string;
+  'paypal-auth-algo': string;
+  'paypal-auth-version'?: string;
+}

--- a/src/module/paypal/application/service/paypal-webhook.service.ts
+++ b/src/module/paypal/application/service/paypal-webhook.service.ts
@@ -1,0 +1,177 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+import { WebhookEventResponseDto } from '@paypal/application/dto/webhook-event-response.dto';
+import { PayPalWebhookEvent } from '@paypal/application/enum/paypal-webhook-event.enum';
+import {
+  IPayPalCaptureResource,
+  IPaypalWebhookBody,
+  IPaypalWebhookVerifyPayload,
+} from '@paypal/application/interface/paypal-webhook-body.interface';
+import { IPayPalWebhookHeaders } from '@paypal/application/interface/paypal-webhook-headers.interface';
+import { WEBHOOK_EVENT_NAME } from '@paypal/domain/webhook-name';
+import { PaypalPaymentProvider } from '@paypal/infrastructure/provider/paypal-payment.provider';
+
+import {
+  IPurchaseRepository,
+  PURCHASE_REPOSITORY_KEY,
+} from '@purchase/application/repository/purchase-repository.interface';
+import { PurchaseStatus } from '@purchase/domain/purchase.status.enum';
+
+@Injectable()
+export class PaypalWebhookService {
+  private webhookId: string;
+  constructor(
+    @Inject(PURCHASE_REPOSITORY_KEY)
+    private readonly purchaseRepository: IPurchaseRepository,
+    private readonly paypalPaymentProvider: PaypalPaymentProvider,
+    private readonly configService: ConfigService,
+  ) {
+    this.webhookId = this.configService.get<string>('paypal.webhookId')!;
+  }
+
+  async verifyWebhook(
+    headers: IPayPalWebhookHeaders,
+    body: IPaypalWebhookBody,
+  ): Promise<boolean> {
+    const payload = this.buildWebhookVerifyPayload(headers, body);
+    const accessToken = await this.paypalPaymentProvider.getAccessToken();
+
+    return await this.paypalPaymentProvider.verifyWebhookSignature(
+      accessToken,
+      payload,
+    );
+  }
+
+  private buildWebhookVerifyPayload(
+    headers: IPayPalWebhookHeaders,
+    body: IPaypalWebhookBody,
+  ): IPaypalWebhookVerifyPayload {
+    return {
+      auth_algo: headers['paypal-auth-algo'],
+      cert_url: headers['paypal-cert-url'],
+      transmission_id: headers['paypal-transmission-id'],
+      transmission_sig: headers['paypal-transmission-sig'],
+      transmission_time: headers['paypal-transmission-time'],
+      webhook_id: this.webhookId,
+      webhook_event: body,
+    };
+  }
+
+  async processEvent(
+    eventType: PayPalWebhookEvent,
+    resource: IPaypalWebhookBody['resource'],
+  ): Promise<WebhookEventResponseDto> {
+    switch (eventType) {
+      case PayPalWebhookEvent.CheckoutOrderApproved:
+        return await this.handleCheckoutOrderApproved(resource.id);
+      case PayPalWebhookEvent.CheckoutOrderDeclined:
+        return await this.handleCheckoutOrderDeclined(resource.id);
+      case PayPalWebhookEvent.PaymentCaptureCompleted:
+        return await this.handlePaymentCaptureCompleted(resource);
+      case PayPalWebhookEvent.PaymentCaptureDenied:
+        return await this.handlePaymentCaptureDenied(resource);
+      case PayPalWebhookEvent.PaymentCaptureCancelled:
+        return await this.handleCancelled(resource);
+    }
+  }
+
+  private async handleCheckoutOrderApproved(
+    orderId: string,
+  ): Promise<WebhookEventResponseDto> {
+    const { id } =
+      await this.paypalPaymentProvider.capturePaymentOrder(orderId);
+
+    return new WebhookEventResponseDto(
+      WEBHOOK_EVENT_NAME,
+      `Order with id ${id} approved`,
+      true,
+      PurchaseStatus.PENDING,
+    );
+  }
+
+  private async handleCheckoutOrderDeclined(
+    orderId: string,
+  ): Promise<WebhookEventResponseDto> {
+    const purchase =
+      await this.purchaseRepository.findByPaymentOrderIdOrFail(orderId);
+
+    purchase.status = PurchaseStatus.FAILED;
+
+    await this.purchaseRepository.saveOne(purchase);
+
+    return new WebhookEventResponseDto(
+      WEBHOOK_EVENT_NAME,
+      `Order with id ${orderId} declined`,
+      true,
+      PurchaseStatus.FAILED,
+    );
+  }
+
+  private async handlePaymentCaptureCompleted(
+    resource: IPayPalCaptureResource,
+  ): Promise<WebhookEventResponseDto> {
+    const paymentOrderId = resource.supplementary_data?.related_ids
+      ?.order_id as string;
+    const captureId = resource.id;
+    const purchase =
+      await this.purchaseRepository.findByPaymentOrderIdOrFail(paymentOrderId);
+
+    purchase.paymentTransactionId = captureId;
+    purchase.status = PurchaseStatus.COMPLETED;
+
+    await this.purchaseRepository.saveOne(purchase);
+
+    return new WebhookEventResponseDto(
+      WEBHOOK_EVENT_NAME,
+      `Order with id ${paymentOrderId} captured successfully with id ${captureId}`,
+      true,
+      PurchaseStatus.COMPLETED,
+    );
+  }
+
+  private async handlePaymentCaptureDenied(
+    resource: IPayPalCaptureResource,
+  ): Promise<WebhookEventResponseDto> {
+    const captureId = resource.id;
+    const paymentOrderId = resource.supplementary_data?.related_ids
+      ?.order_id as string;
+    const purchase =
+      await this.purchaseRepository.findByPaymentOrderIdOrFail(paymentOrderId);
+
+    purchase.status = PurchaseStatus.FAILED;
+    purchase.paymentTransactionId = captureId;
+
+    await this.purchaseRepository.saveOne(purchase);
+
+    return new WebhookEventResponseDto(
+      WEBHOOK_EVENT_NAME,
+      `Order with id ${paymentOrderId} capture failed with id ${captureId}`,
+      true,
+      PurchaseStatus.FAILED,
+    );
+  }
+
+  private async handleCancelled(
+    resource: IPayPalCaptureResource,
+  ): Promise<WebhookEventResponseDto> {
+    const captureId = resource.id;
+    const paymentOrderId = resource.supplementary_data?.related_ids
+      ?.order_id as string;
+
+    const purchase =
+      await this.purchaseRepository.findByPaymentOrderIdOrFail(paymentOrderId);
+
+    purchase.status = PurchaseStatus.CANCELLED;
+    purchase.paymentTransactionId = captureId;
+
+    await this.purchaseRepository.saveOne(purchase);
+
+    return new WebhookEventResponseDto(
+      WEBHOOK_EVENT_NAME,
+      `Order with id ${paymentOrderId} cancelled with id ${captureId}`,
+      true,
+      PurchaseStatus.CANCELLED,
+    );
+  }
+}

--- a/src/module/paypal/domain/webhook-name.ts
+++ b/src/module/paypal/domain/webhook-name.ts
@@ -1,0 +1,1 @@
+export const WEBHOOK_EVENT_NAME = 'webhook-event';

--- a/src/module/paypal/infrastructure/exception/paypal-exception.messages.ts
+++ b/src/module/paypal/infrastructure/exception/paypal-exception.messages.ts
@@ -1,5 +1,5 @@
 export const PAYMENT_ORDER_CREATION_FAIL = 'Payment order creation failed';
 export const PAYMENT_ORDER_CAPTURE_FAIL = 'Payment order capture failed';
 export const ACCESS_TOKEN_ERROR = 'Failed to get access token';
-export const INVALID_PAYPAL_WEBHOOK = 'Invalid PayPal webhook';
 export const WEBHOOK_VERIFICATION_ERROR = 'Failed to verify webhook';
+export const INVALID_PAYPAL_WEBHOOK = 'Invalid PayPal webhook';

--- a/src/module/paypal/infrastructure/guard/paypal-webhook.guard.ts
+++ b/src/module/paypal/infrastructure/guard/paypal-webhook.guard.ts
@@ -1,0 +1,34 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+import { Request } from 'express';
+
+import { IPaypalWebhookBody } from '@paypal/application/interface/paypal-webhook-body.interface';
+import { IPayPalWebhookHeaders } from '@paypal/application/interface/paypal-webhook-headers.interface';
+import { PaypalWebhookService } from '@paypal/application/service/paypal-webhook.service';
+import { INVALID_PAYPAL_WEBHOOK } from '@paypal/infrastructure/exception/paypal-exception.messages';
+
+@Injectable()
+export class PayPalWebhookGuard implements CanActivate {
+  constructor(private readonly paypalWebhookService: PaypalWebhookService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<Request>();
+    const headers = request.headers as unknown as IPayPalWebhookHeaders;
+    const body = request.body as IPaypalWebhookBody;
+
+    const isValid = await this.paypalWebhookService.verifyWebhook(
+      headers,
+      body,
+    );
+
+    if (!isValid) {
+      throw new ForbiddenException(INVALID_PAYPAL_WEBHOOK);
+    }
+
+    return true;
+  }
+}

--- a/src/module/paypal/infrastructure/provider/paypal-payment.provider.ts
+++ b/src/module/paypal/infrastructure/provider/paypal-payment.provider.ts
@@ -93,6 +93,10 @@ export class PaypalPaymentProvider
 
       return data.verification_status === 'SUCCESS';
     } catch (error) {
+      if (error instanceof ApiError) {
+        throw error;
+      }
+
       throw new InternalServerErrorException(
         `${WEBHOOK_VERIFICATION_ERROR} - ${(error as Error).message}`,
       );

--- a/src/module/paypal/interface/paypal.controller.ts
+++ b/src/module/paypal/interface/paypal.controller.ts
@@ -1,0 +1,34 @@
+import {
+  Body,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+
+import { AuthType } from '@iam/authentication/domain/auth-type.enum';
+import { Auth } from '@iam/authentication/infrastructure/decorator/auth.decorator';
+
+import { WebhookEventResponseDto } from '@paypal/application/dto/webhook-event-response.dto';
+import { IPaypalWebhookBody } from '@paypal/application/interface/paypal-webhook-body.interface';
+import { PaypalWebhookService } from '@paypal/application/service/paypal-webhook.service';
+import { PayPalWebhookGuard } from '@paypal/infrastructure/guard/paypal-webhook.guard';
+
+@Controller('paypal')
+@UseGuards(PayPalWebhookGuard)
+export class PaypalController {
+  constructor(private readonly paypalWebhookService: PaypalWebhookService) {}
+
+  @Post('webhook')
+  @HttpCode(HttpStatus.OK)
+  @Auth(AuthType.None)
+  async handleWebhook(
+    @Body() body: IPaypalWebhookBody,
+  ): Promise<WebhookEventResponseDto> {
+    return await this.paypalWebhookService.processEvent(
+      body.event_type,
+      body.resource,
+    );
+  }
+}

--- a/src/module/paypal/paypal.module.ts
+++ b/src/module/paypal/paypal.module.ts
@@ -3,10 +3,16 @@ import { Module } from '@nestjs/common';
 
 import { PaymentModule } from '@payment/payment.module';
 
+import { PaypalWebhookService } from '@paypal/application/service/paypal-webhook.service';
+import { PayPalWebhookGuard } from '@paypal/infrastructure/guard/paypal-webhook.guard';
 import { PaypalPaymentProvider } from '@paypal/infrastructure/provider/paypal-payment.provider';
+import { PaypalController } from '@paypal/interface/paypal.controller';
+
+import { PurchaseModule } from '@purchase/purchase.module';
 
 @Module({
-  imports: [PaymentModule, HttpModule],
-  providers: [PaypalPaymentProvider],
+  imports: [PaymentModule, PurchaseModule, HttpModule],
+  providers: [PaypalPaymentProvider, PaypalWebhookService, PayPalWebhookGuard],
+  controllers: [PaypalController],
 })
 export class PaypalModule {}

--- a/src/module/purchase/application/repository/purchase-repository.interface.ts
+++ b/src/module/purchase/application/repository/purchase-repository.interface.ts
@@ -11,4 +11,6 @@ export interface IPurchaseRepository
     'deleteOneByIdOrFail'
   > {
   findUserPurchase(userId: string, courseId: string): Promise<Purchase | null>;
+  findByPaymentOrderId(paymentOrderId: string): Promise<Purchase | null>;
+  findByPaymentOrderIdOrFail(paymentOrderId: string): Promise<Purchase>;
 }

--- a/src/module/purchase/application/service/purchase-CRUD.service.ts
+++ b/src/module/purchase/application/service/purchase-CRUD.service.ts
@@ -183,6 +183,7 @@ export class PurchaseCRUDService
       [PurchaseStatus.COMPLETED]: [PurchaseStatus.REFUNDED],
       [PurchaseStatus.FAILED]: [],
       [PurchaseStatus.REFUNDED]: [],
+      [PurchaseStatus.CANCELLED]: [],
     };
 
     if (!validTransitions[current].includes(next)) {

--- a/src/module/purchase/domain/purchase.status.enum.ts
+++ b/src/module/purchase/domain/purchase.status.enum.ts
@@ -3,4 +3,5 @@ export enum PurchaseStatus {
   COMPLETED = 'completed',
   FAILED = 'failed',
   REFUNDED = 'refunded',
+  CANCELLED = 'cancelled',
 }

--- a/src/module/purchase/infrastructure/database/purchase.postgres.repository.ts
+++ b/src/module/purchase/infrastructure/database/purchase.postgres.repository.ts
@@ -4,6 +4,7 @@ import { titleCase } from 'change-case-all';
 import { In, Repository } from 'typeorm';
 
 import BaseRepository from '@common/base/infrastructure/database/base.repository';
+import EntityNotFoundException from '@common/base/infrastructure/exception/not.found.exception';
 
 import { PurchaseMapper } from '@purchase/application/mapper/purchase.mapper';
 import { IPurchaseRepository } from '@purchase/application/repository/purchase-repository.interface';
@@ -43,5 +44,31 @@ export class PurchasePostgresRepository
     return purchaseEntity
       ? this.purchaseMapper.toDomainEntity(purchaseEntity)
       : null;
+  }
+
+  async findByPaymentOrderId(paymentOrderId: string): Promise<Purchase | null> {
+    const purchaseEntity = await this.purchaseRepository.findOne({
+      where: {
+        paymentOrderId,
+      },
+    });
+
+    return purchaseEntity
+      ? this.purchaseMapper.toDomainEntity(purchaseEntity)
+      : null;
+  }
+
+  async findByPaymentOrderIdOrFail(paymentOrderId: string): Promise<Purchase> {
+    const purchaseEntity = await this.findByPaymentOrderId(paymentOrderId);
+
+    if (!purchaseEntity) {
+      throw new EntityNotFoundException(
+        'paymentOrderId',
+        paymentOrderId,
+        this.entityType,
+      );
+    }
+
+    return purchaseEntity;
   }
 }

--- a/src/module/purchase/purchase.module.ts
+++ b/src/module/purchase/purchase.module.ts
@@ -54,7 +54,7 @@ const policyHandlersProviders = [
     ...policyHandlersProviders,
   ],
   controllers: [PurchaseController],
-  exports: [],
+  exports: [purchaseRepositoryProvider],
 })
 export class PurchaseModule implements OnModuleInit {
   constructor(private readonly registry: AppSubjectPermissionStorage) {}


### PR DESCRIPTION
# Summary

This PR introduces a `PaypalWebhookService` along with a `PaypalWebhookGuard` and a `PaypalController`, in order to handle the different Paypal's payment webhook events.

# Details

- Updated the `Purchase` entity with a new "cancelled" status.
- Implemented methods for finding purchases by the payment order, as this is necessary to update purchases status on the webhook events.
- Added a `PaypalWebhookGuard` to validate the received webhook by its signature.
- Created the `PaypalWebhookService` with methods to handle the paypal payment events.
- Implemented a `PaypalController` with a route to received paypal webhooks.